### PR TITLE
Changes to the rsx interface and the gl renderer

### DIFF
--- a/mednafen/psx/gpu.cpp
+++ b/mednafen/psx/gpu.cpp
@@ -238,7 +238,7 @@ static void Command_FBCopy(PS_GPU* g, const uint32 *cb)
       }
    }
 
-   rsx_intf_copy_rect(sourceX, sourceY, destX, destY, width, height, g->MaskEvalAND != 0, g->MaskSetOR != 0);
+   rsx_intf_copy_rect(sourceX, sourceY, destX, destY, width, height, g->MaskEvalAND, g->MaskSetOR);
 }
 
 static void Command_FBWrite(PS_GPU* g, const uint32 *cb)
@@ -903,8 +903,8 @@ static void ProcessFIFO(uint32_t in_count)
                         GPU->FBRW_X, GPU->FBRW_Y,
                         GPU->FBRW_W, GPU->FBRW_H,
                         GPU->vram,
-                        GPU->MaskEvalAND != 0,
-                        GPU->MaskSetOR != 0);
+                        GPU->MaskEvalAND,
+                        GPU->MaskSetOR);
                   GPU->InCmd = INCMD_NONE;
                   break;	// Break out of the for() loop.
                }

--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -463,8 +463,8 @@ void rsx_intf_push_triangle(
       uint8_t depth_shift,
       bool dither,
       int blend_mode,
-      bool mask_test,
-      bool set_mask)
+      uint32_t mask_test,
+      uint32_t set_mask)
 {
 #ifdef RSX_DUMP
    const rsx_dump_vertex vertices[3] = {
@@ -491,7 +491,7 @@ void rsx_intf_push_triangle(
                texture_blend_mode,
                depth_shift,
                dither,
-               blend_mode);
+               blend_mode, mask_test, set_mask);
 #endif
          break;
       case RSX_VULKAN:
@@ -502,7 +502,7 @@ void rsx_intf_push_triangle(
                texture_blend_mode,
                depth_shift,
                dither,
-               blend_mode, mask_test, set_mask);
+               blend_mode, mask_test != 0, set_mask != 0);
 #endif
          break;
       case RSX_EXTERNAL_RUST:
@@ -538,8 +538,8 @@ void rsx_intf_push_quad(
 	uint8_t depth_shift,
 	bool dither,
 	int blend_mode,
-   bool mask_test,
-   bool set_mask)
+   uint32_t mask_test,
+   uint32_t set_mask)
 {
 #ifdef RSX_DUMP
    const rsx_dump_vertex vertices[4] = {
@@ -568,7 +568,7 @@ void rsx_intf_push_quad(
 			texture_blend_mode,
 			depth_shift,
 			dither,
-			blend_mode);
+			blend_mode, mask_test, set_mask);
 #endif
 		break;
    case RSX_VULKAN:
@@ -580,7 +580,7 @@ void rsx_intf_push_quad(
 			texture_blend_mode,
 			depth_shift,
 			dither,
-			blend_mode, mask_test, set_mask);
+			blend_mode, mask_test != 0, set_mask != 0);
 #endif
       break;
 	case RSX_EXTERNAL_RUST:
@@ -594,13 +594,13 @@ void rsx_intf_push_line(int16_t p0x, int16_t p0y,
       uint32_t c1,
       bool dither,
       int blend_mode,
-      bool mask_test,
-      bool set_mask)
+      uint32_t mask_test,
+      uint32_t set_mask)
 {
 #ifdef RSX_DUMP
    const rsx_dump_line_data line = {
       p0x, p0y, p1x, p1y, c0, c1, dither, blend_mode,
-      mask_test, set_mask,
+      mask_test != 0, set_mask != 0,
    };
    rsx_dump_line(&line);
 #endif
@@ -611,12 +611,12 @@ void rsx_intf_push_line(int16_t p0x, int16_t p0y,
          break;
       case RSX_OPENGL:
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
-         rsx_gl_push_line(p0x, p0y, p1x, p1y, c0, c1, dither, blend_mode);
+         rsx_gl_push_line(p0x, p0y, p1x, p1y, c0, c1, dither, blend_mode, mask_test, set_mask);
 #endif
          break;
       case RSX_VULKAN:
 #if defined(HAVE_VULKAN)
-         rsx_vulkan_push_line(p0x, p0y, p1x, p1y, c0, c1, dither, blend_mode, mask_test, set_mask);
+         rsx_vulkan_push_line(p0x, p0y, p1x, p1y, c0, c1, dither, blend_mode, mask_test != 0, set_mask != 0);
 #endif
          break;
       case RSX_EXTERNAL_RUST:
@@ -629,10 +629,10 @@ void rsx_intf_push_line(int16_t p0x, int16_t p0y,
 
 void rsx_intf_load_image(uint16_t x, uint16_t y,
       uint16_t w, uint16_t h,
-      uint16_t *vram, bool mask_test, bool set_mask)
+      uint16_t *vram, uint32_t mask_test, uint32_t set_mask)
 {
 #ifdef RSX_DUMP
-   rsx_dump_load_image(x, y, w, h, vram, mask_test, set_mask);
+   rsx_dump_load_image(x, y, w, h, vram, mask_test != 0, set_mask != 0);
 #endif
 
    switch (rsx_type)
@@ -641,7 +641,7 @@ void rsx_intf_load_image(uint16_t x, uint16_t y,
          break;
       case RSX_OPENGL:
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
-         rsx_gl_load_image(x, y, w, h, vram);
+         rsx_gl_load_image(x, y, w, h, vram, mask_test, set_mask);
 #endif
          break;
       case RSX_VULKAN:
@@ -689,10 +689,10 @@ void rsx_intf_fill_rect(uint32_t color,
 
 void rsx_intf_copy_rect(uint16_t src_x, uint16_t src_y,
       uint16_t dst_x, uint16_t dst_y,
-      uint16_t w, uint16_t h, bool mask_test, bool set_mask)
+      uint16_t w, uint16_t h, uint32_t mask_test, uint32_t set_mask)
 {
 #ifdef RSX_DUMP
-   rsx_dump_copy_rect(src_x, src_y, dst_x, dst_y, w, h, mask_test, set_mask);
+   rsx_dump_copy_rect(src_x, src_y, dst_x, dst_y, w, h, mask_test != 0, set_mask != 0);
 #endif
 
    switch (rsx_type)
@@ -702,7 +702,7 @@ void rsx_intf_copy_rect(uint16_t src_x, uint16_t src_y,
       case RSX_OPENGL:
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
          rsx_gl_copy_rect(src_x, src_y, dst_x, dst_y,
-               w, h);
+               w, h, mask_test, set_mask);
 #endif
          break;
       case RSX_VULKAN:

--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -347,7 +347,8 @@ void rsx_intf_set_mask_setting(uint32_t mask_set_or, uint32_t mask_eval_and)
          break;
       case RSX_OPENGL:
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
-         rsx_gl_set_mask_setting(mask_set_or, mask_eval_and);
+         /* We'll do it like Vulkan and...not do it all */
+         //rsx_gl_set_mask_setting(mask_set_or, mask_eval_and);
 #endif
          break;
       case RSX_VULKAN:

--- a/rsx/rsx_intf.h
+++ b/rsx/rsx_intf.h
@@ -23,114 +23,112 @@ enum blending_modes
   BLEND_MODE_ADD_FOURTH = 3
 };
 
-  void rsx_intf_set_environment(retro_environment_t cb);
-  void rsx_intf_set_video_refresh(retro_video_refresh_t cb);
-  void rsx_intf_get_system_av_info(struct retro_system_av_info *info);
+void rsx_intf_set_environment(retro_environment_t cb);
+void rsx_intf_set_video_refresh(retro_video_refresh_t cb);
+void rsx_intf_get_system_av_info(struct retro_system_av_info *info);
 
-  void rsx_intf_init(enum rsx_renderer_type type);
-  bool rsx_intf_open(bool is_pal);
-  void rsx_intf_close(void);
-  void rsx_intf_refresh_variables(void);
-  void rsx_intf_prepare_frame(void);
-  void rsx_intf_finalize_frame(const void *data, unsigned width,
-        unsigned height, unsigned pitch);
+void rsx_intf_init(enum rsx_renderer_type type);
+bool rsx_intf_open(bool is_pal);
+void rsx_intf_close(void);
+void rsx_intf_refresh_variables(void);
+void rsx_intf_prepare_frame(void);
+void rsx_intf_finalize_frame(const void *data, unsigned width,
+     unsigned height, unsigned pitch);
 
-  void rsx_intf_set_tex_window(uint8_t tww, uint8_t twh,
-        uint8_t twx, uint8_t twy);
+void rsx_intf_set_tex_window(uint8_t tww, uint8_t twh,
+     uint8_t twx, uint8_t twy);
 
-  void rsx_intf_set_mask_setting(uint32_t mask_set_or, uint32_t mask_eval_and);
-  void rsx_intf_set_draw_offset(int16_t x, int16_t y);
-  void rsx_intf_set_draw_area(uint16_t x0, uint16_t y0,
-                              uint16_t x1, uint16_t y1);
-  void rsx_intf_set_display_mode(uint16_t x, uint16_t y,
-                            uint16_t w, uint16_t h,
-                            bool depth_24bpp);
+void rsx_intf_set_mask_setting(uint32_t mask_set_or, uint32_t mask_eval_and);
+void rsx_intf_set_draw_offset(int16_t x, int16_t y);
+void rsx_intf_set_draw_area(uint16_t x0, uint16_t y0,
+                           uint16_t x1, uint16_t y1);
+void rsx_intf_set_display_mode(uint16_t x, uint16_t y,
+                               uint16_t w, uint16_t h,
+                               bool depth_24bpp);
 
-  void rsx_intf_push_triangle(float p0x, float p0y, float p0w,
-                         float p1x, float p1y, float p1w,
-                         float p2x, float p2y, float p2w,
-                         uint32_t c0,
-                         uint32_t c1,
-                         uint32_t c2,
-                         uint16_t t0x, uint16_t t0y,
-                         uint16_t t1x, uint16_t t1y,
-                         uint16_t t2x, uint16_t t2y,
-                         uint16_t texpage_x, uint16_t texpage_y,
-                         uint16_t clut_x, uint16_t clut_y,
-                         uint8_t texture_blend_mode,
-                         uint8_t depth_shift,
-                         bool dither,
-                         // This is really an `enum blending_modes`
-                         // but I don't want to deal with enums in the
-                         // FFI
-                         int blend_mode,
-                         bool mask_test,
-                         bool set_mask);
+void rsx_intf_push_triangle(float p0x, float p0y, float p0w,
+                            float p1x, float p1y, float p1w,
+                            float p2x, float p2y, float p2w,
+                            uint32_t c0,
+                            uint32_t c1,
+                            uint32_t c2,
+                            uint16_t t0x, uint16_t t0y,
+                            uint16_t t1x, uint16_t t1y,
+                            uint16_t t2x, uint16_t t2y,
+                            uint16_t texpage_x, uint16_t texpage_y,
+                            uint16_t clut_x, uint16_t clut_y,
+                            uint8_t texture_blend_mode,
+                            uint8_t depth_shift,
+                            bool dither,
+                            // This is really an `enum blending_modes`
+                            // but I don't want to deal with enums in the
+                            // FFI
+                            int blend_mode,
+                            uint32_t mask_test,
+                            uint32_t set_mask);
 
-  void rsx_intf_push_quad(float p0x, float p0y, float p0w,
-	  float p1x, float p1y, float p1w,
-	  float p2x, float p2y, float p2w,
-	  float p3x, float p3y, float p3w,
-	  uint32_t c0,
-	  uint32_t c1,
-	  uint32_t c2,
-	  uint32_t c3,
-	  uint16_t t0x, uint16_t t0y,
-	  uint16_t t1x, uint16_t t1y,
-	  uint16_t t2x, uint16_t t2y,
-	  uint16_t t3x, uint16_t t3y,
-	  uint16_t texpage_x, uint16_t texpage_y,
-	  uint16_t clut_x, uint16_t clut_y,
-	  uint8_t texture_blend_mode,
-	  uint8_t depth_shift,
-	  bool dither,
-	  int blend_mode,
-     bool mask_test,
-     bool set_mask);
+void rsx_intf_push_quad(float p0x, float p0y, float p0w,
+                        float p1x, float p1y, float p1w,
+                        float p2x, float p2y, float p2w,
+                        float p3x, float p3y, float p3w,
+                        uint32_t c0,
+                        uint32_t c1,
+                        uint32_t c2,
+                        uint32_t c3,
+                        uint16_t t0x, uint16_t t0y,
+                        uint16_t t1x, uint16_t t1y,
+                        uint16_t t2x, uint16_t t2y,
+                        uint16_t t3x, uint16_t t3y,
+                        uint16_t texpage_x, uint16_t texpage_y,
+                        uint16_t clut_x, uint16_t clut_y,
+                        uint8_t texture_blend_mode,
+                        uint8_t depth_shift,
+                        bool dither,
+                        int blend_mode,
+                        uint32_t mask_test,
+                        uint32_t set_mask);
 
+void rsx_intf_push_line(int16_t p0x, int16_t p0y,
+                        int16_t p1x, int16_t p1y,
+                        uint32_t c0,
+                        uint32_t c1,
+                        bool dither,
+                        // This is really an `enum blending_modes`
+                        // but I don't want to deal with enums in the
+                        // FFI
+                        int blend_mode,
+                        uint32_t mask_test,
+                        uint32_t set_mask);
 
-  void rsx_intf_push_line(int16_t p0x, int16_t p0y,
-                     int16_t p1x, int16_t p1y,
-                     uint32_t c0,
-                     uint32_t c1,
-                     bool dither,
-                     // This is really an `enum blending_modes`
-                     // but I don't want to deal with enums in the
-                     // FFI
-                     int blend_mode,
-                     bool mask_test,
-                     bool set_mask);
+void rsx_intf_load_image(  uint16_t x, uint16_t y,
+                           uint16_t w, uint16_t h,
+                           uint16_t *vram,
+                           uint32_t mask_test,
+                           uint32_t set_mask);
 
-  void rsx_intf_load_image(uint16_t x, uint16_t y,
-		      uint16_t w, uint16_t h,
-		      uint16_t *vram,
-            bool mask_test,
-            bool set_mask);
+void rsx_intf_fill_rect(uint32_t color,
+                        uint16_t x, uint16_t y,
+                        uint16_t w, uint16_t h);
 
-  void rsx_intf_fill_rect(uint32_t color,
-		     uint16_t x, uint16_t y,
-		     uint16_t w, uint16_t h);
+void rsx_intf_copy_rect(uint16_t src_x, uint16_t src_y,
+                        uint16_t dst_x, uint16_t dst_y,
+                        uint16_t w, uint16_t h, uint32_t mask_test, uint32_t set_mask);
 
-  void rsx_intf_copy_rect(uint16_t src_x, uint16_t src_y,
-		     uint16_t dst_x, uint16_t dst_y,
-		     uint16_t w, uint16_t h, bool mask_test, bool set_mask);
+void rsx_intf_set_type(enum rsx_renderer_type type);
+void rsx_intf_set_fallback_type(enum rsx_renderer_type type);
 
-  void rsx_intf_set_type(enum rsx_renderer_type type);
-  void rsx_intf_set_fallback_type(enum rsx_renderer_type type);
+enum rsx_renderer_type rsx_intf_is_type(void);
 
-  enum rsx_renderer_type rsx_intf_is_type(void);
+void rsx_intf_toggle_display(bool status);
 
-  void rsx_intf_toggle_display(bool status);
-
-  bool rsx_intf_has_software_renderer(void);
+bool rsx_intf_has_software_renderer(void);
 
 #ifdef __cplusplus
   extern "C" {
 #endif
-	  extern retro_environment_t environ_cb;
+     extern retro_environment_t environ_cb;
 #ifdef __cplusplus
   }
 #endif
-
 
 #endif /*__RSX_H__ */

--- a/rsx/rsx_lib_gl.cpp
+++ b/rsx/rsx_lib_gl.cpp
@@ -1178,6 +1178,7 @@ static void GlRenderer_upload_textures(
 
    if (!DRAWBUFFER_IS_EMPTY(renderer->image_load_buffer))
       DrawBuffer_draw(renderer->image_load_buffer, GL_TRIANGLE_STRIP);
+   
    glPolygonMode(GL_FRONT_AND_BACK, renderer->command_polygon_mode);
    glEnable(GL_SCISSOR_TEST);
 
@@ -1262,7 +1263,6 @@ static bool GlRenderer_new(GlRenderer *renderer, DrawConfig config)
       else
          depth = 16;
    }
-
 
    var.key = option_scale_dither;
    bool scale_dither = false;
@@ -1466,7 +1466,6 @@ static void GlRenderer_free(GlRenderer *renderer)
 
 extern bool doCleanFrame;
 
-
 static inline void apply_scissor(GlRenderer *renderer)
 {
    uint16_t _x = renderer->config.draw_area_top_left[0];
@@ -1545,7 +1544,6 @@ static void bind_libretro_framebuffer(GlRenderer *renderer)
    glViewport(0, 0, (GLsizei) w, (GLsizei) h);
 }
 
-
 static bool retro_refresh_variables(GlRenderer *renderer)
 {
    uint8_t upscaling = 1;
@@ -1566,7 +1564,8 @@ static bool retro_refresh_variables(GlRenderer *renderer)
 
    var.key = option_filter;
    uint8_t filter = FILTER_MODE_NEAREST;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) 
+   {
       if (!strcmp(var.value, "nearest"))
          filter = FILTER_MODE_NEAREST;
       else if (!strcmp(var.value, "SABR"))
@@ -1583,27 +1582,26 @@ static bool retro_refresh_variables(GlRenderer *renderer)
 
    var.key = option_depth;
    uint8_t depth = 16;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
-      depth = !strcmp(var.value, "32bpp") ? 32 : 16;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) 
+   {
+      if (!strcmp(var.value, "32bpp"))
+         depth = 32;
    }
-
 
    var.key = option_scale_dither;
    bool scale_dither = false;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) 
+   {
       if (!strcmp(var.value, "enabled"))
          scale_dither = true;
-      else
-         scale_dither = false;
    }
 
    var.key = option_wireframe;
    bool wireframe = false;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) 
+   {
       if (!strcmp(var.value, "enabled"))
          wireframe = true;
-      else
-         wireframe = false;
    }
 
    bool rebuild_fb_out =
@@ -1620,7 +1618,7 @@ static bool retro_refresh_variables(GlRenderer *renderer)
       uint32_t native_width = (uint32_t) VRAM_WIDTH_PIXELS;
       uint32_t native_height = (uint32_t) VRAM_HEIGHT;
 
-      uint32_t w = native_width * upscaling;
+      uint32_t w = native_width  * upscaling;
       uint32_t h = native_height * upscaling;
 
       GLenum texture_storage = GL_RGB5_A1;
@@ -1646,7 +1644,7 @@ static bool retro_refresh_variables(GlRenderer *renderer)
       // to `fb_texture` even though we haven't touched it but
       // this code is not very performance-critical anyway.
 
-      uint16_t top_left[2] = {0, 0};
+      uint16_t top_left[2]   = {0, 0};
       uint16_t dimensions[2] = {(uint16_t) VRAM_WIDTH_PIXELS, (uint16_t) VRAM_HEIGHT};
 
       GlRenderer_upload_textures(renderer, top_left, dimensions,
@@ -1671,10 +1669,9 @@ static bool retro_refresh_variables(GlRenderer *renderer)
 
    glLineWidth((GLfloat) upscaling);
 
-   // If the scaling factor has changed the frontend should be
-   // reconfigured. We can't do that here because it could
-   // destroy the OpenGL context which would destroy `self`
-   //// r5 - replace 'self' by 'this'
+   /* If the scaling factor has changed the frontend should be
+   *  reconfigured. We can't do that here because it could
+   *  destroy the OpenGL context which would destroy 'this' */
    bool reconfigure_frontend =
       renderer->internal_upscaling != upscaling ||
       renderer->display_vram != display_vram ||
@@ -1738,8 +1735,8 @@ static void push_primitive(
       GLenum mode,
       SemiTransparencyMode stm)
 {
-   bool is_semi_transparent = v[0].semi_transparent == 1;
-   bool is_textured = v[0].texture_blend_mode != 0;
+   bool is_semi_transparent = v[0].semi_transparent   == 1;
+   bool is_textured         = v[0].texture_blend_mode != 0;
    // Textured semi-transparent polys can contain opaque texels (when
    // bit 15 of the color is set to 0). Therefore they're drawn twice,
    // once for the opaque texels and once for the semi-transparent
@@ -1786,70 +1783,70 @@ std::vector<Attribute> CommandVertex::attributes()
 
    strcpy(attr.name, "position");
    attr.offset     = offsetof(CommandVertex, position);
-   attr.type         = GL_FLOAT;
+   attr.type       = GL_FLOAT;
    attr.components = 4;
 
    result.push_back(attr);
 
    strcpy(attr.name, "color");
    attr.offset     = offsetof(CommandVertex, color);
-   attr.type         = GL_UNSIGNED_BYTE;
+   attr.type       = GL_UNSIGNED_BYTE;
    attr.components = 3;
 
    result.push_back(attr);
 
    strcpy(attr.name, "texture_coord");
    attr.offset     = offsetof(CommandVertex, texture_coord);
-   attr.type         = GL_UNSIGNED_SHORT;
+   attr.type       = GL_UNSIGNED_SHORT;
    attr.components = 2;
 
    result.push_back(attr);
 
    strcpy(attr.name, "texture_page");
    attr.offset     = offsetof(CommandVertex, texture_page);
-   attr.type         = GL_UNSIGNED_SHORT;
+   attr.type       = GL_UNSIGNED_SHORT;
    attr.components = 2;
 
    result.push_back(attr);
 
    strcpy(attr.name, "clut");
    attr.offset     = offsetof(CommandVertex, clut);
-   attr.type         = GL_UNSIGNED_SHORT;
+   attr.type       = GL_UNSIGNED_SHORT;
    attr.components = 2;
 
    result.push_back(attr);
 
    strcpy(attr.name, "texture_blend_mode");
    attr.offset     = offsetof(CommandVertex, texture_blend_mode);
-   attr.type         = GL_UNSIGNED_BYTE;
+   attr.type       = GL_UNSIGNED_BYTE;
    attr.components = 1;
 
    result.push_back(attr);
 
    strcpy(attr.name, "depth_shift");
    attr.offset     = offsetof(CommandVertex, depth_shift);
-   attr.type         = GL_UNSIGNED_BYTE;
+   attr.type       = GL_UNSIGNED_BYTE;
    attr.components = 1;
 
    result.push_back(attr);
 
    strcpy(attr.name, "dither");
    attr.offset     = offsetof(CommandVertex, dither);
-   attr.type         = GL_UNSIGNED_BYTE;
+   attr.type       = GL_UNSIGNED_BYTE;
    attr.components = 1;
 
    result.push_back(attr);
 
    strcpy(attr.name, "semi_transparent");
    attr.offset     = offsetof(CommandVertex, semi_transparent);
-   attr.type         = GL_UNSIGNED_BYTE;
+   attr.type       = GL_UNSIGNED_BYTE;
    attr.components = 1;
 
    result.push_back(attr);
 
    strcpy(attr.name, "texture_window");
    attr.offset     = offsetof(CommandVertex, texture_window);
-   attr.type         = GL_UNSIGNED_BYTE;
+   attr.type       = GL_UNSIGNED_BYTE;
    attr.components = 4;
 
    result.push_back(attr);
@@ -1864,14 +1861,14 @@ std::vector<Attribute> OutputVertex::attributes()
 
    strcpy(attr.name, "position");
    attr.offset     = offsetof(OutputVertex, position);
-   attr.type         = GL_FLOAT;
+   attr.type       = GL_FLOAT;
    attr.components = 2;
 
    result.push_back(attr);
 
    strcpy(attr.name, "fb_coord");
    attr.offset     = offsetof(OutputVertex, fb_coord);
-   attr.type         = GL_UNSIGNED_SHORT;
+   attr.type       = GL_UNSIGNED_SHORT;
    attr.components = 2;
 
    result.push_back(attr);
@@ -1886,7 +1883,7 @@ std::vector<Attribute> ImageLoadVertex::attributes()
 
    strcpy(attr.name, "position");
    attr.offset     = offsetof(ImageLoadVertex, position);
-   attr.type         = GL_UNSIGNED_SHORT;
+   attr.type       = GL_UNSIGNED_SHORT;
    attr.components = 2;
 
    result.push_back(attr);
@@ -1976,8 +1973,6 @@ struct retro_system_av_info get_av_info(VideoClock std)
    {
       if (!strcmp(var.value, "enabled"))
          widescreen_hack = true;
-      else if (!strcmp(var.value, "disabled"))
-         widescreen_hack = false;
    }
 
    if (display_vram)
@@ -2050,7 +2045,7 @@ bool rsx_gl_open(bool is_pal)
    if ( !glsm_ctl(GLSM_CTL_STATE_CONTEXT_INIT, &params) )
       return false;
 
-   /* No context until `context_reset` is called */
+   /* No context until 'context_reset' is called */
    static_renderer.video_clock  = clock;
 
    return true;
@@ -2074,7 +2069,7 @@ void rsx_gl_refresh_variables(void)
          renderer = static_renderer.state_data;
          break;
       case GlState_Invalid:
-         // Nothing to be done if we don't have a GL context
+         /* Nothing to be done if we don't have a GL context */
          return;
    }
 
@@ -2082,14 +2077,14 @@ void rsx_gl_refresh_variables(void)
 
    if (reconfigure_frontend)
    {
-      // The resolution has changed, we must tell the frontend
-      // to change its format
+      /* The resolution has changed, we must tell the frontend
+       * to change its format */
       struct retro_variable var = {0};
 
       struct retro_system_av_info av_info = get_av_info(static_renderer.video_clock);
 
-      // This call can potentially (but not necessarily) call
-      // `context_destroy` and `context_reset` to reinitialize
+      /* This call can potentially (but not necessarily) call
+       * 'context_destroy' and `context_reset` to reinitialize */
       bool ok = environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &av_info);
 
       if (!ok)
@@ -2113,14 +2108,14 @@ void rsx_gl_prepare_frame(void)
    {
       GlRenderer *renderer = static_renderer.state_data;
 
-      // In case we're upscaling we need to increase the line width
-      // proportionally
+      /* In case we're upscaling we need to increase the line width
+       * proportionally */
       glLineWidth((GLfloat)renderer->internal_upscaling);
       glPolygonMode(GL_FRONT_AND_BACK, renderer->command_polygon_mode);
       glEnable(GL_SCISSOR_TEST);
       glEnable(GL_DEPTH_TEST);
       glDepthFunc(GL_LEQUAL);
-      // Used for PSX GPU command blending
+      /* Used for PSX GPU command blending */
       glBlendColor(0.25, 0.25, 0.25, 0.5);
 
       apply_scissor(renderer);
@@ -2139,11 +2134,11 @@ void rsx_gl_finalize_frame(const void *fb, unsigned width,
    if (static_renderer.state == GlState_Valid)
    {
       GlRenderer *renderer = static_renderer.state_data;
-      // Draw pending commands
+      /* Draw pending commands */
       if (!DRAWBUFFER_IS_EMPTY(renderer->command_buffer))
          GlRenderer_draw(renderer);
 
-      // We can now render to the frontend's buffer
+      /* We can now render to the frontend's buffer */
       bind_libretro_framebuffer(renderer);
 
       glDisable(GL_SCISSOR_TEST);
@@ -2163,7 +2158,7 @@ void rsx_gl_finalize_frame(const void *fb, unsigned width,
       }
       else
       {
-         // Bind 'fb_out' to texture unit 1
+         /* Bind 'fb_out' to texture unit 1 */
          glActiveTexture(GL_TEXTURE1);
          glBindTexture(GL_TEXTURE_2D, renderer->fb_out.id);
 
@@ -2177,7 +2172,7 @@ void rsx_gl_finalize_frame(const void *fb, unsigned width,
 
          if (renderer->display_vram)
          {
-            // Display the entire VRAM as a 16bpp buffer
+            /* Display the entire VRAM as a 16bpp buffer */
             fb_x_start = 0;
             fb_y_start = 0;
             fb_width = VRAM_WIDTH_PIXELS;
@@ -2214,9 +2209,9 @@ void rsx_gl_finalize_frame(const void *fb, unsigned width,
          }
       }
 
-      // Hack: copy fb_out back into fb_texture at the end of every
-      // frame to make offscreen rendering kinda sorta work. Very messy
-      // and slow.
+      /* TODO - Hack: copy fb_out back into fb_texture at the end of every
+       * frame to make offscreen rendering kinda sorta work. Very messy
+       * and slow. */
       {
          Framebuffer _fb;
          ImageLoadVertex slice[4] =
@@ -2255,9 +2250,9 @@ void rsx_gl_finalize_frame(const void *fb, unsigned width,
 
       cleanup_gl_state();
 
-      // When using a hardware renderer we set the data pointer to
-      // -1 to notify the frontend that the frame has been rendered
-      // in the framebuffer.
+      /* When using a hardware renderer we set the data pointer to
+       * -1 to notify the frontend that the frame has been rendered
+       * in the framebuffer. */
       video_cb(   RETRO_HW_FRAME_BUFFER_VALID,
             renderer->frontend_resolution[0],
             renderer->frontend_resolution[1], 0);
@@ -2291,9 +2286,10 @@ void rsx_gl_set_mask_setting(uint32_t mask_set_or, uint32_t mask_eval_and)
    {
       GlRenderer *renderer = static_renderer.state_data;
 
-      // Finish drawing anything with the current offset
+      /* Finish drawing anything with the current offset */
       if (!DRAWBUFFER_IS_EMPTY(renderer->command_buffer))
          GlRenderer_draw(renderer);
+
       renderer->mask_set_or   = mask_set_or;
       renderer->mask_eval_and = mask_eval_and;
    }
@@ -2305,9 +2301,10 @@ void rsx_gl_set_draw_offset(int16_t x, int16_t y)
    {
       GlRenderer *renderer = static_renderer.state_data;
 
-      // Finish drawing anything with the current offset
-      if (!DRAWBUFFER_IS_EMPTY(renderer->command_buffer))
+      /* Finish drawing anything with the current offset */
+      if (!DRAWBUFFER_IS_EMPTY(renderer->command_buffer)) 
          GlRenderer_draw(renderer);
+      
       renderer->config.draw_offset[0] = x;
       renderer->config.draw_offset[1] = y;
    }
@@ -2335,7 +2332,7 @@ void  rsx_gl_set_draw_area(uint16_t x0,
    {
       GlRenderer *renderer = static_renderer.state_data;
 
-      // Finish drawing anything in the current area
+      /* Finish drawing anything in the current area */
       if (!DRAWBUFFER_IS_EMPTY(renderer->command_buffer))
          GlRenderer_draw(renderer);
 
@@ -2467,11 +2464,12 @@ void rsx_gl_push_quad(
 
       bool is_semi_transparent = v[0].semi_transparent == 1;
       bool is_textured         = v[0].texture_blend_mode != 0;
-      // Textured semi-transparent polys can contain opaque texels (when
-      // bit 15 of the color is set to 0). Therefore they're drawn twice,
-      // once for the opaque texels and once for the semi-transparent
-      // ones. Only untextured semi-transparent triangles don't need to be
-      // drawn as opaque.
+      
+      /* Textured semi-transparent polys can contain opaque texels (when
+       * bit 15 of the color is set to 0). Therefore they're drawn twice,
+       * once for the opaque texels and once for the semi-transparent
+       * ones. Only untextured semi-transparent triangles don't need to be
+       * drawn as opaque. */
       bool is_opaque           = !is_semi_transparent || is_textured;
 
       vertex_preprocessing(renderer, v, 4, GL_TRIANGLES, semi_transparency_mode);
@@ -2510,8 +2508,18 @@ void rsx_gl_push_triangle(
       uint8_t texture_blend_mode,
       uint8_t depth_shift,
       bool dither,
-      int blend_mode)
+      int blend_mode, uint32_t mask_set_or, uint32_t mask_eval_and)
 {
+   GlRenderer *renderer = NULL;
+
+   if (static_renderer.state == GlState_Valid)
+      renderer = static_renderer.state_data;
+   else
+      return;
+
+   renderer->mask_set_or   = mask_set_or;
+   renderer->mask_eval_and = mask_eval_and;
+
    SemiTransparencyMode semi_transparency_mode = SemiTransparencyMode_Add;
    bool semi_transparent = false;
    switch (blend_mode) {
@@ -2576,11 +2584,7 @@ void rsx_gl_push_triangle(
       }
    };
 
-   if (static_renderer.state == GlState_Valid)
-   {
-      GlRenderer *renderer = static_renderer.state_data;
       push_primitive(renderer, v, 3, GL_TRIANGLES, semi_transparency_mode);
-   }
 }
 
 void rsx_gl_fill_rect(uint32_t color,
@@ -2596,13 +2600,13 @@ void rsx_gl_fill_rect(uint32_t color,
    {
       GlRenderer *renderer = static_renderer.state_data;
 
-      // Draw pending commands
+      /* Draw pending commands */
       if (!DRAWBUFFER_IS_EMPTY(renderer->command_buffer))
          GlRenderer_draw(renderer);
 
-      // Fill rect ignores the draw area. Save the previous value
-      // and reconfigure the scissor box to the fill rectangle
-      // instead.
+      /* Fill rect ignores the draw area. Save the previous value
+       * and reconfigure the scissor box to the fill rectangle
+       * instead. */
       uint16_t draw_area_top_left[2] = {
          renderer->config.draw_area_top_left[0],
          renderer->config.draw_area_top_left[1]
@@ -2621,7 +2625,7 @@ void rsx_gl_fill_rect(uint32_t color,
 
       /* This scope is intentional, just like in the Rust version */
       {
-         // Bind the out framebuffer
+         /* Bind the out framebuffer */
          Framebuffer _fb;
          Framebuffer_init(&_fb, &renderer->fb_out);
 
@@ -2630,8 +2634,8 @@ void rsx_gl_fill_rect(uint32_t color,
             glClearColor(   (float) col[0] / 255.0,
                   (float) col[1] / 255.0,
                   (float) col[2] / 255.0,
-                  // XXX Not entirely sure what happens to
-                  // the mask bit in fill_rect commands
+                  /* TODO - XXX Not entirely sure what happens to
+                     the mask bit in fill_rect commands */
                   0.0);
             glClear(GL_COLOR_BUFFER_BIT);
             doCleanFrame = false;
@@ -2640,7 +2644,7 @@ void rsx_gl_fill_rect(uint32_t color,
          glDeleteFramebuffers(1, &_fb.id);
       }
 
-      // Reconfigure the draw area
+      /* Reconfigure the draw area */
       renderer->config.draw_area_top_left[0]    = draw_area_top_left[0];
       renderer->config.draw_area_top_left[1]    = draw_area_top_left[1];
       renderer->config.draw_area_bot_right[0]   = draw_area_bot_right[0];
@@ -2653,76 +2657,79 @@ void rsx_gl_fill_rect(uint32_t color,
 void rsx_gl_copy_rect(
       uint16_t src_x, uint16_t src_y,
       uint16_t dst_x, uint16_t dst_y,
-      uint16_t w, uint16_t h)
+      uint16_t w, uint16_t h, uint32_t mask_set_or, uint32_t mask_eval_and)
 {
-
+   GlRenderer *renderer = NULL;
    if (static_renderer.state == GlState_Valid)
-   {
-      GlRenderer *renderer        = static_renderer.state_data;
-      uint16_t source_top_left[2] = {src_x, src_y};
-      uint16_t target_top_left[2] = {dst_x, dst_y};
-      uint16_t dimensions[2]      = {w, h};
+      GlRenderer *renderer = static_renderer.state_data;
+   else
+      return;
 
-      /* Draw pending commands */
-      if (!DRAWBUFFER_IS_EMPTY(renderer->command_buffer))
-         GlRenderer_draw(renderer);
+   renderer->mask_set_or   = mask_set_or;
+   renderer->mask_eval_and = mask_eval_and;
 
-      uint32_t upscale = renderer->internal_upscaling;
+   uint16_t source_top_left[2] = {src_x, src_y};
+   uint16_t target_top_left[2] = {dst_x, dst_y};
+   uint16_t dimensions[2]      = {w, h};
 
-      GLint src_x = (GLint) source_top_left[0] * (GLint) upscale;
-      GLint src_y = (GLint) source_top_left[1] * (GLint) upscale;
-      GLint dst_x = (GLint) target_top_left[0] * (GLint) upscale;
-      GLint dst_y = (GLint) target_top_left[1] * (GLint) upscale;
+   /* Draw pending commands */
+   if (!DRAWBUFFER_IS_EMPTY(renderer->command_buffer))
+      GlRenderer_draw(renderer);
 
-      GLsizei w = (GLsizei) dimensions[0] * (GLsizei) upscale;
-      GLsizei h = (GLsizei) dimensions[1] * (GLsizei) upscale;
+   uint32_t upscale = renderer->internal_upscaling;
+
+   GLint src_x = (GLint) source_top_left[0] * (GLint) upscale;
+   GLint src_y = (GLint) source_top_left[1] * (GLint) upscale;
+   GLint dst_x = (GLint) target_top_left[0] * (GLint) upscale;
+   GLint dst_y = (GLint) target_top_left[1] * (GLint) upscale;
+
+   GLsizei w = (GLsizei) dimensions[0] * (GLsizei) upscale;
+   GLsizei h = (GLsizei) dimensions[1] * (GLsizei) upscale;
 
 #ifdef NEW_COPY_RECT
-      /* TODO/FIXME - buggy code!
-       *
-       * Dead or Alive/Tekken 3 (high-res interlaced game) has screen
-       * flickering issues with this code! */
+   /* TODO/FIXME - buggy code!
+    *
+    * Dead or Alive/Tekken 3 (high-res interlaced game) has screen
+    * flickering issues with this code! */
 
-      // The diagonal is duplicated. I originally used "1, 2, 1, 2" to
-      // duplicate the diagonal but I believe it was incorrect because of
-      // the OpenGL filling convention. At least it's what TinyTiger told
-      // me...
+   /* The diagonal is duplicated. I originally used "1, 2, 1, 2" to
+    *  duplicate the diagonal but I believe it was incorrect because of
+    *  the OpenGL filling convention. At least it's what TinyTiger told
+    *  me... */
 
-      GLuint fb;
+   GLuint fb;
 
-      glGenFramebuffers(1, &fb);
-      glBindFramebuffer(GL_READ_FRAMEBUFFER, fb);
-      glFramebufferTexture(GL_READ_FRAMEBUFFER,
-            GL_COLOR_ATTACHMENT0,
-            renderer->fb_out.id,
-            0);
+   glGenFramebuffers(1, &fb);
+   glBindFramebuffer(GL_READ_FRAMEBUFFER, fb);
+   glFramebufferTexture(GL_READ_FRAMEBUFFER,
+         GL_COLOR_ATTACHMENT0,
+         renderer->fb_out.id,
+         0);
 
-      glReadBuffer(GL_COLOR_ATTACHMENT0);
+   glReadBuffer(GL_COLOR_ATTACHMENT0);
 
-      // Can I bind the same texture to the framebuffer and
-      // GL_TEXTURE_2D? Something tells me this is undefined
-      // behaviour. I could use glReadPixels and glWritePixels instead
-      // or something like that.
-      glBindTexture(GL_TEXTURE_2D, renderer->fb_out.id);
+   /* TODO - Can I bind the same texture to the framebuffer and
+    * GL_TEXTURE_2D? Something tells me this is undefined
+    * behaviour. I could use glReadPixels and glWritePixels instead
+    * or something like that. */
+   glBindTexture(GL_TEXTURE_2D, renderer->fb_out.id);
+   glCopyTexSubImage2D(GL_TEXTURE_2D, 0, dst_x, dst_y, src_x, src_y, w, h);
 
-      glCopyTexSubImage2D(GL_TEXTURE_2D, 0, dst_x, dst_y, src_x, src_y, w, h);
-
-      glDeleteFramebuffers(1, &fb);
+   glDeleteFramebuffers(1, &fb);
 #else
 
-      // The diagonal is duplicated
+   /* The diagonal is duplicated */
 
-      // XXX CopyImageSubData gives undefined results if the source
-      // and target area overlap, this should be handled
-      // explicitely
-      /* TODO - OpenGL 4.3 and GLES 3.2 requirement! FIXME! */
-      glCopyImageSubData( renderer->fb_out.id, GL_TEXTURE_2D, 0, src_x, src_y, 0,
-            renderer->fb_out.id, GL_TEXTURE_2D, 0, dst_x, dst_y, 0,
-            w, h, 1 );
+   /* XXX CopyImageSubData gives undefined results if the source
+    * and target area overlap, this should be handled
+    * explicitely */
+   /* TODO - OpenGL 4.3 and GLES 3.2 requirement! FIXME! */
+   glCopyImageSubData( renderer->fb_out.id, GL_TEXTURE_2D, 0, src_x, src_y, 0,
+         renderer->fb_out.id, GL_TEXTURE_2D, 0, dst_x, dst_y, 0,
+         w, h, 1 );
 #endif
 
-      get_error("rsx_gl_copy_rect");
-   }
+   get_error("rsx_gl_copy_rect");
 }
 
 void rsx_gl_push_line(
@@ -2730,8 +2737,17 @@ void rsx_gl_push_line(
       int16_t p1x, int16_t p1y,
       uint32_t c0, uint32_t c1,
       bool dither,
-      int blend_mode)
+      int blend_mode, uint32_t mask_set_or, uint32_t mask_eval_and)
 {
+   GlRenderer *renderer = NULL;
+   if (static_renderer.state == GlState_Valid)
+      GlRenderer *renderer = static_renderer.state_data;
+   else
+      return;
+
+   renderer->mask_set_or   = mask_set_or;
+   renderer->mask_eval_and = mask_eval_and;
+
    SemiTransparencyMode semi_transparency_mode = SemiTransparencyMode_Add;
    bool semi_transparent = false;
 
@@ -2761,112 +2777,108 @@ void rsx_gl_push_line(
          exit(EXIT_FAILURE);
    }
 
+   CommandVertex v[2] = {
+      {
+         {(float)p0x, (float)p0y, 0., 1.0}, /* position */
+         {(uint8_t) c0, (uint8_t) (c0 >> 8), (uint8_t) (c0 >> 16)}, /* color */
+         {0, 0}, /* texture_coord */
+         {0, 0}, /* texture_page */
+         {0, 0}, /* clut */
+         0,      /* texture_blend_mode */
+         0,      /* depth_shift */
+         (uint8_t) dither,
+         semi_transparent,
+      },
+      {
+         {(float)p1x, (float)p1y, 0., 1.0}, /* position */
+         {(uint8_t) c1, (uint8_t) (c1 >> 8), (uint8_t) (c1 >> 16)}, /* color */
+         {0, 0}, /* texture_coord */
+         {0, 0}, /* texture_page */
+         {0, 0}, /* clut */
+         0,      /* texture_blend_mode */
+         0,      /* depth_shift */
+         (uint8_t) dither,
+         semi_transparent,
+      }
+   };
 
-   if (static_renderer.state == GlState_Valid)
-   {
-      GlRenderer *renderer = static_renderer.state_data;
-
-      CommandVertex v[2] = {
-         {
-            {(float)p0x, (float)p0y, 0., 1.0}, /* position */
-            {(uint8_t) c0, (uint8_t) (c0 >> 8), (uint8_t) (c0 >> 16)}, /* color */
-            {0, 0}, /* texture_coord */
-            {0, 0}, /* texture_page */
-            {0, 0}, /* clut */
-            0,      /* texture_blend_mode */
-            0,      /* depth_shift */
-            (uint8_t) dither,
-            semi_transparent,
-         },
-         {
-            {(float)p1x, (float)p1y, 0., 1.0}, /* position */
-            {(uint8_t) c1, (uint8_t) (c1 >> 8), (uint8_t) (c1 >> 16)}, /* color */
-            {0, 0}, /* texture_coord */
-            {0, 0}, /* texture_page */
-            {0, 0}, /* clut */
-            0,      /* texture_blend_mode */
-            0,      /* depth_shift */
-            (uint8_t) dither,
-            semi_transparent,
-         }
-      };
-      push_primitive(renderer, v, 2, GL_LINES, semi_transparency_mode);
-   }
+   push_primitive(renderer, v, 2, GL_LINES, semi_transparency_mode);
 }
 
 void rsx_gl_load_image(uint16_t x, uint16_t y,
       uint16_t w, uint16_t h,
-      uint16_t *vram)
+      uint16_t *vram, uint32_t mask_set_or, uint32_t mask_eval_and)
 {
-
-   /* TODO FIXME - upload_vram_window expects a
-      uint16_t[VRAM_HEIGHT*VRAM_WIDTH_PIXELS] array arg instead of a ptr */
-
+   GlRenderer *renderer = NULL;
    if (static_renderer.state == GlState_Valid)
+      GlRenderer *renderer = static_renderer.state_data;
+   else
+      return;
+
+   renderer->mask_set_or   = mask_set_or;
+   renderer->mask_eval_and = mask_eval_and;
+      
+   Framebuffer _fb;
+   uint16_t top_left[2];
+   uint16_t dimensions[2];
+
+   top_left[0]            = x;
+   top_left[1]            = y;
+   dimensions[0]          = w;
+   dimensions[1]          = h;
+
+   if (!DRAWBUFFER_IS_EMPTY(renderer->command_buffer))
+      GlRenderer_draw(renderer);
+
+   Texture_set_sub_image_window(
+         &renderer->fb_texture,
+         top_left,
+         dimensions,
+         (size_t) VRAM_WIDTH_PIXELS,
+         GL_RGBA,
+         GL_UNSIGNED_SHORT_1_5_5_5_REV,
+         vram);
+
+   uint16_t x_start    = top_left[0];
+   uint16_t x_end      = x_start + dimensions[0];
+   uint16_t y_start    = top_left[1];
+   uint16_t y_end      = y_start + dimensions[1];
+
+   const size_t slice_len = 4;
+   ImageLoadVertex slice[slice_len] =
    {
-      Framebuffer _fb;
-      uint16_t top_left[2];
-      uint16_t dimensions[2];
-      GlRenderer *renderer   = static_renderer.state_data;
+      {   {x_start,   y_start }   },
+      {   {x_end,     y_start }   },
+      {   {x_start,   y_end   }   },
+      {   {x_end,     y_end   }   }
+   };
 
-      top_left[0]            = x;
-      top_left[1]            = y;
-      dimensions[0]          = w;
-      dimensions[1]          = h;
+   DrawBuffer_push_slice(renderer->image_load_buffer, slice, slice_len);
 
-      if (!DRAWBUFFER_IS_EMPTY(renderer->command_buffer))
-         GlRenderer_draw(renderer);
-
-      Texture_set_sub_image_window(
-            &renderer->fb_texture,
-            top_left,
-            dimensions,
-            (size_t) VRAM_WIDTH_PIXELS,
-            GL_RGBA,
-            GL_UNSIGNED_SHORT_1_5_5_5_REV,
-            vram);
-
-      uint16_t x_start    = top_left[0];
-      uint16_t x_end      = x_start + dimensions[0];
-      uint16_t y_start    = top_left[1];
-      uint16_t y_end      = y_start + dimensions[1];
-
-      const size_t slice_len = 4;
-      ImageLoadVertex slice[slice_len] =
-      {
-         {   {x_start,   y_start }   },
-         {   {x_end,     y_start }   },
-         {   {x_start,   y_end   }   },
-         {   {x_end,     y_end   }   }
-      };
-
-      DrawBuffer_push_slice(renderer->image_load_buffer, slice, slice_len);
-
-      if (renderer->image_load_buffer->program)
-      {
-         glUseProgram(renderer->image_load_buffer->program->id);
-         glUniform1i(renderer->image_load_buffer->program->uniforms["fb_texture"], 0);
-         /* fb_texture is always at 1x */
-         glUniform1ui(renderer->image_load_buffer->program->uniforms["internal_upscaling"], 1);
-      }
-
-
-      glDisable(GL_SCISSOR_TEST);
-      glDisable(GL_BLEND);
-      glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
-
-      /* Bind the output framebuffer */
-      Framebuffer_init(&_fb, &renderer->fb_out);
-
-      if (!DRAWBUFFER_IS_EMPTY(renderer->image_load_buffer))
-         DrawBuffer_draw(renderer->image_load_buffer, GL_TRIANGLE_STRIP);
-      glPolygonMode(GL_FRONT_AND_BACK, renderer->command_polygon_mode);
-      glEnable(GL_SCISSOR_TEST);
-
-      get_error("rsx_gl_load_image");
-
-      glDeleteFramebuffers(1, &_fb.id);
+   if (renderer->image_load_buffer->program)
+   {
+      glUseProgram(renderer->image_load_buffer->program->id);
+      glUniform1i(renderer->image_load_buffer->program->uniforms["fb_texture"], 0);
+      /* fb_texture is always at 1x */
+      glUniform1ui(renderer->image_load_buffer->program->uniforms["internal_upscaling"], 1);
    }
+
+   glDisable(GL_SCISSOR_TEST);
+   glDisable(GL_BLEND);
+   glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
+   /* Bind the output framebuffer */
+   Framebuffer_init(&_fb, &renderer->fb_out);
+
+   if (!DRAWBUFFER_IS_EMPTY(renderer->image_load_buffer))
+      DrawBuffer_draw(renderer->image_load_buffer, GL_TRIANGLE_STRIP);
+   
+   glPolygonMode(GL_FRONT_AND_BACK, renderer->command_polygon_mode);
+   glEnable(GL_SCISSOR_TEST);
+
+   get_error("rsx_gl_load_image");
+
+   glDeleteFramebuffers(1, &_fb.id);
 }
 
 void rsx_gl_toggle_display(bool status)

--- a/rsx/rsx_lib_gl.cpp
+++ b/rsx/rsx_lib_gl.cpp
@@ -145,40 +145,40 @@ struct Attribute
 struct CommandVertex {
    /* Position in PlayStation VRAM coordinates */
    float position[4];
-   /// RGB color, 8bits per component
+   /* RGB color, 8bits per component */
    uint8_t color[3];
-   /// Texture coordinates within the page
+   /* Texture coordinates within the page */
    uint16_t texture_coord[2];
-   /// Texture page (base offset in VRAM used for texture lookup)
+   /* Texture page (base offset in VRAM used for texture lookup) */
    uint16_t texture_page[2];
-   /// Color Look-Up Table (palette) coordinates in VRAM
+   /* Color Look-Up Table (palette) coordinates in VRAM */
    uint16_t clut[2];
-   /// Blending mode: 0: no texture, 1: raw-texture, 2: texture-blended
+   /* Blending mode: 0: no texture, 1: raw-texture, 2: texture-blended */
    uint8_t texture_blend_mode;
-   /// Right shift from 16bits: 0 for 16bpp textures, 1 for 8bpp, 2
-   /// for 4bpp
+   /* Right shift from 16bits: 0 for 16bpp textures, 1 for 8bpp, 2
+    * for 4bpp */
    uint8_t depth_shift;
-   /// True if dithering is enabled for this primitive
+   /* True if dithering is enabled for this primitive */
    uint8_t dither;
-   /// 0: primitive is opaque, 1: primitive is semi-transparent
+   /* 0: primitive is opaque, 1: primitive is semi-transparent */
    uint8_t semi_transparent;
-   /// Texture window mask/OR values
+   /* Texture window mask/OR values */
    uint8_t texture_window[4];
 
    static std::vector<Attribute> attributes();
 };
 
 struct OutputVertex {
-   /// Vertex position on the screen
+   /* Vertex position on the screen */
    float position[2];
-   /// Corresponding coordinate in the framebuffer
+   /* Corresponding coordinate in the framebuffer */
    uint16_t fb_coord[2];
 
    static std::vector<Attribute> attributes();
 };
 
 struct ImageLoadVertex {
-   // Vertex position in VRAM
+   /* Vertex position in VRAM */
    uint16_t position[2];
 
    static std::vector<Attribute> attributes();
@@ -218,34 +218,32 @@ struct TransparencyIndex {
 template<typename T>
 struct DrawBuffer
 {
-   /// OpenGL name for this buffer
+   /* OpenGL name for this buffer */
    GLuint id;
-   /// Vertex Array Object containing the bindings for this
-   /// buffer. I'm assuming that each VAO will only use a single
-   /// buffer for simplicity.
+   /* Vertex Array Object containing the bindings for this
+    * buffer. I'm assuming that each VAO will only use a single
+    * buffer for simplicity. */
    GLuint vao;
-   /// Program used to draw this buffer
+   /* Program used to draw this buffer */
    Program* program;
-   /// Currently mapped buffer range (write-only)
+   /* Currently mapped buffer range (write-only) */
    T *map;
-
-   /// Number of elements T mapped at once in 'map'
+   /* Number of elements T mapped at once in 'map' */
    size_t capacity;
-   /// Index one-past the last element stored in `map`, relative to
-   /// the first element in `map`
+   /* Index one-past the last element stored in 'map', relative to
+    * the first element in 'map' */
    size_t map_index;
-   /// Absolute offset of the 1st mapped element in the current
-   /// buffer relative to the beginning of the GL storage.
+   /* Absolute offset of the 1st mapped element in the current
+    * buffer relative to the beginning of the GL storage. */
    size_t map_start;
 };
-
 
 struct GlRenderer {
    /* Buffer used to handle PlayStation GPU draw commands */
    DrawBuffer<CommandVertex>* command_buffer;
    /* Buffer used to draw to the frontend's framebuffer */
    DrawBuffer<OutputVertex>* output_buffer;
-   /* Buffer used to copy textures from `fb_texture` to `fb_out` */
+   /* Buffer used to copy textures from 'fb_texture' to 'fb_out' */
    DrawBuffer<ImageLoadVertex>* image_load_buffer;
 
    GLushort opaque_triangle_indices[INDEX_BUFFER_LEN];
@@ -372,7 +370,7 @@ static void get_error(const char *msg)
    }
 
    /* glGetError should always be called in a loop, until 
-   it returns GL_NO_ERROR, if all error flags are to be reset. */
+    * it returns GL_NO_ERROR, if all error flags are to be reset. */
    while (error != GL_NO_ERROR)
       error = glGetError();
 
@@ -601,7 +599,6 @@ static void DrawBuffer_enable_attribute(DrawBuffer<T> *drawbuffer, const char* a
       return;
 
    glBindVertexArray(drawbuffer->vao);
-
    glEnableVertexAttribArray(index);
 }
 
@@ -614,7 +611,6 @@ static void DrawBuffer_disable_attribute(DrawBuffer<T> *drawbuffer, const char* 
       return;
 
    glBindVertexArray(drawbuffer->vao);
-
    glDisableVertexAttribArray(index);
 }
 
@@ -627,9 +623,9 @@ static void DrawBuffer_push_slice(DrawBuffer<T> *drawbuffer, T slice[], size_t n
    assert(n <= DRAWBUFFER_REMAINING_CAPACITY(drawbuffer));
    assert(drawbuffer->map != NULL);
 
-   memcpy(drawbuffer->map + drawbuffer->map_index,
-         slice,
-         n * sizeof(T));
+   memcpy(  drawbuffer->map + drawbuffer->map_index,
+            slice,
+            n * sizeof(T));
 
    drawbuffer->map_index += n;
 }
@@ -671,7 +667,7 @@ static void DrawBuffer_map__no_bind(DrawBuffer<T> *drawbuffer)
    /* If we're already mapped something's wrong */
    assert(drawbuffer->map == NULL);
 
-   /* We don't have enough room left to remap `capacity`,
+   /* We don't have enough room left to remap 'capacity',
     * start back from the beginning of the buffer. */
    if (drawbuffer->map_start > 2 * drawbuffer->capacity)
       drawbuffer->map_start = 0;
@@ -855,18 +851,18 @@ static void Framebuffer_init(struct Framebuffer *fb,
    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fb->id);
 
    glFramebufferTexture(   GL_DRAW_FRAMEBUFFER,
-         GL_COLOR_ATTACHMENT0,
-         color_texture->id,
-         0);
+                           GL_COLOR_ATTACHMENT0,
+                           color_texture->id,
+                           0);
 
    GLenum col_attach_0 = GL_COLOR_ATTACHMENT0;
+   
    glDrawBuffers(1, &col_attach_0);
    glViewport( 0,
-         0,
-         (GLsizei) color_texture->width,
-         (GLsizei) color_texture->height);
+               0,
+               (GLsizei) color_texture->width,
+               (GLsizei) color_texture->height);
 }
-
 
 static void Texture_init(
       struct Texture *tex,
@@ -879,10 +875,10 @@ static void Texture_init(
    glGenTextures(1, &id);
    glBindTexture(GL_TEXTURE_2D, id);
    glTexStorage2D(GL_TEXTURE_2D,
-         1,
-         internal_format,
-         (GLsizei) width,
-         (GLsizei) height);
+                  1,
+                  internal_format,
+                  (GLsizei) width,
+                  (GLsizei) height);
 
    tex->id     = id;
    tex->width  = width;
@@ -899,15 +895,15 @@ static void Texture_set_sub_image(
 {
    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
    glBindTexture(GL_TEXTURE_2D, tex->id);
-   glTexSubImage2D(GL_TEXTURE_2D,
-         0,
-         (GLint) top_left[0],
-         (GLint) top_left[1],
-         (GLsizei) resolution[0],
-         (GLsizei) resolution[1],
-         format,
-         ty,
-         (void*) data);
+   glTexSubImage2D(  GL_TEXTURE_2D,
+                     0,
+                     (GLint) top_left[0],
+                     (GLint) top_left[1],
+                     (GLsizei) resolution[0],
+                     (GLsizei) resolution[1],
+                     format,
+                     ty,
+                     (void*) data);
 }
 
 static void Texture_set_sub_image_window(
@@ -928,9 +924,7 @@ static void Texture_set_sub_image_window(
    uint16_t* sub_data = &( data[index] );
 
    glPixelStorei(GL_UNPACK_ROW_LENGTH, (GLint) row_len);
-
    Texture_set_sub_image(tex, top_left, resolution, format, ty, sub_data);
-
    glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
 }
 
@@ -1171,8 +1165,8 @@ static void GlRenderer_upload_textures(
    glDisable(GL_BLEND);
    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 
-   // Bind the output framebuffer
-   // let _fb = Framebuffer::new(&self.fb_out);
+   /* Bind the output framebuffer */
+   /* let _fb = Framebuffer::new(&self.fb_out); */
    Framebuffer _fb;
    Framebuffer_init(&_fb, &renderer->fb_out);
 
@@ -1257,29 +1251,26 @@ static bool GlRenderer_new(GlRenderer *renderer, DrawConfig config)
 
    var.key = option_depth;
    uint8_t depth = 16;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) 
+   {
       if (!strcmp(var.value, "32bpp"))
          depth = 32;
-      else
-         depth = 16;
    }
 
    var.key = option_scale_dither;
    bool scale_dither = false;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) 
+   {
       if (!strcmp(var.value, "enabled"))
          scale_dither = true;
-      else
-         scale_dither = false;
    }
 
    var.key = option_wireframe;
    bool wireframe = false;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) 
+   {
       if (!strcmp(var.value, "enabled"))
          wireframe = true;
-      else
-         wireframe = false;
    }
 
    log_cb(RETRO_LOG_INFO, "Building OpenGL state (%dx internal res., %dbpp)\n", upscaling, depth);
@@ -1339,9 +1330,9 @@ static bool GlRenderer_new(GlRenderer *renderer, DrawConfig config)
    uint32_t native_width  = (uint32_t) VRAM_WIDTH_PIXELS;
    uint32_t native_height = (uint32_t) VRAM_HEIGHT;
 
-   // Texture holding the raw VRAM texture contents. We can't
-   // meaningfully upscale it since most games use paletted
-   // textures.
+   /* Texture holding the raw VRAM texture contents. We can't
+    * meaningfully upscale it since most games use paletted
+    * textures. */
    Texture_init(&renderer->fb_texture, native_width, native_height, GL_RGB5_A1);
 
    if (depth > 16)
@@ -1481,8 +1472,8 @@ static inline void apply_scissor(GlRenderer *renderer)
 
    GLsizei upscale = (GLsizei)renderer->internal_upscaling;
 
-   // We need to scale those to match the internal resolution if
-   // upscaling is enabled
+   /* We need to scale those to match the internal resolution if
+    * upscaling is enabled */
    GLsizei x = (GLsizei) _x * upscale;
    GLsizei y = (GLsizei) _y * upscale;
    GLsizei w = (GLsizei) _w * upscale;
@@ -1505,7 +1496,7 @@ static void bind_libretro_framebuffer(GlRenderer *renderer)
    {
       _w = VRAM_WIDTH_PIXELS;
       _h = VRAM_HEIGHT;
-      // Is this accurate?
+      /* Is this accurate? */
       aspect_ratio = 2.0 / 1.0;
    } else {
       _w = renderer->config.display_resolution[0];
@@ -1538,7 +1529,7 @@ static void bind_libretro_framebuffer(GlRenderer *renderer)
       renderer->frontend_resolution[1] = h;
    }
 
-   // Bind the output framebuffer provided by the frontend
+   /* Bind the output framebuffer provided by the frontend */
    fbo = glsm_get_current_framebuffer();
    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo);
    glViewport(0, 0, (GLsizei) w, (GLsizei) h);
@@ -1640,9 +1631,9 @@ static bool retro_refresh_variables(GlRenderer *renderer)
       renderer->fb_out.height = 0;
       Texture_init(&renderer->fb_out, w, h, texture_storage);
 
-      // This is a bit wasteful since it'll re-upload the data
-      // to `fb_texture` even though we haven't touched it but
-      // this code is not very performance-critical anyway.
+      /* This is a bit wasteful since it'll re-upload the data
+       * to 'fb_texture' even though we haven't touched it but
+       * this code is not very performance-critical anyway. */
 
       uint16_t top_left[2]   = {0, 0};
       uint16_t dimensions[2] = {(uint16_t) VRAM_WIDTH_PIXELS, (uint16_t) VRAM_HEIGHT};
@@ -1715,8 +1706,9 @@ static void vertex_preprocessing(
 
    if (is_semi_transparent &&
          (stm != renderer->semi_transparency_mode ||
-          mode != renderer->command_draw_mode)) {
-      // We're changing the transparency mode
+          mode != renderer->command_draw_mode)) 
+   {
+      /* We're changing the transparency mode */
       TransparencyIndex ti;
       ti.transparency_mode = renderer->semi_transparency_mode;
       ti.last_index        = renderer->semi_transparent_index_pos;
@@ -1737,11 +1729,11 @@ static void push_primitive(
 {
    bool is_semi_transparent = v[0].semi_transparent   == 1;
    bool is_textured         = v[0].texture_blend_mode != 0;
-   // Textured semi-transparent polys can contain opaque texels (when
-   // bit 15 of the color is set to 0). Therefore they're drawn twice,
-   // once for the opaque texels and once for the semi-transparent
-   // ones. Only untextured semi-transparent triangles don't need to be
-   // drawn as opaque.
+   /* Textured semi-transparent polys can contain opaque texels (when
+    * bit 15 of the color is set to 0). Therefore they're drawn twice,
+    * once for the opaque texels and once for the semi-transparent
+    * ones. Only untextured semi-transparent triangles don't need to be
+    * drawn as opaque. */
    bool is_opaque = !is_semi_transparent || is_textured;
 
    vertex_preprocessing(renderer, v, count, mode, stm);
@@ -2084,7 +2076,7 @@ void rsx_gl_refresh_variables(void)
       struct retro_system_av_info av_info = get_av_info(static_renderer.video_clock);
 
       /* This call can potentially (but not necessarily) call
-       * 'context_destroy' and `context_reset` to reinitialize */
+       * 'context_destroy' and 'context_reset' to reinitialize */
       bool ok = environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &av_info);
 
       if (!ok)
@@ -2338,7 +2330,7 @@ void  rsx_gl_set_draw_area(uint16_t x0,
 
       renderer->config.draw_area_top_left[0] = x0;
       renderer->config.draw_area_top_left[1] = y0;
-      // Draw area coordinates are inclusive
+      /* Draw area coordinates are inclusive */
       renderer->config.draw_area_bot_right[0] = x1 + 1;
       renderer->config.draw_area_bot_right[1] = y1 + 1;
 

--- a/rsx/rsx_lib_gl.h
+++ b/rsx/rsx_lib_gl.h
@@ -21,7 +21,7 @@ void rsx_gl_finalize_frame(   const void *fb, unsigned width,
 void rsx_gl_set_tex_window(   uint8_t tww, uint8_t twh,
                               uint8_t twx, uint8_t twy);
 
-void rsx_gl_set_mask_setting(uint32_t mask_set_or, uint32_t mask_eval_and);
+void rsx_gl_set_mask_setting(uint32_t mask_eval_and, uint32_t mask_set_or);
 void rsx_gl_set_draw_offset(int16_t x, int16_t y);
 
 void rsx_gl_set_draw_area( uint16_t x, uint16_t y,
@@ -45,7 +45,8 @@ void rsx_gl_push_triangle( float p0x, float p0y, float p0w,
                            uint8_t texture_blend_mode,
                            uint8_t depth_shift,
                            bool dither,
-                           int blend_mode, uint32_t mask_set_or, uint32_t mask_eval_and);
+                           int blend_mode, 
+                           uint32_t mask_eval_and, uint32_t mask_set_or);
 
 void rsx_gl_push_quad(  float p0x, float p0y, float p0w,
                         float p1x, float p1y, float p1w,
@@ -64,18 +65,21 @@ void rsx_gl_push_quad(  float p0x, float p0y, float p0w,
                         uint8_t texture_blend_mode,
                         uint8_t depth_shift,
                         bool dither,
-                        int blend_mode, uint32_t mask_set_or, uint32_t mask_eval_and);
+                        int blend_mode, 
+                        uint32_t mask_eval_and, uint32_t mask_set_or);
 
 
 void rsx_gl_push_line(  int16_t p0x, int16_t p0y,
                         int16_t p1x, int16_t p1y,
                         uint32_t c0,
                         uint32_t c1,
-                        bool dither, int blend_mode, uint32_t mask_set_or, uint32_t mask_eval_and);
+                        bool dither, int blend_mode, 
+                        uint32_t mask_eval_and, uint32_t mask_set_or);
 
 void rsx_gl_load_image( uint16_t x, uint16_t y,
                         uint16_t w, uint16_t h,
-                        uint16_t *vram, uint32_t mask_set_or, uint32_t mask_eval_and);
+                        uint16_t *vram, 
+                        uint32_t mask_eval_and, uint32_t mask_set_or);
 
 void rsx_gl_fill_rect(  uint32_t color,
                         uint16_t x, uint16_t y,
@@ -83,7 +87,8 @@ void rsx_gl_fill_rect(  uint32_t color,
 
 void rsx_gl_copy_rect(  uint16_t src_x, uint16_t src_y,
                         uint16_t dst_x, uint16_t dst_y,
-                        uint16_t w, uint16_t h, uint32_t mask_set_or, uint32_t mask_eval_and);
+                        uint16_t w, uint16_t h, 
+                        uint32_t mask_eval_and, uint32_t mask_set_or);
 
 void rsx_gl_toggle_display(bool status);
 

--- a/rsx/rsx_lib_gl.h
+++ b/rsx/rsx_lib_gl.h
@@ -5,85 +5,88 @@
 #include "rsx.h"
 #include "rsx_intf.h"
 
-  void rsx_gl_set_blend_mode(enum blending_modes mode);
-  void rsx_gl_set_environment(retro_environment_t);
-  void rsx_gl_set_video_refresh(retro_video_refresh_t);
-  void rsx_gl_get_system_av_info(struct retro_system_av_info *);
+void rsx_gl_set_blend_mode(enum blending_modes mode);
+void rsx_gl_set_environment(retro_environment_t);
+void rsx_gl_set_video_refresh(retro_video_refresh_t);
+void rsx_gl_get_system_av_info(struct retro_system_av_info *);
 
-  void rsx_gl_init(void);
-  bool rsx_gl_open(bool is_pal);
-  void rsx_gl_close(void);
-  void rsx_gl_refresh_variables(void);
-  void rsx_gl_prepare_frame(void);
-  void rsx_gl_finalize_frame(const void *fb, unsigned width,
-        unsigned height, unsigned pitch);
-  void rsx_gl_set_tex_window(uint8_t tww, uint8_t twh,
-        uint8_t twx, uint8_t twy);
+void rsx_gl_init(void);
+bool rsx_gl_open(bool is_pal);
+void rsx_gl_close(void);
+void rsx_gl_refresh_variables(void);
+void rsx_gl_prepare_frame(void);
+void rsx_gl_finalize_frame(   const void *fb, unsigned width,
+                              unsigned height, unsigned pitch);
 
-  void rsx_gl_set_mask_setting(uint32_t mask_set_or, uint32_t mask_eval_and);
-  void rsx_gl_set_draw_offset(int16_t x, int16_t y);
-  void rsx_gl_set_draw_area(uint16_t x, uint16_t y,
-			 uint16_t w, uint16_t h);
-  void rsx_gl_set_display_mode(uint16_t x, uint16_t y,
-			    uint16_t w, uint16_t h,
-			    bool depth_24bpp);
+void rsx_gl_set_tex_window(   uint8_t tww, uint8_t twh,
+                              uint8_t twx, uint8_t twy);
 
-  void rsx_gl_push_triangle(float p0x, float p0y, float p0w,
-			 float p1x, float p1y, float p1w,
-			 float p2x, float p2y, float p2w,
-			 uint32_t c0,
-			 uint32_t c1,
-			 uint32_t c2,
-			 uint16_t t0x, uint16_t t0y,
-			 uint16_t t1x, uint16_t t1y,
-			 uint16_t t2x, uint16_t t2y,
-			 uint16_t texpage_x, uint16_t texpage_y,
-			 uint16_t clut_x, uint16_t clut_y,
-			 uint8_t texture_blend_mode,
-			 uint8_t depth_shift,
-			 bool dither,
-          int blend_mode);
+void rsx_gl_set_mask_setting(uint32_t mask_set_or, uint32_t mask_eval_and);
+void rsx_gl_set_draw_offset(int16_t x, int16_t y);
 
-  void rsx_gl_push_quad(float p0x, float p0y, float p0w,
-	  float p1x, float p1y, float p1w,
-	  float p2x, float p2y, float p2w,
-	  float p3x, float p3y, float p3w,
-	  uint32_t c0,
-	  uint32_t c1,
-	  uint32_t c2,
-	  uint32_t c3,
-	  uint16_t t0x, uint16_t t0y,
-	  uint16_t t1x, uint16_t t1y,
-	  uint16_t t2x, uint16_t t2y,
-	  uint16_t t3x, uint16_t t3y,
-	  uint16_t texpage_x, uint16_t texpage_y,
-	  uint16_t clut_x, uint16_t clut_y,
-	  uint8_t texture_blend_mode,
-	  uint8_t depth_shift,
-	  bool dither,
-	  int blend_mode);
+void rsx_gl_set_draw_area( uint16_t x, uint16_t y,
+                           uint16_t w, uint16_t h);
+
+void rsx_gl_set_display_mode( uint16_t x, uint16_t y,
+                              uint16_t w, uint16_t h,
+                              bool depth_24bpp);
+
+void rsx_gl_push_triangle( float p0x, float p0y, float p0w,
+                           float p1x, float p1y, float p1w,
+                           float p2x, float p2y, float p2w,
+                           uint32_t c0,
+                           uint32_t c1,
+                           uint32_t c2,
+                           uint16_t t0x, uint16_t t0y,
+                           uint16_t t1x, uint16_t t1y,
+                           uint16_t t2x, uint16_t t2y,
+                           uint16_t texpage_x, uint16_t texpage_y,
+                           uint16_t clut_x, uint16_t clut_y,
+                           uint8_t texture_blend_mode,
+                           uint8_t depth_shift,
+                           bool dither,
+                           int blend_mode, uint32_t mask_set_or, uint32_t mask_eval_and);
+
+void rsx_gl_push_quad(  float p0x, float p0y, float p0w,
+                        float p1x, float p1y, float p1w,
+                        float p2x, float p2y, float p2w,
+                        float p3x, float p3y, float p3w,
+                        uint32_t c0,
+                        uint32_t c1,
+                        uint32_t c2,
+                        uint32_t c3,
+                        uint16_t t0x, uint16_t t0y,
+                        uint16_t t1x, uint16_t t1y,
+                        uint16_t t2x, uint16_t t2y,
+                        uint16_t t3x, uint16_t t3y,
+                        uint16_t texpage_x, uint16_t texpage_y,
+                        uint16_t clut_x, uint16_t clut_y,
+                        uint8_t texture_blend_mode,
+                        uint8_t depth_shift,
+                        bool dither,
+                        int blend_mode, uint32_t mask_set_or, uint32_t mask_eval_and);
 
 
-  void rsx_gl_push_line(int16_t p0x, int16_t p0y,
-		     int16_t p1x, int16_t p1y,
-		     uint32_t c0,
-		     uint32_t c1,
-		     bool dither, int blend_mode);
+void rsx_gl_push_line(  int16_t p0x, int16_t p0y,
+                        int16_t p1x, int16_t p1y,
+                        uint32_t c0,
+                        uint32_t c1,
+                        bool dither, int blend_mode, uint32_t mask_set_or, uint32_t mask_eval_and);
 
-  void rsx_gl_load_image(uint16_t x, uint16_t y,
-		      uint16_t w, uint16_t h,
-		      uint16_t *vram);
+void rsx_gl_load_image( uint16_t x, uint16_t y,
+                        uint16_t w, uint16_t h,
+                        uint16_t *vram, uint32_t mask_set_or, uint32_t mask_eval_and);
 
-  void rsx_gl_fill_rect(uint32_t color,
-		     uint16_t x, uint16_t y,
-		     uint16_t w, uint16_t h);
+void rsx_gl_fill_rect(  uint32_t color,
+                        uint16_t x, uint16_t y,
+                        uint16_t w, uint16_t h);
 
-  void rsx_gl_copy_rect(uint16_t src_x, uint16_t src_y,
-		     uint16_t dst_x, uint16_t dst_y,
-		     uint16_t w, uint16_t h);
+void rsx_gl_copy_rect(  uint16_t src_x, uint16_t src_y,
+                        uint16_t dst_x, uint16_t dst_y,
+                        uint16_t w, uint16_t h, uint32_t mask_set_or, uint32_t mask_eval_and);
 
-  void rsx_gl_toggle_display(bool status);
+void rsx_gl_toggle_display(bool status);
 
-  bool rsx_gl_has_software_renderer(void);
+bool rsx_gl_has_software_renderer(void);
 
 #endif /*__RSX_GL_H__ */


### PR DESCRIPTION
In this PR, the GL renderer imitates the vulkan renderer's behavior in regards to tracking the behavior of mednafen's MaskEvalAND and MaskSetOR variables.

