### PR TITLE
PBP: CD_SelectedDisc cannot be < 0

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1997,7 +1997,7 @@ int StateAction(StateMem *sm, int load, int data_only)
    {
       if(CD_IsPBP)
       {
-         if(!cdifs || CD_SelectedDisc >= PBP_DiscCount)
+         if((!cdifs || CD_SelectedDisc >= PBP_DiscCount) && PBP_DiscCount > 0)
             CD_SelectedDisc = -1;
 
          CDEject();


### PR DESCRIPTION
should probably fix this issue, assuming that he is using single-disc game.
https://github.com/libretro/beetle-psx-libretro/issues/297

When a game is only using 1 disk to play, loading state will deduct -1 from CD_SelectedDisc which will make this < 0 causing emulation to stop during disk access.

This PR will check how many discs are there (PBP_DiscCount) and only deducts CD_SelectedDisc when its greater than 0(multiple-disc game).