### PR TITLE
Fixes to code to compile for MSVC

### DIFF
--- a/deps/flac-1.3.2/src/libFLAC/windows_unicode_filenames.c
+++ b/deps/flac-1.3.2/src/libFLAC/windows_unicode_filenames.c
@@ -194,6 +194,8 @@ HANDLE WINAPI flac_internal_CreateFile_utf8(const char *lpFileName, DWORD dwDesi
 		handle = CreateFile2(wname, dwDesiredAccess, dwShareMode, CREATE_ALWAYS, NULL);
 		free(wname);
 	}
+
+	return handle;
 #else
 	if (!utf8_filenames) {
 		return CreateFileA(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);

--- a/mednafen/mednafen-types.h
+++ b/mednafen/mednafen-types.h
@@ -255,6 +255,10 @@ template<typename T> typename std::remove_all_extents<T>::type* MDAP(T* v) { ret
 #endif
 #endif /* NOT_LIBRETRO */
 
+#ifndef _MSC_VER
 #define MDFN_ALIGN(n)        __attribute__ ((aligned (n)))
+#else
+#define MDFN_ALIGN(n)        __declspec(align(n))
+#endif
 
 #endif

--- a/mednafen/psx/cpu.h
+++ b/mednafen/psx/cpu.h
@@ -222,7 +222,7 @@ class PS_CPU
 
  uint32 Exception(uint32 code, uint32 PC, const uint32 NP, const uint32 instr) MDFN_WARN_UNUSED_RESULT;
 
- template<bool DebugMode, bool BIOSPrintMode, bool ILHMode> pscpu_timestamp_t RunReal(pscpu_timestamp_t timestamp_in) NO_INLINE;
+ template<bool DebugMode, bool BIOSPrintMode, bool ILHMode> NO_INLINE pscpu_timestamp_t RunReal(pscpu_timestamp_t timestamp_in);
 
  template<typename T> T PeekMemory(uint32 address) MDFN_COLD;
  template<typename T> void PokeMemory(uint32 address, T value) MDFN_COLD;

--- a/mednafen/psx/gpu_common.h
+++ b/mednafen/psx/gpu_common.h
@@ -194,7 +194,7 @@ static INLINE uint16_t GetTexel(PS_GPU *g, int32_t u_arg, int32_t v_arg)
      uint32_t gro = fbtex_y * 1024U + fbtex_x;
 
      PS_GPU::TexCache_t *TexCache = &g->TexCache[0];
-     PS_GPU::TexCache_t *c;
+     PS_GPU::TexCache_t *c = NULL;  //assigned to NULL to suppress potentially uninitialized variable error
 
      switch(TexMode_TA)
      {

--- a/mednafen/psx/mdec.cpp
+++ b/mednafen/psx/mdec.cpp
@@ -36,7 +36,7 @@
 
      // This condition when InFIFO.CanWrite() != 0 is a bit buggy on real hardware, decoding loop *seems* to be reading too
      // much and pulling garbage from the FIFO.
-     if(InCounter == 0xFFFF)	
+     if(InCounter == 0xFFFF)
       InFIFOReady = true;
     }
 
@@ -87,12 +87,12 @@ static bool InCommand;
 static uint8 QMatrix[2][64];
 static uint32 QMIndex;
 
-static int16 IDCTMatrix[64] MDFN_ALIGN(16);
+MDFN_ALIGN(16) static int16 IDCTMatrix[64];
 static uint32 IDCTMIndex;
 
 static uint8 QScale;
 
-static int16 Coeff[64] MDFN_ALIGN(16);
+MDFN_ALIGN(16) static int16 Coeff[64];
 static uint32 CoeffIndex;
 static uint32 DecodeWB;
 
@@ -113,14 +113,14 @@ static uint8 RAMOffsetWWS;
 
 static const uint8 ZigZag[64] =
 {
- 0x00, 0x08, 0x01, 0x02, 0x09, 0x10, 0x18, 0x11, 
- 0x0a, 0x03, 0x04, 0x0b, 0x12, 0x19, 0x20, 0x28, 
- 0x21, 0x1a, 0x13, 0x0c, 0x05, 0x06, 0x0d, 0x14, 
- 0x1b, 0x22, 0x29, 0x30, 0x38, 0x31, 0x2a, 0x23, 
- 0x1c, 0x15, 0x0e, 0x07, 0x0f, 0x16, 0x1d, 0x24, 
- 0x2b, 0x32, 0x39, 0x3a, 0x33, 0x2c, 0x25, 0x1e, 
- 0x17, 0x1f, 0x26, 0x2d, 0x34, 0x3b, 0x3c, 0x35, 
- 0x2e, 0x27, 0x2f, 0x36, 0x3d, 0x3e, 0x37, 0x3f, 
+ 0x00, 0x08, 0x01, 0x02, 0x09, 0x10, 0x18, 0x11,
+ 0x0a, 0x03, 0x04, 0x0b, 0x12, 0x19, 0x20, 0x28,
+ 0x21, 0x1a, 0x13, 0x0c, 0x05, 0x06, 0x0d, 0x14,
+ 0x1b, 0x22, 0x29, 0x30, 0x38, 0x31, 0x2a, 0x23,
+ 0x1c, 0x15, 0x0e, 0x07, 0x0f, 0x16, 0x1d, 0x24,
+ 0x2b, 0x32, 0x39, 0x3a, 0x33, 0x2c, 0x25, 0x1e,
+ 0x17, 0x1f, 0x26, 0x2d, 0x34, 0x3b, 0x3c, 0x35,
+ 0x2e, 0x27, 0x2f, 0x36, 0x3d, 0x3e, 0x37, 0x3f,
 };
 
 void MDEC_Power(void)
@@ -251,7 +251,7 @@ static void IDCT_1D_Multi(int16 *in_coeff, T *out_coeff)
       for( x = 0; x < 8; x++)
       {
 #ifdef __SSE2__
-         int32 tmp[4] MDFN_ALIGN(16);
+         MDFN_ALIGN(16) int32 tmp[4];
          __m128i m   = _mm_load_si128((__m128i *)&IDCTMatrix[(x * 8)]);
          __m128i sum = _mm_madd_epi16(m, c);
          sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, (3 << 0) | (2 << 2) | (1 << 4) | (0 << 6)));
@@ -281,7 +281,7 @@ static void IDCT_1D_Multi(int16 *in_coeff, T *out_coeff)
 
 static void IDCT(int16 *in_coeff, int8 *out_coeff)
 {
-   int16 tmpbuf[64] MDFN_ALIGN(16);
+   MDFN_ALIGN(16) int16 tmpbuf[64];
 
    IDCT_1D_Multi<int16>(in_coeff, tmpbuf);
    IDCT_1D_Multi<int8>(tmpbuf, out_coeff);
@@ -505,10 +505,10 @@ static INLINE void WriteImageData(uint16 V, int32* eat_cycles)
          case 5:
             IDCT(Coeff, &block_y[0][0]);
             break;
-      }   
+      }
 
       // Timing in the actual PS1 MDEC is complex due to (apparent) pipelining, but the average when decoding a large number of blocks is
-      // about 512.  
+      // about 512.
       *eat_cycles += 512;
 
       if(DecodeWB >= 2)

--- a/mednafen/psx/timer.cpp
+++ b/mednafen/psx/timer.cpp
@@ -144,7 +144,7 @@ static uint32_t CalcNextEvent(void)
       const uint32_t target = ((Timers[i].Mode & 0x18) && (Timers[i].Counter < Timers[i].Target)) ? Timers[i].Target : 0x10000;
       const uint32_t count_delta = target - Timers[i].Counter;
       uint32_t tmp_clocks;
-         
+
       if((i == 0x2) && (Timers[i].Mode & 0x200))
          tmp_clocks = (count_delta * 8) - Timers[i].Div8Counter;
       else
@@ -159,7 +159,7 @@ static uint32_t CalcNextEvent(void)
    return(next_event);
 }
 
-static MDFN_FASTCALL bool TimerMatch(unsigned i)
+static bool MDFN_FASTCALL TimerMatch(unsigned i)
 {
    bool irq_exact = false;
 
@@ -190,7 +190,7 @@ static MDFN_FASTCALL bool TimerMatch(unsigned i)
    return irq_exact;
 }
 
-static MDFN_FASTCALL bool TimerOverflow(unsigned i)
+static bool MDFN_FASTCALL TimerOverflow(unsigned i)
 {
    bool irq_exact = false;
 
@@ -215,7 +215,7 @@ static MDFN_FASTCALL bool TimerOverflow(unsigned i)
    return irq_exact;
 }
 
-static MDFN_FASTCALL void ClockTimer(int i, uint32_t clocks)
+static void MDFN_FASTCALL ClockTimer(int i, uint32_t clocks)
 {
    int32_t before = Timers[i].Counter;
    int32_t target = 0x10000;
@@ -270,7 +270,7 @@ static MDFN_FASTCALL void ClockTimer(int i, uint32_t clocks)
    }
 }
 
-MDFN_FASTCALL void TIMER_SetVBlank(bool status)
+void MDFN_FASTCALL TIMER_SetVBlank(bool status)
 {
    switch(Timers[1].Mode & 0x7)
    {
@@ -313,7 +313,7 @@ MDFN_FASTCALL void TIMER_SetVBlank(bool status)
    vblank = status;
 }
 
-MDFN_FASTCALL void TIMER_SetHRetrace(bool status)
+void MDFN_FASTCALL TIMER_SetHRetrace(bool status)
 {
    if(hretrace && !status)
    {
@@ -329,7 +329,7 @@ MDFN_FASTCALL void TIMER_SetHRetrace(bool status)
    hretrace = status;
 }
 
-MDFN_FASTCALL void TIMER_AddDotClocks(uint32_t count)
+void MDFN_FASTCALL TIMER_AddDotClocks(uint32_t count)
 {
    if(Timers[0].Mode & 0x100)
       ClockTimer(0, count);
@@ -341,7 +341,7 @@ void TIMER_ClockHRetrace(void)
       ClockTimer(1, 1);
 }
 
-MDFN_FASTCALL int32_t TIMER_Update(const int32_t timestamp)
+int32_t MDFN_FASTCALL TIMER_Update(const int32_t timestamp)
 {
    int32_t cpu_clocks = timestamp - lastts;
 
@@ -361,7 +361,7 @@ MDFN_FASTCALL int32_t TIMER_Update(const int32_t timestamp)
    return(timestamp + CalcNextEvent());
 }
 
-static MDFN_FASTCALL void CalcCountingStart(unsigned which)
+static void MDFN_FASTCALL CalcCountingStart(unsigned which)
 {
    Timers[which].DoZeCounting = true;
 
@@ -395,8 +395,8 @@ void TIMER_Write(const int32_t timestamp, uint32_t A, uint16_t V)
 
    V <<= (A & 3) * 8;
 
-   /* 
-   PSX_DBGINFO("[TIMER] Write: %08x %04x\n", A, V); 
+   /*
+   PSX_DBGINFO("[TIMER] Write: %08x %04x\n", A, V);
    */
 
    if(which >= 3)
@@ -428,7 +428,7 @@ void TIMER_Write(const int32_t timestamp, uint32_t A, uint16_t V)
    PSX_SetEventNT(PSX_EVENT_TIMER, timestamp + CalcNextEvent());
 }
 
-MDFN_FASTCALL uint16_t TIMER_Read(const int32_t timestamp, uint32_t A)
+uint16_t MDFN_FASTCALL TIMER_Read(const int32_t timestamp, uint32_t A)
 {
    uint16_t ret = 0;
    int which = (A >> 4) & 0x3;

--- a/mednafen/psx/timer.h
+++ b/mednafen/psx/timer.h
@@ -22,15 +22,15 @@ uint32_t TIMER_GetRegister(unsigned int which, char *special, const uint32_t spe
 void TIMER_SetRegister(unsigned int which, uint32_t value);
 
 
-MDFN_FASTCALL void TIMER_Write(const int32_t timestamp, uint32_t A, uint16_t V);
-MDFN_FASTCALL uint16_t TIMER_Read(const int32_t timestamp, uint32_t A);
+void MDFN_FASTCALL TIMER_Write(const int32_t timestamp, uint32_t A, uint16_t V);
+uint16_t MDFN_FASTCALL TIMER_Read(const int32_t timestamp, uint32_t A);
 
-MDFN_FASTCALL void TIMER_AddDotClocks(uint32_t count);
+void MDFN_FASTCALL TIMER_AddDotClocks(uint32_t count);
 void TIMER_ClockHRetrace(void);
-MDFN_FASTCALL void TIMER_SetHRetrace(bool status);
-MDFN_FASTCALL void TIMER_SetVBlank(bool status);
+void MDFN_FASTCALL TIMER_SetHRetrace(bool status);
+void MDFN_FASTCALL TIMER_SetVBlank(bool status);
 
-MDFN_FASTCALL int32_t TIMER_Update(const int32_t);
+int32_t MDFN_FASTCALL TIMER_Update(const int32_t);
 void TIMER_ResetTS(void);
 
 void TIMER_Power(void) MDFN_COLD;


### PR DESCRIPTION
Fixes to source code to compile on MSVC 2017.  These changes were also tested on mingw64, and still built okay.  Have not tested the impact on CLANG builds or other compilers.

* `MDFN_ALIGN` is defined for MSVC now as `__declspec(align(n))`
* `MDFN_ALIGN` moved to beginning of variable declaration, as needed by `__declspec(align(n))`
* `NO_INLINE` moved to before the type of the function, as needed by `__declspec(noinline)`
* `MDFN_FASTCALL` moved to between function type and function name, as needed by `__fastcall`
* Fixed libflac bug where it did not return the handle value
* Suppressed a compiler error in `GetTexel` by assigning an uninitialized variable to NULL.  An invalid `TexMode_TA` value will now segfault from a NULL pointer instead of using some random memory.