### PR TITLE
Fix BSD build

### DIFF
--- a/libretro-common/rthreads/rthreads.c
+++ b/libretro-common/rthreads/rthreads.c
@@ -53,7 +53,8 @@
 #include <time.h>
 #endif
 
-#if defined(VITA) || defined(BSD)
+#if defined(VITA) || defined(__FreeBSD__) || defined(__DragonFly__) || \
+  defined(__OpenBSD__) || defined(__NetBSD__)
 #include <sys/time.h>
 #endif
 


### PR DESCRIPTION
There is no 'BSD' define anywhere in the Makefiles, so change the check to built-in platform defines.