### PR TITLE
Avoid stuttering on CD-ROM sector reads

### DIFF
--- a/mednafen/cdrom/CDAccess.cpp
+++ b/mednafen/cdrom/CDAccess.cpp
@@ -59,3 +59,14 @@ CDAccess *cdaccess_open_image(bool *success, const char *path, bool image_memcac
 #endif
    return new CDAccess_Image(success, path, image_memcache);
 }
+
+bool CDAccess::Read_Raw_PW(uint8_t *buf, int32_t lba)
+{
+   uint8 tmpbuf[2352 + 96];
+
+   if (!Read_Raw_Sector(tmpbuf, lba))
+      return false;
+   memcpy(buf, tmpbuf + 2352, 96);
+
+   return true;
+}

--- a/mednafen/cdrom/CDAccess.h
+++ b/mednafen/cdrom/CDAccess.h
@@ -18,6 +18,8 @@ class CDAccess
 
  virtual bool Read_Raw_Sector(uint8_t *buf, int32_t lba) = 0;
 
+ virtual bool Read_Raw_PW(uint8_t *buf, int32_t lba);
+
  virtual bool Read_TOC(TOC *toc) = 0;
 
  virtual void Eject(bool eject_status) = 0;		// Eject a disc if it's physical, otherwise NOP.  Returns true on success(or NOP), false on error

--- a/mednafen/cdrom/CDAccess_CHD.cpp
+++ b/mednafen/cdrom/CDAccess_CHD.cpp
@@ -443,6 +443,13 @@ bool CDAccess_CHD::Read_Raw_Sector(uint8 *buf, int32 lba)
    return true;
 }
 
+bool CDAccess_CHD::Read_Raw_PW(uint8_t *buf, int32_t lba)
+{
+   memset(buf, 0, 96);
+   MakeSubPQ(lba, buf);
+   return true;
+}
+
 bool CDAccess_CHD::Read_TOC(TOC *toc)
 {
    TOC_Clear(toc);

--- a/mednafen/cdrom/CDAccess_CHD.h
+++ b/mednafen/cdrom/CDAccess_CHD.h
@@ -15,6 +15,8 @@ class CDAccess_CHD : public CDAccess
 
       virtual bool Read_Raw_Sector(uint8_t *buf, int32_t lba);
 
+      virtual bool Read_Raw_PW(uint8_t *buf, int32_t lba);
+
       virtual bool Read_TOC(TOC *toc);
 
       virtual void Eject(bool eject_status);

--- a/mednafen/cdrom/CDAccess_Image.cpp
+++ b/mednafen/cdrom/CDAccess_Image.cpp
@@ -1199,6 +1199,13 @@ void CDAccess_Image::MakeSubPQ(int32 lba, uint8 *SubPWBuf)
       SubPWBuf[i] |= (((buf[i >> 3] >> (7 - (i & 0x7))) & 1) ? 0x40 : 0x00) | pause_or;
 }
 
+bool CDAccess_Image::Read_Raw_PW(uint8_t *buf, int32_t lba)
+{
+   memset(buf, 0, 96);
+   MakeSubPQ(lba, buf);
+   return true;
+}
+
 bool CDAccess_Image::Read_TOC(TOC *toc)
 {
    unsigned i;

--- a/mednafen/cdrom/CDAccess_Image.h
+++ b/mednafen/cdrom/CDAccess_Image.h
@@ -41,6 +41,8 @@ class CDAccess_Image : public CDAccess
 
       virtual bool Read_Raw_Sector(uint8_t *buf, int32_t lba);
 
+      virtual bool Read_Raw_PW(uint8_t *buf, int32_t lba);
+
       virtual bool Read_TOC(TOC *toc);
 
       virtual void Eject(bool eject_status);

--- a/mednafen/cdrom/CDAccess_PBP.cpp
+++ b/mednafen/cdrom/CDAccess_PBP.cpp
@@ -340,6 +340,14 @@ void CDAccess_PBP::MakeSubPQ(int32 lba, uint8 *SubPWBuf)
       SubPWBuf[i] |= (((buf[i >> 3] >> (7 - (i & 0x7))) & 1) ? 0x40 : 0x00) | pause_or;
 }
 
+bool CDAccess_PBP::Read_Raw_PW(uint8_t *buf, int32_t lba)
+{
+   memset(buf, 0, 96);
+   MakeSubPQ(lba, buf);
+   return true;
+}
+
+
 int CDAccess_PBP::decompress2(void *out, uint32_t *out_size, void *in, uint32_t in_size)
 {
    static z_stream z;

--- a/mednafen/cdrom/CDAccess_PBP.h
+++ b/mednafen/cdrom/CDAccess_PBP.h
@@ -17,6 +17,8 @@ class CDAccess_PBP : public CDAccess
 
       virtual bool Read_Raw_Sector(uint8_t *buf, int32_t lba);
 
+      virtual bool Read_Raw_PW(uint8_t *buf, int32_t lba);
+
       virtual bool Read_TOC(TOC *toc);
 
       virtual void Eject(bool eject_status);

--- a/mednafen/cdrom/cdromif.cpp
+++ b/mednafen/cdrom/cdromif.cpp
@@ -493,9 +493,6 @@ bool CDIF_MT::ReadRawSector(uint8 *buf, uint32 lba, bool async)
 
 bool CDIF_MT::ReadRawSectorPWOnly(uint8 *buf, uint32 lba, bool hint_fullread)
 {
-   uint8 tmpbuf[2352 + 96];
-   bool ret;
-
    if(UnrecoverableError)
    {
       memset(buf, 0, 96);
@@ -511,10 +508,12 @@ bool CDIF_MT::ReadRawSectorPWOnly(uint8 *buf, uint32 lba, bool hint_fullread)
       return(false);
    }
 
-   ret = ReadRawSector(tmpbuf, lba);
-   memcpy(buf, tmpbuf + 2352, 96);
+   if (hint_fullread)
+   {
+      HintReadSector(lba);
+   }
 
-   return ret;
+   return disc_cdaccess->Read_Raw_PW(buf, lba);
 }
 
 void CDIF_MT::HintReadSector(uint32 lba)
@@ -628,9 +627,6 @@ bool CDIF_ST::ReadRawSector(uint8 *buf, uint32 lba, bool async)
 
 bool CDIF_ST::ReadRawSectorPWOnly(uint8 *buf, uint32 lba, bool hint_fullread)
 {
-   uint8 tmpbuf[2352 + 96];
-   bool ret;
-
    if(UnrecoverableError)
    {
       memset(buf, 0, 96);
@@ -646,10 +642,7 @@ bool CDIF_ST::ReadRawSectorPWOnly(uint8 *buf, uint32 lba, bool hint_fullread)
       return(false);
    }
 
-   ret = ReadRawSector(tmpbuf, lba);
-   memcpy(buf, tmpbuf + 2352, 96);
-
-   return ret;
+   return disc_cdaccess->Read_Raw_PW(buf, lba);
 }
 
 bool CDIF_ST::Eject(bool eject_status)

--- a/mednafen/cdrom/cdromif.h
+++ b/mednafen/cdrom/cdromif.h
@@ -38,7 +38,7 @@ class CDIF
       }
 
       virtual void HintReadSector(uint32_t lba) = 0;
-      virtual bool ReadRawSector(uint8_t *buf, uint32_t lba) = 0;
+      virtual bool ReadRawSector(uint8_t *buf, uint32_t lba, bool async = false) = 0;
       virtual bool ReadRawSectorPWOnly(uint8_t *buf, uint32_t lba, bool hint_fullread) = 0;
 
       // Call for mode 1 or mode 2 form 1 only.

--- a/mednafen/psx/cdc.cpp
+++ b/mednafen/psx/cdc.cpp
@@ -904,9 +904,16 @@ void PS_CDC::HandlePlayRead(void)
       PSX_WARNING("[CDC] In leadout area: %u", CurSector);
    }
 
-   Cur_CDIF->ReadRawSector(read_buf, CurSector);	// FIXME: error out on error.
-   DecodeSubQ(read_buf + 2352);
+   if(!SeekRetryCounter)
+      Cur_CDIF->ReadRawSector(read_buf, CurSector, false);
+   else if (!Cur_CDIF->ReadRawSector(read_buf, CurSector, true))
+   {
+      SeekRetryCounter--;
+      PSRCounter = 33868800 / 75;
+      return;
+   }
 
+   DecodeSubQ(read_buf + 2352);
 
    if(SubQBuf_Safe[1] == 0xAA && (DriveStatus == DS_PLAYING || (!(SubQBuf_Safe[0] & 0x40) && (Mode & MODE_CDDA))))
    {


### PR DESCRIPTION
This avoids needing to turn on CD pre-caching to prevent emulation stuttering.  The two changes are fairly simple:

- Instead of synchronously waiting for the background I/O thread and blocking emulation, make the emulated program wait longer and check back later.  This seems unlikely to cause compatibility problems given that real games had to contend with imperfect physical CD-ROM drives -- some of which were being literally melted by the power supply -- but the pre-cache option is available to bypass this if needed.
- Annoyingly, there is `PreSeekHack` method which synchronously reads subchannel data *prior* to emulating the seek time.  Since the CD interface actually reads the entire sector to extract the subchannel data, this defeats many of the benefits of background I/O (speculative read-ahead still helps).  It turns out that the subchannel data is usually computed from scratch anyway, so I refactored it to avoid reading the sector.  It seems reading the subchannel data was intended to provide a hint to the background thread to read the full sector -- this now actually works.