### PR TITLE
Fix compilation on MinGW/GCC

### DIFF
--- a/mednafen/psx/gte.cpp
+++ b/mednafen/psx/gte.cpp
@@ -1073,8 +1073,8 @@ static INLINE void TransformXY(int64_t h_div_sz, float precise_h_div_sz, uint16 
    float precise_y = fofy + ((float)IR2 * precise_h_div_sz);
 
    /* Clamp precision values to valid range */
-   precise_x = max(-0x400, min(precise_x, 0x3ff));
-   precise_y = max(-0x400, min(precise_y, 0x3ff));
+   precise_x = max(-0x400, std::min<float>(precise_x, 0x3ff));
+   precise_y = max(-0x400, std::min<float>(precise_y, 0x3ff));
 
    uint32 value = *((uint32*)&XY_FIFO[3]);
    PGXP_pushSXYZ2f(precise_x, precise_y, (float)z, value);


### PR DESCRIPTION
Fix the following compilation errors:

```
In file included from mednafen/psx/gte.cpp:24:0:
mednafen/psx/gte.cpp: In function 'void TransformXY(int64_t, float, uint16)':
mednafen/psx/gte.cpp:1076:48: error: 'min' was not declared in this scope
    precise_x = max(-0x400, min(precise_x, 0x3ff));
                                                ^
./mednafen/../pgxp/pgxp_gte.h:67:30: note: in definition of macro 'max'
 #   define max(a, b) ((a) > (b) ? (a) : (b))
                              ^
mednafen/psx/gte.cpp:1076:48: note: suggested alternative:
    precise_x = max(-0x400, min(precise_x, 0x3ff));
                                                ^
./mednafen/../pgxp/pgxp_gte.h:67:30: note: in definition of macro 'max'
 #   define max(a, b) ((a) > (b) ? (a) : (b))
                              ^
In file included from C:/msys64/mingw64/include/c++/6.1.0/bits/char_traits.h:39:0,
                 from C:/msys64/mingw64/include/c++/6.1.0/string:40,
                 from mednafen/psx/../git.h:4,
                 from mednafen/psx/../mednafen.h:12,
                 from mednafen/psx/psx.h:4,
                 from mednafen/psx/gte.cpp:21:
C:/msys64/mingw64/include/c++/6.1.0/bits/stl_algobase.h:243:5: note:   'std::min'
     min(const _Tp& __a, const _Tp& __b, _Compare __comp)
     ^~~
make: *** [Makefile:378: mednafen/psx/gte.o] Error 1

```