### PR TITLE
set_controller_port can try to set a port beyond what we support

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3940,6 +3940,8 @@ unsigned retro_api_version(void)
 
 void retro_set_controller_port_device(unsigned in_port, unsigned device)
 {
+   if (in_port >= MAX_PLAYERS)
+      return;
    switch (device)
    {
       case RETRO_DEVICE_JOYPAD:


### PR DESCRIPTION
This patch just makes set_controller_port ignore ports beyond MAX_PLAYERS.

Fixes a crash with netplay, but also fixes a crash that can be achieved without netplay: Set your max players to at least 9, then try to set the controller on port 9 and mednafen/PSX craps the bed.