### PR TITLE
fix splotchy tomb raider skin with bilinear/3point

### DIFF
--- a/rustation-libretro/src/shaders/command_fragment.glsl.h
+++ b/rustation-libretro/src/shaders/command_fragment.glsl.h
@@ -460,8 +460,8 @@ vec4 get_texel_xbr()
 #ifdef FILTER_3POINT
 vec4 get_texel_3point()
 {
-  float x = frag_texture_coord.x - 0.5;
-  float y = frag_texture_coord.y - 0.5;
+  float x = frag_texture_coord.x;
+  float y = frag_texture_coord.y;
 
   float u_frac = fract(x);
   float v_frac = fract(y);
@@ -495,8 +495,8 @@ vec4 get_texel_3point()
 // Bilinear filtering
 vec4 get_texel_bilinear()
 {
-  float x = frag_texture_coord.x - 0.5;
-  float y = frag_texture_coord.y - 0.5;
+  float x = frag_texture_coord.x;
+  float y = frag_texture_coord.y;
 
   float u_frac = fract(x);
   float v_frac = fract(y);


### PR DESCRIPTION
Those -0.5 texel offsets were added to reduce the artifacting that happens with these filtering methods when they sample outside of the desired texture (both of them sample texels surrounding the current texel and then average their values together; this can lead to grabbing outlines or other colors that are in neighboring textures on the same texture sheet). This does not fix JINC2, which samples 2 texels out. This behavior leads me to guess that Tomb Raider may use a palette texture for the gouraud shading and these algos are jumping into the adjacent palettes when they sample the neighboring texels. /shrug