### PR TITLE
Precache compressed (rather than uncompressed) CHD data

### DIFF
--- a/deps/libchdr/chd.h
+++ b/deps/libchdr/chd.h
@@ -349,6 +349,8 @@ struct _chd_verify_result
 /* open an existing CHD file */
 chd_error chd_open(const char *filename, int mode, chd_file *parent, chd_file **chd);
 
+/* precache underlying file */
+chd_error chd_precache(chd_file *chd);
 
 /* close a CHD file */
 void chd_close(chd_file *chd);

--- a/mednafen/cdrom/CDAccess_CHD.cpp
+++ b/mednafen/cdrom/CDAccess_CHD.cpp
@@ -56,6 +56,13 @@ bool CDAccess_CHD::ImageOpen(const char *path, bool image_memcache)
    if (err != CHDERR_NONE)
       return false;
 
+   if (image_memcache)
+   {
+      err = chd_precache(chd);
+      if (err != CHDERR_NONE)
+         return false;
+   }
+
    /* allocate storage for sector reads */
    const chd_header *head = chd_get_header(chd);
    hunkmem = (uint8_t*)malloc(head->hunkbytes);

--- a/mednafen/cdrom/CDAccess_CHD.h
+++ b/mednafen/cdrom/CDAccess_CHD.h
@@ -23,8 +23,6 @@ class CDAccess_CHD : public CDAccess
       chd_file *chd;
       /* hunk data cache */
       uint8_t *hunkmem;
-      /* cached entire disc? */
-      bool memcache;
       /* last hunknum read */
       int oldhunk;
 


### PR DESCRIPTION
This makes the cache disc option more tolerable than my previous attempt.  Loading multi-disc playlists with a cold OS page cache still produces mystifying delays on startup, but at least it doesn't peg a CPU to 100% for over a minute.

I'm still dissatisfied with pre-caching discs to avoid stutter.  You shouldn't need an SSD to be able to keep up with a simulated 2x CD-ROM drive from 1994.  The CD emulation code probably needs to be reworked.