### PR TITLE
Reword "Dualshock analog toggle" option, clarify instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@ Note that RetroArch does not currently have .pbp database due to variability in 
 * PSX Initial Scanline PAL - Sets the first scanline to be drawn on screen for PAL systems
 * PSX Last Scanline - Sets the last scanline to be drawn on screen
 * PSX Last Scanline PAL - Sets the last scanline to be drawn on screen for PAL systems
-* Dualshock analog toggle - Enables/Disables the analog button from Dualshock controllers, if disabled analogs are always on, if enabled you can toggle it's state with START+SELECT+L1+L2+R1+R2
+* DualShock Analog button toggle - Enables/Disables the Analog button from DualShock controllers, if disabled analogs are always on, if enabled you can toggle their state by pressing and holding START+SELECT+L1+L2+R1+R2
 * Port 1 PSX Enable Multitap - Enables/Disables multitap functionality on port 1
 * Port 2 PSX Enable Multitap - Enables/Disables multitap functionality on port 2

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3823,7 +3823,7 @@ void retro_set_environment(retro_environment_t cb)
       { "beetle_psx_initial_scanline_pal", "Initial scanline PAL; 0|1|2|3|4|5|6|7|8|9|10|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40" },
       { "beetle_psx_last_scanline", "Last scanline; 239|238|237|236|235|234|232|231|230|229|228|227|226|225|224|223|222|221|220|219|218|217|216|215|214|213|212|211|210" },
       { "beetle_psx_last_scanline_pal", "Last scanline PAL; 287|286|285|284|283|283|282|281|280|279|278|277|276|275|274|273|272|271|270|269|268|267|266|265|264|263|262|261|260" },
-      { "beetle_psx_analog_toggle", "Dualshock analog toggle; disabled|enabled" },
+      { "beetle_psx_analog_toggle", "DualShock Analog button toggle; disabled|enabled" },
       { "beetle_psx_enable_multitap_port1", "Port 1: Multitap enable; disabled|enabled" },
       { "beetle_psx_enable_multitap_port2", "Port 2: Multitap enable; disabled|enabled" },
       { "beetle_psx_frame_duping_enable", "Frame duping (speedup); disabled|enabled" },


### PR DESCRIPTION
The current name is very vague IMHO, so the option ends up doing the opposite of expected for those who don't know that the Joypad is selected instead of the DualShock by default.