### PR TITLE
Add + to the ingored character list when processing cheats.

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1954,7 +1954,7 @@ static bool DecodeGS(const std::string& cheat_string, MemoryPatch* patch)
 
  for(unsigned i = 0; i < cheat_string.size(); i++)
  {
-  if(cheat_string[i] == ' ' || cheat_string[i] == '-' || cheat_string[i] == ':')
+  if(cheat_string[i] == ' ' || cheat_string[i] == '-' || cheat_string[i] == ':' || cheat_string[i] == '+')
    continue;
 
   nybble_count++;


### PR DESCRIPTION
'+' seems to be a popular divider when it comes to cheats within RetroArch, but any cheat with a + in it would cause mednafen to error out.  I added + to the ignored character list to work around this.  Problem solved for now.