### PR TITLE
Silence linker unused warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ ifneq (,$(findstring unix,$(platform)))
       IS_X86 = 1
    endif
    LDFLAGS += $(PTHREAD_FLAGS)
-   FLAGS += $(PTHREAD_FLAGS)
+   FLAGS +=
    ifeq ($(HAVE_OPENGL),1)
       ifneq (,$(findstring gles,$(platform)))
          GLES = 1


### PR DESCRIPTION
`-lpthread` is a linker flag and should not be in `FLAGS` and only in `LDFLAGS`.  This silences the following numerous warnings on freebsd.
```
cc: warning: -lpthread: 'linker' input unused
```
It might be a good idea to do this for other platforms too, but I am reluctant to make changes for something I can't test.