### PR TITLE
libretro-common: Bump OpenGL version requirement to 3.3

### DIFF
--- a/libretro-common/glsm/glsm.c
+++ b/libretro-common/glsm/glsm.c
@@ -2207,7 +2207,7 @@ static bool glsm_state_ctx_init(void *data)
 #ifdef CORE
    hw_render.context_type       = RETRO_HW_CONTEXT_OPENGL_CORE;
    hw_render.version_major      = 3;
-   hw_render.version_minor      = 1;
+   hw_render.version_minor      = 3;
 #else
    hw_render.context_type       = RETRO_HW_CONTEXT_OPENGL;
 #endif


### PR DESCRIPTION
There isn't a 3.1 core profile context and requesting one is wrong. Recent mesa commits have revealed this as wrong and causes problems for beetle-psx. A 3.3 OpenGL context is what beetle-psx originally requested, but at some point this was lowered.

Fixes https://github.com/libretro/beetle-psx-libretro/issues/315