### PR TITLE
Update small code pieces to closer match mednafen's code

### DIFF
--- a/mednafen/psx/gte.cpp
+++ b/mednafen/psx/gte.cpp
@@ -1044,7 +1044,7 @@ static INLINE uint32_t Divide(uint32_t dividend, uint32_t divisor)
       dividend <<= shift_bias;
       divisor <<= shift_bias;
 
-      return ((int64_t)dividend * CalcRecip(divisor | 0x8000) + 32768) >> 16;
+      return std::min<uint32>(0x1FFFF, ((uint64_t)dividend * CalcRecip(divisor | 0x8000) + 32768) >> 16);
    }
 
    FLAGS |= 1 << 17;


### PR DESCRIPTION
I don't know if these changes will have any effects in games since I suspect them to be corner cases in the emulation but they "fix" the cpu and gte tests that are working in the most recent mednafen version (0.9.38.7) but not in the current core -> http://emulation.gametechwiki.com/index.php/PS1_Tests

To be specific, the basic memory loads and branch&links in cpu and the RTPS and RTPT opcode gte tests were reported to have wrong values in those tests (again, I wouldn't count on these changes to have too much of an effect in normal emulation, if at all).

Other than that there are also mismatches in the cpx tests (which probably require more extensive code updates to mednafens code base) and probably in the gpu but I couldn't test the latter since it took apparently forever to complete the tests (in both mednafen and libretro).