### PR TITLE
Implement several dither modes: 1x, upscaled or disabled

### DIFF
--- a/mednafen/psx/gpu.h
+++ b/mednafen/psx/gpu.h
@@ -66,6 +66,8 @@ class PS_GPU
 
    public:
 
+      void BuildDitherTable(bool enabled);
+
       static PS_GPU *Build(bool pal_clock_and_tv, int sls, int sle, uint8 upscale_shift) MDFN_COLD;
       static void Destroy(PS_GPU *gpu) MDFN_COLD;
 
@@ -167,6 +169,7 @@ class PS_GPU
       }
 
       uint8 upscale_shift;
+      uint8 dither_upscale_shift;
 
       uint32 DMAControl;
 

--- a/mednafen/psx/gpu_polygon.cpp
+++ b/mednafen/psx/gpu_polygon.cpp
@@ -190,15 +190,19 @@ INLINE void PS_GPU::DrawSpan(int y, uint32_t clut_offset, const int32_t x_start,
             b = COORD_GET_INT(ig.b);
          }
 
+         int32_t dither_x = x >> dither_upscale_shift;
+         int32_t dither_y = y >> dither_upscale_shift;
+
          if(textured)
          {
             uint16_t fbw = GetTexel<TexMode_TA>(clut_offset, COORD_GET_INT(ig.u), COORD_GET_INT(ig.v));
 
             if(fbw)
             {
-               if(TexMult)
-                  fbw = ModTexel(fbw, r, g, b, (dtd) ? (x & 3) : 3, (dtd) ? (y & 3) : 2);
-               PlotPixel<BlendMode, MaskEval_TA, true>(x, y, fbw);
+	      if(TexMult) {
+                  fbw = ModTexel(fbw, r, g, b, (dtd) ? (dither_x & 3) : 3, (dtd) ? (dither_y & 3) : 2);
+	      }
+	      PlotPixel<BlendMode, MaskEval_TA, true>(x, y, fbw);
             }
          }
          else
@@ -207,9 +211,9 @@ INLINE void PS_GPU::DrawSpan(int y, uint32_t clut_offset, const int32_t x_start,
 
             if(goraud && dtd)
             {
-               pix |= DitherLUT[y & 3][x & 3][r] << 0;
-               pix |= DitherLUT[y & 3][x & 3][g] << 5;
-               pix |= DitherLUT[y & 3][x & 3][b] << 10;
+               pix |= DitherLUT[dither_y & 3][dither_x & 3][r] << 0;
+               pix |= DitherLUT[dither_y & 3][dither_x & 3][g] << 5;
+               pix |= DitherLUT[dither_y & 3][dither_x & 3][b] << 10;
             }
             else
             {


### PR DESCRIPTION
Depending on the game and shader used different modes give different results.

Note that this changes the default behaviour: so far the dithering pattern was scaled alongside with the internal resolution, now it defaults to "1x" since this is the most accurate setting.