### PR TITLE
Clamp depth values to near/2.f to prevent the projection factor becom…

### DIFF
--- a/mednafen/psx/gte.cpp
+++ b/mednafen/psx/gte.cpp
@@ -1073,8 +1073,8 @@ static INLINE void TransformXY(int64_t h_div_sz, float precise_h_div_sz, uint16 
    float precise_y = fofy + ((float)IR2 * precise_h_div_sz);
 
    /* Clamp precision values to valid range */
-   precise_x = max(-0x400, min(precise_x, 0x3ff));
-   precise_y = max(-0x400, min(precise_y, 0x3ff));
+   precise_x = max(-0x400, std::min<float>(precise_x, 0x3ff));
+   precise_y = max(-0x400, std::min<float>(precise_y, 0x3ff));
 
    uint32 value = *((uint32*)&XY_FIFO[3]);
    PGXP_pushSXYZ2f(precise_x, precise_y, (float)z, value);
@@ -1167,7 +1167,7 @@ static int64_t RTP(uint32_t instr, uint32_t vector_index)
    /* Projection factor: 1.16 unsigned */
    projection_factor = Divide(H, Z_FIFO[3]);
 
-   precise_h_div_sz  = (float)H / (float)Z_FIFO[3]; 
+   precise_h_div_sz  = (float)H / max(H/2.f, (float)Z_FIFO[3]); 
 
    TransformXY(projection_factor, precise_h_div_sz, Z_FIFO[3]);
 


### PR DESCRIPTION
…ing too large (or div_by_0)

Should fix RRR.