### PR TITLE
Turn upscaling into an option, fix savestates

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -32,6 +32,7 @@ unsigned char widescreen_auto_ar;
 unsigned char widescreen_auto_ar_old;
 
 bool psx_cpu_overclock;
+uint8_t psx_gpu_upscale_shift;
 static bool is_pal;
 
 char retro_save_directory[4096];
@@ -1275,11 +1276,9 @@ static void InitCommon(std::vector<CDIF *> *CDInterfaces, const bool EmulateMemc
       sle = tmp;
    }
 
-   uint8_t upscale_shift = 0;
-
    CPU = new PS_CPU();
    SPU = new PS_SPU();
-   GPU = new PS_GPU(region == REGION_EU, sls, sle, upscale_shift);
+   GPU = new PS_GPU(region == REGION_EU, sls, sle, psx_gpu_upscale_shift);
    CDC = new PS_CDC();
    FIO = new FrontIO(emulate_memcard, emulate_multitap);
    FIO->SetAMCT(MDFN_GetSettingB("psx.input.analog_mode_ct"));
@@ -2118,8 +2117,6 @@ extern void SetInput(int port, const char *type, void *ptr);
 static bool overscan;
 static double last_sound_rate;
 
-static MDFN_Surface *surf;
-
 static bool failed_init;
 
 char *psx_analog_type;
@@ -2145,6 +2142,23 @@ static Deinterlacer deint;
 #define MEDNAFEN_CORE_GEOMETRY_MAX_W 700
 #define MEDNAFEN_CORE_GEOMETRY_MAX_H 576
 #define MEDNAFEN_CORE_GEOMETRY_ASPECT_RATIO (4.0 / 3.0)
+
+static MDFN_Surface *surf = NULL;
+
+static void alloc_surface() {
+  MDFN_PixelFormat pix_fmt(MDFN_COLORSPACE_RGB, 16, 8, 0, 24);
+  uint32_t width  = MEDNAFEN_CORE_GEOMETRY_MAX_W;
+  uint32_t height = is_pal ? MEDNAFEN_CORE_GEOMETRY_MAX_H  : 480;
+
+  width  <<= GPU->upscale_shift;
+  height <<= GPU->upscale_shift;
+
+  if (surf != NULL) {
+    delete surf;
+  }
+
+  surf = new MDFN_Surface(NULL, width, height, width, pix_fmt);
+}
 
 static void check_system_specs(void)
 {
@@ -2429,6 +2443,24 @@ static void check_variables(void)
    }
    else
       widescreen_auto_ar = false;
+
+   var.key = "beetle_psx_internal_resolution";
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+     // We only support one digit upscaling ratios for now... fix me
+     // if we even want 16x.
+     uint8_t val = var.value[0] - '0';
+
+     assert(var.value[1] == 'x');
+
+     // Upscale must be a power of two
+     assert((val & (val - 1)) == 0);
+
+     psx_gpu_upscale_shift = ffs(val) - 1;
+   }
+   else
+     psx_gpu_upscale_shift = 0;
 
    var.key = "beetle_psx_analog_toggle";
 
@@ -2978,17 +3010,9 @@ bool retro_load_game(const struct retro_game_info *info)
 	MDFN_LoadGameCheats(NULL);
 	MDFNMP_InstallReadPatches();
 
-   MDFN_PixelFormat pix_fmt(MDFN_COLORSPACE_RGB, 16, 8, 0, 24);
-
    is_pal = (CalcDiscSCEx() == REGION_EU);
 
-   uint32_t width  = MEDNAFEN_CORE_GEOMETRY_MAX_W;
-   uint32_t height = is_pal ? MEDNAFEN_CORE_GEOMETRY_MAX_H  : 480;
-
-   width  <<= GPU->upscale_shift;
-   height <<= GPU->upscale_shift;
-
-   surf = new MDFN_Surface(NULL, width, height, width, pix_fmt);
+   alloc_surface();
 
 #ifdef NEED_DEINTERLACER
 	PrevInterlaced = false;
@@ -3146,14 +3170,32 @@ void retro_run(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
    {
       widescreen_auto_ar_old = widescreen_auto_ar;
+
       check_variables();
+
+      if (GPU->upscale_shift != psx_gpu_upscale_shift) {
+	struct retro_system_av_info new_av_info;
+	retro_get_system_av_info(&new_av_info);
+
+	if (environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO,
+		       &new_av_info)) {
+	  // We successfully changed the frontend's resolution, we can
+	  // apply the change immediately
+	  GPU->AllocVRam(psx_gpu_upscale_shift);
+	  alloc_surface();
+	} else {
+	  // Failed, we have to postpone the upscaling change
+	  psx_gpu_upscale_shift = GPU->upscale_shift;
+	}
+      }
 
       if (widescreen_auto_ar != widescreen_auto_ar_old)
       {
-         struct retro_system_av_info new_av_info;
-         retro_get_system_av_info(&new_av_info);
-         environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &new_av_info);
+	struct retro_system_av_info new_av_info;
+	retro_get_system_av_info(&new_av_info);
+	environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &new_av_info);
       }
+
    }
 
    if (setting_apply_analog_toggle)
@@ -3368,17 +3410,13 @@ void retro_get_system_info(struct retro_system_info *info)
 
 void retro_get_system_av_info(struct retro_system_av_info *info)
 {
-  assert(GPU != NULL);
-
-  uint8_t upscale_shift = GPU->upscale_shift;
-
    memset(info, 0, sizeof(*info));
    info->timing.fps            = is_pal ? 49.842 : 59.941;
    info->timing.sample_rate    = 44100;
-   info->geometry.base_width   = MEDNAFEN_CORE_GEOMETRY_BASE_W << upscale_shift;
-   info->geometry.base_height  = MEDNAFEN_CORE_GEOMETRY_BASE_H << upscale_shift;
-   info->geometry.max_width    = MEDNAFEN_CORE_GEOMETRY_MAX_W << upscale_shift;
-   info->geometry.max_height   = MEDNAFEN_CORE_GEOMETRY_MAX_H << upscale_shift;
+   info->geometry.base_width   = MEDNAFEN_CORE_GEOMETRY_BASE_W << psx_gpu_upscale_shift;
+   info->geometry.base_height  = MEDNAFEN_CORE_GEOMETRY_BASE_H << psx_gpu_upscale_shift;
+   info->geometry.max_width    = MEDNAFEN_CORE_GEOMETRY_MAX_W << psx_gpu_upscale_shift;
+   info->geometry.max_height   = MEDNAFEN_CORE_GEOMETRY_MAX_H << psx_gpu_upscale_shift;
    info->geometry.aspect_ratio = !widescreen_auto_ar ? MEDNAFEN_CORE_GEOMETRY_ASPECT_RATIO : (float)16/9;
 }
 
@@ -3448,6 +3486,7 @@ void retro_set_environment(retro_environment_t cb)
       { "beetle_psx_skipbios", "Skip BIOS; disabled|enabled" },
       { "beetle_psx_widescreen_hack", "Widescreen mode hack; disabled|enabled" },
       { "beetle_psx_widescreen_auto_ar", "Widescreen hack auto aspect ratio; disabled|enabled" },
+      { "beetle_psx_internal_resolution", "Internal GPU resolution; 1x(native)|2x|4x|8x" },
       { "beetle_psx_use_mednafen_memcard0_method", "Memcard 0 method; libretro|mednafen" },
       { "beetle_psx_shared_memory_cards", "Shared memcards (restart); disabled|enabled" },
       { "beetle_psx_initial_scanline", "Initial scanline; 0|1|2|3|4|5|6|7|8|9|10|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40" },

--- a/mednafen/psx/gpu.cpp
+++ b/mednafen/psx/gpu.cpp
@@ -115,15 +115,24 @@ PS_GPU::~PS_GPU()
 
 void PS_GPU::AllocVRam(uint8_t ushift) {
   uint16_t *vram_new;
+  unsigned width = 1024 << ushift;
+  unsigned height = 512 << ushift;
 
-  unsigned npixels = (512 * 1024) << (ushift * 2);
+  vram_new = new uint16_t[width * height];
 
-  vram_new = new uint16_t[npixels];
-
-  memset(vram_new, 0, npixels * sizeof(*vram_new));
+  memset(vram_new, 0, width * height * sizeof(*vram_new));
 
   if (vram != NULL) {
-      // XXX rescale
+    // We already have a VRAM buffer, we can copy its content into the
+    // new one. For simplicity we do the transfer at 1x internal
+    // resolution.
+
+    for (unsigned y = 0; y < height; y++) {
+      for (unsigned x = 0; x < width; x++) {
+	vram_new[y * width + x] = texel_fetch(x >> ushift, y >> ushift);
+      }
+    }
+
     delete [] vram;
     vram = NULL;
   }

--- a/mednafen/psx/gpu.h
+++ b/mednafen/psx/gpu.h
@@ -310,7 +310,7 @@ class PS_GPU
          void PlotPixel(int32 x, int32 y, uint16 pix);
 
       template<int BlendMode, bool MaskEval_TA, bool textured>
-         void PlotLinePixel(int32 x, int32 y, uint16 pix);
+         void PlotNativePixel(int32 x, int32 y, uint16 pix);
 
       template<uint32 TexMode_TA>
          uint16 GetTexel(uint32 clut_offset, int32 u, int32 v);

--- a/mednafen/psx/gpu_common.cpp
+++ b/mednafen/psx/gpu_common.cpp
@@ -2,7 +2,7 @@ template<int BlendMode, bool MaskEval_TA, bool textured>
 INLINE void PS_GPU::PlotPixel(int32_t x, int32_t y, uint16_t fore_pix)
 {
    // More Y precision bits than GPU RAM installed in (non-arcade, at least) Playstation hardware.
-   y &= (512 << UPSCALE_SHIFT) - 1;
+   y &= (512 << upscale_shift) - 1;
 
    if(BlendMode >= 0 && (fore_pix & 0x8000))
    {

--- a/mednafen/psx/gpu_common.cpp
+++ b/mednafen/psx/gpu_common.cpp
@@ -75,9 +75,9 @@ INLINE void PS_GPU::PlotPixel(int32_t x, int32_t y, uint16_t fore_pix)
    }
 }
 
-/// Copy of PlotPixel without internal upscaling, used to draw lines
+/// Copy of PlotPixel without internal upscaling, used to draw lines and sprites
 template<int BlendMode, bool MaskEval_TA, bool textured>
-INLINE void PS_GPU::PlotLinePixel(int32_t x, int32_t y, uint16_t fore_pix)
+INLINE void PS_GPU::PlotNativePixel(int32_t x, int32_t y, uint16_t fore_pix)
 {
    y &= 511;	// More Y precision bits than GPU RAM installed in (non-arcade, at least) Playstation hardware.
 

--- a/mednafen/psx/gpu_line.cpp
+++ b/mednafen/psx/gpu_line.cpp
@@ -170,7 +170,7 @@ void PS_GPU::DrawLine(line_point *points)
 
          // FIXME: There has to be a faster way than checking for being inside the drawing area for each pixel.
          if(x >= ClipX0 && x <= ClipX1 && y >= ClipY0 && y <= ClipY1)
-            PlotLinePixel<BlendMode, MaskEval_TA, false>(x, y, pix);
+	   PlotNativePixel<BlendMode, MaskEval_TA, false>(x, y, pix);
       }
 
       AddLineStep<goraud>(cur_point, step);

--- a/mednafen/psx/gpu_polygon.cpp
+++ b/mednafen/psx/gpu_polygon.cpp
@@ -132,10 +132,10 @@ template<bool goraud, bool textured, int BlendMode, bool TexMult, uint32_t TexMo
 INLINE void PS_GPU::DrawSpan(int y, uint32_t clut_offset, const int32_t x_start, const int32_t x_bound, i_group ig, const i_deltas &idl)
 {
    int32_t xs = x_start, xb = x_bound;
-   int32 clipx0 = ClipX0 << UPSCALE_SHIFT;
-   int32 clipx1 = ClipX1 << UPSCALE_SHIFT;
+   int32 clipx0 = ClipX0 << upscale_shift;
+   int32 clipx1 = ClipX1 << upscale_shift;
 
-   if(LineSkipTest(this, y >> UPSCALE_SHIFT))
+   if(LineSkipTest(this, y >> upscale_shift))
       return;
 
    if(xs < xb)	// (xs != xb)
@@ -146,17 +146,17 @@ INLINE void PS_GPU::DrawSpan(int y, uint32_t clut_offset, const int32_t x_start,
       if(xb > (clipx1 + 1))
          xb = clipx1 + 1;
 
-      if(xs < xb && ((y & (UPSCALE - 1)) == 0))
+      if(xs < xb && ((y & (upscale() - 1)) == 0))
       {
-         DrawTimeAvail -= (xb - xs) >> UPSCALE_SHIFT;
+         DrawTimeAvail -= (xb - xs) >> upscale_shift;
 
          if(goraud || textured)
          {
-            DrawTimeAvail -= (xb - xs) >> UPSCALE_SHIFT;
+            DrawTimeAvail -= (xb - xs) >> upscale_shift;
          }
          else if((BlendMode >= 0) || MaskEval_TA)
          {
-            DrawTimeAvail -= (((((xb  >> UPSCALE_SHIFT) + 1) & ~1) - ((xs  >> UPSCALE_SHIFT) & ~1)) >> 1);
+            DrawTimeAvail -= (((((xb  >> upscale_shift) + 1) & ~1) - ((xs  >> upscale_shift) & ~1)) >> 1);
          }
       }
 
@@ -275,12 +275,12 @@ void PS_GPU::DrawTriangle(tri_vertex *vertices, uint32_t clut)
 
     // Upscale
    for (int i = 0; i < 3; i++) {
-      vertices[i].x <<= UPSCALE_SHIFT;
-      vertices[i].y <<= UPSCALE_SHIFT;
+      vertices[i].x <<= upscale_shift;
+      vertices[i].y <<= upscale_shift;
    }
 
-   int32 clipy0 = ClipY0 << UPSCALE_SHIFT;
-   int32 clipy1 = ClipY1 << UPSCALE_SHIFT;
+   int32 clipy0 = ClipY0 << upscale_shift;
+   int32 clipy1 = ClipY1 << upscale_shift;
 
    if(!CalcIDeltas(idl, vertices[0], vertices[1], vertices[2]))
       return;


### PR DESCRIPTION
With these patches it's possible to change the upscaling using a core option. If the frontend supports changing the output max width/height through `RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO` the change takes place immediately.

They also fix the savestates: they're always made at 1x so they will remain compatible regardless of the upscaling setting.