### PR TITLE
Add multiline cheat support.

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -20,6 +20,10 @@
 
 #include "../pgxp/pgxp_main.h"
 
+#include <vector>
+#include <iostream>
+#define ISHEXDEC ((codeLine[cursor]>='0') && (codeLine[cursor]<='9')) || ((codeLine[cursor]>='a') && (codeLine[cursor]<='f')) || ((codeLine[cursor]>='A') && (codeLine[cursor]<='F'))
+
 struct retro_perf_callback perf_cb;
 retro_get_cpu_features_t perf_get_cpu_features_cb = NULL;
 retro_log_printf_t log_cb;
@@ -4174,42 +4178,81 @@ size_t retro_get_memory_size(unsigned type)
 
 void retro_cheat_reset(void)
 {
-	MDFN_FlushGameCheats(1);
+   MDFN_FlushGameCheats(1);
 }
 
-void retro_cheat_set(unsigned index, bool enabled, const char * code)
+void retro_cheat_set(unsigned index, bool enabled, const char * codeLine)
 {
-	const CheatFormatStruct* cf = CheatFormats;
-	char name[256];
-	MemoryPatch patch;
+   const CheatFormatStruct* cf = CheatFormats;
+   std::string name;
+   std::vector<std::string> codeParts;
+   std::vector<MemoryPatch> patches;
+   int matchLength=0;
+   int cursor;
+   std::string part;
 
-	//Decode the cheat
-	try
-	{
-		cf->DecodeCheat(std::string(code), &patch);
-	}
-	catch(std::exception &e)
-	{
-		return;
-	}
+   if (codeLine==NULL) return;
 
-	//Generate a name
-	sprintf(name,"cheat_%u",index);
+   //Break the code into Parts
+   for (cursor=0;;cursor++)
+   {
+      if (ISHEXDEC){
+         matchLength++;
+      } else {
+         if (matchLength){
+            part=codeLine+cursor-matchLength;
+            part.erase(matchLength,std::string::npos);
+            codeParts.push_back(part);
+            matchLength=0;
+         }
+      }
+      if (!codeLine[cursor]){
+         break;
+      }
+   }
 
-	//Set parameters
-	patch.name=std::string(name);
-	patch.status=enabled;
+   for (cursor=0;cursor<codeParts.size();cursor++)
+   {
+      part=codeParts[cursor];
+      if (part.length()==8){
+         part+=codeParts[++cursor];
+      }
+      if (part.length()==12) {
+         //Decode the cheat
+         try
+         {
+            MemoryPatch patch;
+            cf->DecodeCheat(std::string(part), &patch);
+            patches.push_back(patch);
+         }
+         catch(std::exception &e)
+         {
+             continue;
+         }
+      }
+   }
 
-	//Add the Cheat
-	try
-	{
-		MDFNI_AddCheat(name,patch.addr,patch.val,patch.compare,patch.type,patch.length,patch.bigendian);
+   //Generate a name
+   name="cheat_"+index;
 
-	}
-	catch(std::exception &e)
-	{
-		return;
-	}
+   for (cursor=0;cursor<patches.size();cursor++){
+      //Set parameters
+      patches[cursor].name=name;
+      patches[cursor].status=enabled;
+
+      //Add the Cheat
+      try
+      {
+         MDFNI_AddCheat(name.c_str(),patches[cursor].addr,patches[cursor].val,patches[cursor].compare,patches[cursor].type,patches[cursor].length,patches[cursor].bigendian);
+      }
+      catch(std::exception &e)
+      {
+         continue;
+      }
+   }
+
+
+
 }
 
 #ifdef _WIN32

--- a/mednafen/mempatcher-driver.h
+++ b/mednafen/mempatcher-driver.h
@@ -27,7 +27,7 @@ struct MemoryPatch
 
 int MDFNI_DecodePAR(const char *code, uint32 *a, uint8 *v, uint8 *c, char *type);
 int MDFNI_DecodeGG(const char *str, uint32 *a, uint8 *v, uint8 *c, char *type);
-int MDFNI_AddCheat(const char *name, uint32 addr, uint64 val, uint64 compare, char type, unsigned int length, bool bigendian);
+void MDFNI_AddCheat(const MemoryPatch& patch);
 int MDFNI_DelCheat(uint32 which);
 int MDFNI_ToggleCheat(uint32 which);
 


### PR DESCRIPTION
Codes are delimited based on any non-hexdec character.
Individual codes can be split into two parts [8+4char] or in a single part [12char].

Changes to mempatcher.cpp and mempatcher-driver.h are backported from a newer version of standalone mednafen, with minor tweaks to make it cooperate with this fork.