### PR TITLE
Convert remaining option names to option_* macros.

### DIFF
--- a/rustation-libretro/src/retrogl/retrogl.cpp
+++ b/rustation-libretro/src/retrogl/retrogl.cpp
@@ -5,6 +5,8 @@
 #include <string.h> // memcpy()
 #include <stdexcept>
 
+#include "libretro_options.h"
+
 /*
 *
 *   THIS CLASS IS A SINGLETON!
@@ -257,14 +259,14 @@ struct retro_system_av_info get_av_info(VideoClock std)
 {
     struct retro_variable var = {0};
 
-    var.key = "beetle_psx_internal_resolution";
+    var.key = option_internal_resolution;
     uint8_t upscaling = 1;
     if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
       /* Same limitations as libretro.cpp */
       upscaling = var.value[0] -'0';
     }
 
-    var.key = "beetle_psx_display_vram";
+    var.key = option_display_vram;
     bool display_vram = false;
     if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
       if (!strcmp(var.value, "enabled"))
@@ -273,7 +275,7 @@ struct retro_system_av_info get_av_info(VideoClock std)
 	display_vram = false;
     }
 
-    var.key = "beetle_psx_widescreen_hack";
+    var.key = option_widescreen_hack;
     bool widescreen_hack = false;
     if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
         if (!strcmp(var.value, "enabled"))


### PR DESCRIPTION
The rename was done in 2b2070b, but one file was missed.

Also for some reason fixes the partial screen issue
(https://github.com/libretro/beetle-psx-libretro/issues/136).

I can not tell exactly what caused the issue but it seemed that libretro was getting wrong information about the viewport (the clipping seemed to be on the libretro level).