### PR TITLE
Remove a redundant SetDisc call when loading multi-disc PBP files

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1968,8 +1968,6 @@ int StateAction(StateMem *sm, int load, int data_only)
             CD_SelectedDisc = -1;
 
          CDEject();
-         CDC->SetDisc(CD_TrayOpen, (CD_SelectedDisc >= 0 && !CD_TrayOpen) ? (*cdifs)[0] : NULL,
-               (CD_SelectedDisc >= 0 && !CD_TrayOpen) ? cdifs_scex_ids[0] : NULL);
          CDInsertEject();
       } else {
          if(!cdifs || CD_SelectedDisc >= (int)cdifs->size())


### PR DESCRIPTION
There was a comment on https://github.com/libretro/beetle-psx-libretro/pull/266 about one of the SetDisc calls being redundant. We need the one in `CDInsertEject`, but I removed the other one. I still see the correct log messages, and the state seems to load properly and I can load disc 2 savegames after a soft reset.