### PR TITLE
Silence -Wunused-but-set-variable warnings

### DIFF
--- a/mednafen/psx/gpu_polygon.cpp
+++ b/mednafen/psx/gpu_polygon.cpp
@@ -587,6 +587,7 @@ static void Command_DrawPolygon(PS_GPU *gpu, const uint32_t *cb)
    uint16_t clut_x = (clut & (0x3f << 4));
    uint16_t clut_y = (clut >> 10) & 0x1ff;
 
+#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_VULKAN)
    enum blending_modes blend_mode = BLEND_MODE_AVERAGE;
 
    if (textured)
@@ -597,7 +598,6 @@ static void Command_DrawPolygon(PS_GPU *gpu, const uint32_t *cb)
          blend_mode = BLEND_MODE_ADD;
    }
 
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_VULKAN)
    if (rsx_intf_is_type() == RSX_OPENGL || rsx_intf_is_type() == RSX_VULKAN)
    {
       if (numvertices == 4)

--- a/mednafen/psx/gpu_sprite.cpp
+++ b/mednafen/psx/gpu_sprite.cpp
@@ -175,6 +175,7 @@ static void Command_DrawSprite(PS_GPU *gpu, const uint32_t *cb)
    uint16_t clut_x = (clut & (0x3f << 4));
    uint16_t clut_y = (clut >> 10) & 0x1ff;
 
+#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_VULKAN)
    enum blending_modes blend_mode = BLEND_MODE_AVERAGE;
 
    if (textured)
@@ -185,7 +186,6 @@ static void Command_DrawSprite(PS_GPU *gpu, const uint32_t *cb)
        blend_mode = BLEND_MODE_ADD;
    }
 
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_VULKAN)
    if (rsx_intf_is_type() == RSX_OPENGL || rsx_intf_is_type() == RSX_VULKAN)
    {
       rsx_intf_push_quad(  x,                /* p0x */


### PR DESCRIPTION
Silences extremely spammy `-Wunused-but-set-variable` warnings when built without `HAVE_OPENGL=1` or `HAVE_VULKAN=1`.

Example:
```
mednafen/psx/gpu_sprite.cpp:178:24: warning: variable 'blend_mode' set but not used [-Wunused-but-set-variable]
mednafen/psx/gpu_sprite.cpp: In instantiation of 'void Command_DrawSprite(PS_GPU*, const uint32_t*) [with unsigned char raw_size = 1u; bool textured = true; int BlendMode = 0; bool TexMult = true; unsigned int TexMode_TA = 2u; bool MaskEval_TA = true; uint32_t = unsigned int]':
mednafen/psx/gpu.cpp:498:1:   required from here
mednafen/psx/gpu_sprite.cpp:178:24: warning: variable 'blend_mode' set but not used [-Wunused-but-set-variable]
mednafen/psx/gpu_sprite.cpp: In instantiation of 'void Command_DrawSprite(PS_GPU*, const uint32_t*) [with unsigned char raw_size = 1u; bool textured = true; int BlendMode = 1; bool TexMult = true; unsigned int TexMode_TA = 0u; bool MaskEval_TA = false; uint32_t = unsigned int]':
mednafen/psx/gpu.cpp:498:1:   required from here
mednafen/psx/gpu_sprite.cpp:178:24: warning: variable 'blend_mode' set but not used [-Wunused-but-set-variable]
mednafen/psx/gpu_sprite.cpp: In instantiation of 'void Command_DrawSprite(PS_GPU*, const uint32_t*) [with unsigned char raw_size = 1u; bool textured = true; int BlendMode = 1; bool TexMult = true; unsigned int TexMode_TA = 1u; bool MaskEval_TA = false; uint32_t = unsigned int]':
```