### PR TITLE
Fix Playstation executable loading.

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1712,6 +1712,8 @@ static int Load(const char *name, MDFNFILE *fp)
          return -1;
    }
 
+   MDFNGameInfo = &EmulatedPSX;
+
    return(1);
 }
 


### PR DESCRIPTION
Mednafen has functionality to load a playstation executable ([like this](http://psx.amidog.se/doku.php?id=psx:download:cpu#CPU_Test))  instead of an cd.
In Beetle this functionality is implemented but a bug caused the executable to not load.
After a simple patch the functionality now works.