### PR TITLE
Make the texture window a vertex attribute instead of using uniforms

### DIFF
--- a/rustation-libretro/src/renderer/GlRenderer.cpp
+++ b/rustation-libretro/src/renderer/GlRenderer.cpp
@@ -229,12 +229,6 @@ void GlRenderer::draw()
     this->command_buffer->program->uniform1i("fb_texture", 0);
     this->command_buffer->program->uniform1ui("texture_flt", this->filter_type);
 
-    // Set the texture window parameters
-    this->command_buffer->program->uniform1ui("tex_x_mask", tex_x_mask);
-    this->command_buffer->program->uniform1ui("tex_x_or", tex_x_or);
-    this->command_buffer->program->uniform1ui("tex_y_mask", tex_y_mask);
-    this->command_buffer->program->uniform1ui("tex_y_or", tex_y_or);
-
     // Bind the out framebuffer
     Framebuffer _fb = Framebuffer(this->fb_out, this->fb_out_depth);
 
@@ -729,9 +723,6 @@ void GlRenderer::set_draw_offset(int16_t x, int16_t y)
 void GlRenderer::set_tex_window(uint8_t tww, uint8_t twh, uint8_t twx,
       uint8_t twy)
 {
-    // Finish drawing anything with the current texture window
-    this->draw();
-
     this->tex_x_mask = ~(tww << 3);
     this->tex_x_or = (twx & tww) << 3;
     this->tex_y_mask = ~(twh << 3);
@@ -775,8 +766,13 @@ void GlRenderer::push_triangle( CommandVertex v[3],
 
     size_t slice_len = 3;
     size_t i;
+
     for (i = 0; i < slice_len; ++i) {
         v[i].position[2] = z;
+	v[i].texture_window[0] = tex_x_mask;
+	v[i].texture_window[1] = tex_x_or;
+	v[i].texture_window[2] = tex_y_mask;
+	v[i].texture_window[3] = tex_y_or;
     }
 
     bool needs_opaque_draw =
@@ -916,6 +912,7 @@ std::vector<Attribute> CommandVertex::attributes()
     result.push_back( Attribute("depth_shift",          offsetof(CommandVertex, depth_shift),           GL_UNSIGNED_BYTE,   1) );
     result.push_back( Attribute("dither",               offsetof(CommandVertex, dither),                GL_UNSIGNED_BYTE,   1) );
     result.push_back( Attribute("semi_transparent",     offsetof(CommandVertex, semi_transparent),      GL_UNSIGNED_BYTE,   1) );
+    result.push_back( Attribute("texture_window",       offsetof(CommandVertex, texture_window),        GL_UNSIGNED_BYTE,   4) );
 
     return result;
 }

--- a/rustation-libretro/src/renderer/GlRenderer.h
+++ b/rustation-libretro/src/renderer/GlRenderer.h
@@ -56,6 +56,8 @@ struct CommandVertex {
     uint8_t dither;
     /// 0: primitive is opaque, 1: primitive is semi-transparent
     uint8_t semi_transparent;
+    /// Texture window mask/OR values
+    uint8_t texture_window[4];
 
     static std::vector<Attribute> attributes();
 };
@@ -122,7 +124,7 @@ public:
     /// Counter for preserving primitive draw order in the z-buffer
     /// since we draw semi-transparent primitives out-of-order.
     int16_t primitive_ordering;
-    /// Texture window masks
+    /// Texture window mask/OR values
     uint8_t tex_x_mask;
     uint8_t tex_x_or;
     uint8_t tex_y_mask;

--- a/rustation-libretro/src/renderer/shaders/command_fragment.glsl.h
+++ b/rustation-libretro/src/renderer/shaders/command_fragment.glsl.h
@@ -9,10 +9,6 @@ uniform uint dither_scaling;
 // 0: Only draw opaque pixels, 1: only draw semi-transparent pixels
 uniform uint draw_semi_transparent;
 uniform uint texture_flt;
-uniform uint tex_x_mask;
-uniform uint tex_x_or;
-uniform uint tex_y_mask;
-uniform uint tex_y_or;
 
 in vec3 frag_shading_color;
 // Texture page: base offset for texture lookup.
@@ -29,6 +25,8 @@ flat in uint frag_depth_shift;
 flat in uint frag_dither;
 // 0: Opaque primitive, 1: semi-transparent primitive
 flat in uint frag_semi_transparent;
+// Texture window: [ X mask, X or, Y mask, Y or ]
+flat in uvec4 frag_texture_window;
 
 out vec4 frag_color;
 
@@ -82,8 +80,8 @@ vec4 sample_texel(vec2 coords) {
    uint tex_y = uint(coords.y) & 0xffU;
 
    // Texture window adjustments
-   tex_x = (tex_x & tex_x_mask) | tex_x_or;
-   tex_y = (tex_y & tex_y_mask) | tex_y_or;
+   tex_x = (tex_x & frag_texture_window[0]) | frag_texture_window[1];
+   tex_y = (tex_y & frag_texture_window[2]) | frag_texture_window[3];
 
    // Adjust x coordinate based on the texel color depth.
    uint tex_x_pix = tex_x / pix_per_hw;

--- a/rustation-libretro/src/renderer/shaders/command_vertex.glsl.h
+++ b/rustation-libretro/src/renderer/shaders/command_vertex.glsl.h
@@ -11,6 +11,7 @@ in uint texture_blend_mode;
 in uint depth_shift;
 in uint dither;
 in uint semi_transparent;
+in uvec4 texture_window;
 
 // Drawing offset
 uniform ivec2 offset;
@@ -23,6 +24,7 @@ flat out uint frag_texture_blend_mode;
 flat out uint frag_depth_shift;
 flat out uint frag_dither;
 flat out uint frag_semi_transparent;
+flat out uvec4 frag_texture_window;
 
 void main() {
    ivec2 pos = position.xy + offset;
@@ -50,5 +52,5 @@ void main() {
    frag_depth_shift = depth_shift;
    frag_dither = dither;
    frag_semi_transparent = semi_transparent;
-}
-);
+   frag_texture_window = texture_window;
+});


### PR DESCRIPTION
This should improve the performance of game that use texture window heavily by reducing the number of draw calls. Ridge Racer in particular gets a pretty massive speedup with this patch. Functionally it should be equivalent to the previous version.