### PR TITLE
Update renderer.cpp

### DIFF
--- a/parallel-psx/renderer/renderer.cpp
+++ b/parallel-psx/renderer/renderer.cpp
@@ -386,8 +386,7 @@ ImageHandle Renderer::scanout_to_texture()
 
 		ensure_command_buffer();
 
-		auto info = ImageCreateInfo::render_target(rect.width ? rect.width : 64u, rect.height ? rect.height : 64u,
-		                                           VK_FORMAT_R8G8B8A8_UNORM);
+		auto info = ImageCreateInfo::render_target(64u, 64u, VK_FORMAT_R8G8B8A8_UNORM);
 
 		if (!reuseable_scanout || reuseable_scanout->get_create_info().width != info.width ||
 		    reuseable_scanout->get_create_info().height != info.height)


### PR DESCRIPTION
Trying to fix issue #126.

In the past, there was a bug in the GL renderer caused by the 'display_off' flag not being respected, which resulted in us getting some frames that were expected to be black but were instead filled with garbage or a combo of garbage and past frames.

Currently the Vulkan renderer seems to be suffering from the same bug. Based on the comments, the intention is that it is supposed to be done in scanout_to_texture(), but what I think I see is cleanups but not the insurance of a black screen.

So, in good hacking fashion, I tried to make the 'render_target' with the size of (0, 0), which segfaults. So I settled with 64u, which was already there and I assume is the smallest it can be before it segfaults.
And this seems to result in the desired black screen.

The patch needs to be vetted by someone who knows Vulkan.