### PR TITLE
Revert 'Better error handling'

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3145,7 +3145,7 @@ bool retro_load_game(const struct retro_game_info *info)
    char tocbasepath[4096];
    bool ret = false;
 
-   if (!info || failed_init)
+   if (failed_init)
       return false;
 
    struct retro_input_descriptor desc[] = {


### PR DESCRIPTION
Reverts https://github.com/libretro/beetle-psx-libretro/commit/76b13e1ccf1f3085fd5e5de21e221e521fb1bf72.

beetle-psx-libretro will segfault regardless, see https://github.com/libretro/RetroArch/issues/4493.