### PR TITLE
Fix compile for freebsd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ else ifneq (,$(findstring armv,$(platform)))
    override platform += unix
 endif
 
+ifneq ($(findstring BSD,$(shell uname -a)),)
+   FLAGS += -DBSD
+endif
+
 ifneq ($(platform), osx)
    ifeq ($(findstring Haiku,$(shell uname -a)),)
       PTHREAD_FLAGS = -lpthread

--- a/libretro-common/rthreads/rthreads.c
+++ b/libretro-common/rthreads/rthreads.c
@@ -792,7 +792,7 @@ bool scond_wait_timeout(scond_t *cond, slock_t *lock, int64_t timeout_us)
    now.tv_nsec = tm.tv_usec * 1000;
 #elif defined(RETRO_WIN32_USE_PTHREADS)
    _ftime64_s(&now);
-#elif !defined(GEKKO)
+#elif !defined(GEKKO) || !defined(BSD)
    /* timeout on libogc is duration, not end time. */
    clock_gettime(CLOCK_REALTIME, &now);
 #endif


### PR DESCRIPTION
Fixes the following build error on freebsd, note I only have a headless server to test building on. I can not try actually running the core on freebsd yet.
```
libretro-common/rthreads/rthreads.c:797:18: error: use of undeclared identifier
      'CLOCK_REALTIME'
   clock_gettime(CLOCK_REALTIME, &now);
                 ^
1 error generated.
gmake: *** [Makefile:431: libretro-common/rthreads/rthreads.o] Error 1
```
@bparker Can you review this?