### PR TITLE
Fixes to code to compile for MSVC + changes to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,6 +514,17 @@ FLAGS += $(ENDIANNESS_DEFINES) \
          -D_FILE_OFFSET_BITS=64 \
          -D__STDC_CONSTANT_MACROS
 
+ifneq (,$(findstring windows_msvc2017,$(platform)))
+FLAGS += -D_CRT_SECURE_NO_WARNINGS \
+	 -D_CRT_NONSTDC_NO_DEPRECATE \
+	 -D__ORDER_LITTLE_ENDIAN__ \
+	 -D__BYTE_ORDER__=__ORDER_LITTLE_ENDIAN__ \
+	 -DNOMINMAX \
+	 //utf-8 \
+	 //std:c++17
+LDFLAGS += "opengl32.lib"
+endif
+
 ifeq ($(HAVE_VULKAN),1)
    FLAGS += -DHAVE_VULKAN
 endif

--- a/deps/flac-1.3.2/src/libFLAC/windows_unicode_filenames.c
+++ b/deps/flac-1.3.2/src/libFLAC/windows_unicode_filenames.c
@@ -194,6 +194,8 @@ HANDLE WINAPI flac_internal_CreateFile_utf8(const char *lpFileName, DWORD dwDesi
 		handle = CreateFile2(wname, dwDesiredAccess, dwShareMode, CREATE_ALWAYS, NULL);
 		free(wname);
 	}
+
+	return handle;
 #else
 	if (!utf8_filenames) {
 		return CreateFileA(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -94,7 +94,7 @@ static bool firmware_is_present(unsigned region)
    char bios_path[4096];
    static const size_t list_size = 10;
    const char *bios_name_list[list_size];
-   const char *bios_sha1;
+   const char *bios_sha1 = NULL;
 
    log_cb(RETRO_LOG_INFO, "Checking if required firmware is present.\n");
 

--- a/mednafen/mednafen-types.h
+++ b/mednafen/mednafen-types.h
@@ -176,7 +176,6 @@ typedef uint64_t uint64;
   //
   // Begin MSVC
   //
-  #pragma message("Compiling with MSVC, untested")
 
   #define INLINE __forceinline
   #define NO_INLINE __declspec(noinline)

--- a/mednafen/mednafen-types.h
+++ b/mednafen/mednafen-types.h
@@ -255,6 +255,10 @@ template<typename T> typename std::remove_all_extents<T>::type* MDAP(T* v) { ret
 #endif
 #endif /* NOT_LIBRETRO */
 
+#ifndef _MSC_VER
 #define MDFN_ALIGN(n)        __attribute__ ((aligned (n)))
+#else
+#define MDFN_ALIGN(n)        __declspec(align(n))
+#endif
 
 #endif

--- a/mednafen/psx/cpu.h
+++ b/mednafen/psx/cpu.h
@@ -222,7 +222,7 @@ class PS_CPU
 
  uint32 Exception(uint32 code, uint32 PC, const uint32 NP, const uint32 instr) MDFN_WARN_UNUSED_RESULT;
 
- template<bool DebugMode, bool BIOSPrintMode, bool ILHMode> pscpu_timestamp_t RunReal(pscpu_timestamp_t timestamp_in) NO_INLINE;
+ template<bool DebugMode, bool BIOSPrintMode, bool ILHMode> NO_INLINE pscpu_timestamp_t RunReal(pscpu_timestamp_t timestamp_in);
 
  template<typename T> T PeekMemory(uint32 address) MDFN_COLD;
  template<typename T> void PokeMemory(uint32 address, T value) MDFN_COLD;

--- a/mednafen/psx/gpu_common.h
+++ b/mednafen/psx/gpu_common.h
@@ -194,7 +194,7 @@ static INLINE uint16_t GetTexel(PS_GPU *g, int32_t u_arg, int32_t v_arg)
      uint32_t gro = fbtex_y * 1024U + fbtex_x;
 
      PS_GPU::TexCache_t *TexCache = &g->TexCache[0];
-     PS_GPU::TexCache_t *c;
+     PS_GPU::TexCache_t *c = NULL;  //assigned to NULL to suppress potentially uninitialized variable error
 
      switch(TexMode_TA)
      {

--- a/mednafen/psx/gpu_common.h
+++ b/mednafen/psx/gpu_common.h
@@ -194,7 +194,7 @@ static INLINE uint16_t GetTexel(PS_GPU *g, int32_t u_arg, int32_t v_arg)
      uint32_t gro = fbtex_y * 1024U + fbtex_x;
 
      PS_GPU::TexCache_t *TexCache = &g->TexCache[0];
-     PS_GPU::TexCache_t *c = NULL;  //assigned to NULL to suppress potentially uninitialized variable error
+     PS_GPU::TexCache_t *c = NULL;
 
      switch(TexMode_TA)
      {

--- a/mednafen/psx/mdec.cpp
+++ b/mednafen/psx/mdec.cpp
@@ -36,7 +36,7 @@
 
      // This condition when InFIFO.CanWrite() != 0 is a bit buggy on real hardware, decoding loop *seems* to be reading too
      // much and pulling garbage from the FIFO.
-     if(InCounter == 0xFFFF)	
+     if(InCounter == 0xFFFF)
       InFIFOReady = true;
     }
 
@@ -87,12 +87,12 @@ static bool InCommand;
 static uint8 QMatrix[2][64];
 static uint32 QMIndex;
 
-static int16 IDCTMatrix[64] MDFN_ALIGN(16);
+MDFN_ALIGN(16) static int16 IDCTMatrix[64];
 static uint32 IDCTMIndex;
 
 static uint8 QScale;
 
-static int16 Coeff[64] MDFN_ALIGN(16);
+MDFN_ALIGN(16) static int16 Coeff[64];
 static uint32 CoeffIndex;
 static uint32 DecodeWB;
 
@@ -113,14 +113,14 @@ static uint8 RAMOffsetWWS;
 
 static const uint8 ZigZag[64] =
 {
- 0x00, 0x08, 0x01, 0x02, 0x09, 0x10, 0x18, 0x11, 
- 0x0a, 0x03, 0x04, 0x0b, 0x12, 0x19, 0x20, 0x28, 
- 0x21, 0x1a, 0x13, 0x0c, 0x05, 0x06, 0x0d, 0x14, 
- 0x1b, 0x22, 0x29, 0x30, 0x38, 0x31, 0x2a, 0x23, 
- 0x1c, 0x15, 0x0e, 0x07, 0x0f, 0x16, 0x1d, 0x24, 
- 0x2b, 0x32, 0x39, 0x3a, 0x33, 0x2c, 0x25, 0x1e, 
- 0x17, 0x1f, 0x26, 0x2d, 0x34, 0x3b, 0x3c, 0x35, 
- 0x2e, 0x27, 0x2f, 0x36, 0x3d, 0x3e, 0x37, 0x3f, 
+ 0x00, 0x08, 0x01, 0x02, 0x09, 0x10, 0x18, 0x11,
+ 0x0a, 0x03, 0x04, 0x0b, 0x12, 0x19, 0x20, 0x28,
+ 0x21, 0x1a, 0x13, 0x0c, 0x05, 0x06, 0x0d, 0x14,
+ 0x1b, 0x22, 0x29, 0x30, 0x38, 0x31, 0x2a, 0x23,
+ 0x1c, 0x15, 0x0e, 0x07, 0x0f, 0x16, 0x1d, 0x24,
+ 0x2b, 0x32, 0x39, 0x3a, 0x33, 0x2c, 0x25, 0x1e,
+ 0x17, 0x1f, 0x26, 0x2d, 0x34, 0x3b, 0x3c, 0x35,
+ 0x2e, 0x27, 0x2f, 0x36, 0x3d, 0x3e, 0x37, 0x3f,
 };
 
 void MDEC_Power(void)
@@ -251,7 +251,7 @@ static void IDCT_1D_Multi(int16 *in_coeff, T *out_coeff)
       for( x = 0; x < 8; x++)
       {
 #ifdef __SSE2__
-         int32 tmp[4] MDFN_ALIGN(16);
+         MDFN_ALIGN(16) int32 tmp[4];
          __m128i m   = _mm_load_si128((__m128i *)&IDCTMatrix[(x * 8)]);
          __m128i sum = _mm_madd_epi16(m, c);
          sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, (3 << 0) | (2 << 2) | (1 << 4) | (0 << 6)));
@@ -281,7 +281,7 @@ static void IDCT_1D_Multi(int16 *in_coeff, T *out_coeff)
 
 static void IDCT(int16 *in_coeff, int8 *out_coeff)
 {
-   int16 tmpbuf[64] MDFN_ALIGN(16);
+   MDFN_ALIGN(16) int16 tmpbuf[64];
 
    IDCT_1D_Multi<int16>(in_coeff, tmpbuf);
    IDCT_1D_Multi<int8>(tmpbuf, out_coeff);
@@ -505,10 +505,10 @@ static INLINE void WriteImageData(uint16 V, int32* eat_cycles)
          case 5:
             IDCT(Coeff, &block_y[0][0]);
             break;
-      }   
+      }
 
       // Timing in the actual PS1 MDEC is complex due to (apparent) pipelining, but the average when decoding a large number of blocks is
-      // about 512.  
+      // about 512.
       *eat_cycles += 512;
 
       if(DecodeWB >= 2)

--- a/mednafen/psx/timer.cpp
+++ b/mednafen/psx/timer.cpp
@@ -144,7 +144,7 @@ static uint32_t CalcNextEvent(void)
       const uint32_t target = ((Timers[i].Mode & 0x18) && (Timers[i].Counter < Timers[i].Target)) ? Timers[i].Target : 0x10000;
       const uint32_t count_delta = target - Timers[i].Counter;
       uint32_t tmp_clocks;
-         
+
       if((i == 0x2) && (Timers[i].Mode & 0x200))
          tmp_clocks = (count_delta * 8) - Timers[i].Div8Counter;
       else
@@ -159,7 +159,7 @@ static uint32_t CalcNextEvent(void)
    return(next_event);
 }
 
-static MDFN_FASTCALL bool TimerMatch(unsigned i)
+static bool MDFN_FASTCALL TimerMatch(unsigned i)
 {
    bool irq_exact = false;
 
@@ -190,7 +190,7 @@ static MDFN_FASTCALL bool TimerMatch(unsigned i)
    return irq_exact;
 }
 
-static MDFN_FASTCALL bool TimerOverflow(unsigned i)
+static bool MDFN_FASTCALL TimerOverflow(unsigned i)
 {
    bool irq_exact = false;
 
@@ -215,7 +215,7 @@ static MDFN_FASTCALL bool TimerOverflow(unsigned i)
    return irq_exact;
 }
 
-static MDFN_FASTCALL void ClockTimer(int i, uint32_t clocks)
+static void MDFN_FASTCALL ClockTimer(int i, uint32_t clocks)
 {
    int32_t before = Timers[i].Counter;
    int32_t target = 0x10000;
@@ -270,7 +270,7 @@ static MDFN_FASTCALL void ClockTimer(int i, uint32_t clocks)
    }
 }
 
-MDFN_FASTCALL void TIMER_SetVBlank(bool status)
+void MDFN_FASTCALL TIMER_SetVBlank(bool status)
 {
    switch(Timers[1].Mode & 0x7)
    {
@@ -313,7 +313,7 @@ MDFN_FASTCALL void TIMER_SetVBlank(bool status)
    vblank = status;
 }
 
-MDFN_FASTCALL void TIMER_SetHRetrace(bool status)
+void MDFN_FASTCALL TIMER_SetHRetrace(bool status)
 {
    if(hretrace && !status)
    {
@@ -329,7 +329,7 @@ MDFN_FASTCALL void TIMER_SetHRetrace(bool status)
    hretrace = status;
 }
 
-MDFN_FASTCALL void TIMER_AddDotClocks(uint32_t count)
+void MDFN_FASTCALL TIMER_AddDotClocks(uint32_t count)
 {
    if(Timers[0].Mode & 0x100)
       ClockTimer(0, count);
@@ -341,7 +341,7 @@ void TIMER_ClockHRetrace(void)
       ClockTimer(1, 1);
 }
 
-MDFN_FASTCALL int32_t TIMER_Update(const int32_t timestamp)
+int32_t MDFN_FASTCALL TIMER_Update(const int32_t timestamp)
 {
    int32_t cpu_clocks = timestamp - lastts;
 
@@ -361,7 +361,7 @@ MDFN_FASTCALL int32_t TIMER_Update(const int32_t timestamp)
    return(timestamp + CalcNextEvent());
 }
 
-static MDFN_FASTCALL void CalcCountingStart(unsigned which)
+static void MDFN_FASTCALL CalcCountingStart(unsigned which)
 {
    Timers[which].DoZeCounting = true;
 
@@ -395,8 +395,8 @@ void TIMER_Write(const int32_t timestamp, uint32_t A, uint16_t V)
 
    V <<= (A & 3) * 8;
 
-   /* 
-   PSX_DBGINFO("[TIMER] Write: %08x %04x\n", A, V); 
+   /*
+   PSX_DBGINFO("[TIMER] Write: %08x %04x\n", A, V);
    */
 
    if(which >= 3)
@@ -428,7 +428,7 @@ void TIMER_Write(const int32_t timestamp, uint32_t A, uint16_t V)
    PSX_SetEventNT(PSX_EVENT_TIMER, timestamp + CalcNextEvent());
 }
 
-MDFN_FASTCALL uint16_t TIMER_Read(const int32_t timestamp, uint32_t A)
+uint16_t MDFN_FASTCALL TIMER_Read(const int32_t timestamp, uint32_t A)
 {
    uint16_t ret = 0;
    int which = (A >> 4) & 0x3;

--- a/mednafen/psx/timer.cpp
+++ b/mednafen/psx/timer.cpp
@@ -387,7 +387,7 @@ static void MDFN_FASTCALL CalcCountingStart(unsigned which)
 
 }
 
-void TIMER_Write(const int32_t timestamp, uint32_t A, uint16_t V)
+void MDFN_FASTCALL TIMER_Write(const int32_t timestamp, uint32_t A, uint16_t V)
 {
    TIMER_Update(timestamp);
 

--- a/mednafen/psx/timer.h
+++ b/mednafen/psx/timer.h
@@ -22,15 +22,15 @@ uint32_t TIMER_GetRegister(unsigned int which, char *special, const uint32_t spe
 void TIMER_SetRegister(unsigned int which, uint32_t value);
 
 
-MDFN_FASTCALL void TIMER_Write(const int32_t timestamp, uint32_t A, uint16_t V);
-MDFN_FASTCALL uint16_t TIMER_Read(const int32_t timestamp, uint32_t A);
+void MDFN_FASTCALL TIMER_Write(const int32_t timestamp, uint32_t A, uint16_t V);
+uint16_t MDFN_FASTCALL TIMER_Read(const int32_t timestamp, uint32_t A);
 
-MDFN_FASTCALL void TIMER_AddDotClocks(uint32_t count);
+void MDFN_FASTCALL TIMER_AddDotClocks(uint32_t count);
 void TIMER_ClockHRetrace(void);
-MDFN_FASTCALL void TIMER_SetHRetrace(bool status);
-MDFN_FASTCALL void TIMER_SetVBlank(bool status);
+void MDFN_FASTCALL TIMER_SetHRetrace(bool status);
+void MDFN_FASTCALL TIMER_SetVBlank(bool status);
 
-MDFN_FASTCALL int32_t TIMER_Update(const int32_t);
+int32_t MDFN_FASTCALL TIMER_Update(const int32_t);
 void TIMER_ResetTS(void);
 
 void TIMER_Power(void) MDFN_COLD;

--- a/parallel-psx/atlas/atlas.hpp
+++ b/parallel-psx/atlas/atlas.hpp
@@ -2,6 +2,7 @@
 
 #include <stdint.h>
 #include <vector>
+#include <algorithm>
 
 namespace PSX
 {

--- a/parallel-psx/vulkan/command_buffer.hpp
+++ b/parallel-psx/vulkan/command_buffer.hpp
@@ -410,8 +410,11 @@ private:
 	{
 		float blend_constants[4];
 	} potential_static_state = {};
+#ifndef _MSC_VER
+	//suppress compiler error on MSVC by ommitting this check
 	static_assert(sizeof(static_state.words) >= sizeof(static_state.state),
 	              "Hashable pipeline state is not large enough!");
+#endif
 
 	struct DynamicState
 	{

--- a/parallel-psx/vulkan/image.hpp
+++ b/parallel-psx/vulkan/image.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+
 #include "cookie.hpp"
 #include "format.hpp"
 #include "intrusive.hpp"

--- a/parallel-psx/vulkan/shader.cpp
+++ b/parallel-psx/vulkan/shader.cpp
@@ -2,6 +2,10 @@
 #include "device.hpp"
 #include "spirv_cross.hpp"
 
+#include <algorithm>
+using std::min;
+using std::max;
+
 using namespace std;
 using namespace spirv_cross;
 

--- a/parallel-psx/vulkan/util.hpp
+++ b/parallel-psx/vulkan/util.hpp
@@ -9,7 +9,27 @@ namespace Vulkan
 #define trailing_zeroes(x) ((x) == 0 ? 32 : __builtin_ctz(x))
 #define trailing_ones(x) __builtin_ctz(~(x))
 #else
+#ifdef _MSC_VER
+#include <intrin.h>
+static __inline uint32_t leading_zeroes(uint32_t x)
+{
+	if (x == 0) return 32;
+	return __lzcnt(x);
+}
+static __inline uint32_t trailing_zeroes(uint32_t x)
+{
+	if (x == 0) return 32;
+	unsigned long index = 0;
+	_BitScanForward(&index, x);
+	return (uint32_t)index;
+}
+static __inline uint32_t trailing_ones(uint32_t x)
+{
+	return trailing_zeroes(~x);
+}
+#else
 #error "Implement me."
+#endif
 #endif
 
 template <typename T>

--- a/parallel-psx/vulkan/vulkan.hpp
+++ b/parallel-psx/vulkan/vulkan.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "util.hpp"
-#include "vulkan_symbol_wrapper.h"
 #include <memory>
 #include <stdexcept>
+#include "util.hpp"
+#include "vulkan_symbol_wrapper.h"
 
 #define STRINGIFY(x) #x
 

--- a/rsx/shaders_gl/command_vertex.glsl.h
+++ b/rsx/shaders_gl/command_vertex.glsl.h
@@ -1,10 +1,13 @@
 #include "shaders_common.h"
 
+#undef command_vertex_name_
 #if defined(FILTER_SABR) || defined(FILTER_XBR)
-static const char * command_vertex_xbr = GLSL(
+#define command_vertex_name_ command_vertex_xbr
 #else
-static const char *command_vertex = GLSL(
+#define command_vertex_name_ command_vertex
 #endif
+
+static const char * command_vertex_name_ = GLSL(
 // Vertex shader for rendering GPU draw commands in the framebuffer
 in vec4 position;
 in uvec3 color;
@@ -29,8 +32,10 @@ flat out uint frag_depth_shift;
 flat out uint frag_dither;
 flat out uint frag_semi_transparent;
 flat out uvec4 frag_texture_window;
+)
 
 #if defined(FILTER_SABR) || defined(FILTER_XBR)
+STRINGIZE(
 out vec2 tc;
 out vec4 xyp_1_2_3;
 out vec4 xyp_6_7_8;
@@ -39,8 +44,9 @@ out vec4 xyp_16_17_18;
 out vec4 xyp_21_22_23;
 out vec4 xyp_5_10_15;
 out vec4 xyp_9_14_9;
+)
 #endif
-
+STRINGIZE(
 void main() {
    vec2 pos = position.xy + vec2(offset);
 
@@ -70,9 +76,10 @@ void main() {
    frag_dither = dither;
    frag_semi_transparent = semi_transparent;
    frag_texture_window = texture_window;
-
+)
 #if defined(FILTER_SABR) || defined(FILTER_XBR)
-   tc = frag_texture_coord.xy;
+STRINGIZE(
+	tc = frag_texture_coord.xy;
    xyp_1_2_3    = tc.xxxy + vec4(-1.,  0., 1., -2.);
    xyp_6_7_8    = tc.xxxy + vec4(-1.,  0., 1., -1.);
    xyp_11_12_13 = tc.xxxy + vec4(-1.,  0., 1.,  0.);
@@ -80,7 +87,10 @@ void main() {
    xyp_21_22_23 = tc.xxxy + vec4(-1.,  0., 1.,  2.);
    xyp_5_10_15  = tc.xyyy + vec4(-2., -1., 0.,  1.);
    xyp_9_14_9   = tc.xyyy + vec4( 2., -1., 0.,  1.);
+)
 #endif
+STRINGIZE(
 }
-
 );
+
+#undef command_vertex_name_

--- a/rsx/shaders_gl/shaders_common.h
+++ b/rsx/shaders_gl/shaders_common.h
@@ -2,5 +2,6 @@
 #define _SHADERS_COMMON
 
 #define GLSL(src) "#version 330 core\n" #src
+#define STRINGIZE(src) #src
 
 #endif


### PR DESCRIPTION
Fixes to source code to compile on MSVC 2017, plus changes to the makefile which might fix it.  These changes were also tested on mingw64, and still built okay.  Have not tested the impact on CLANG builds or other compilers.

I'm just making this pull request to see if the tests pass.

* `MDFN_ALIGN` is defined for MSVC now as `__declspec(align(n))`
* `MDFN_ALIGN` moved to beginning of variable declaration, as needed by `__declspec(align(n))`
* `NO_INLINE` moved to before the type of the function, as needed by `__declspec(noinline)`
* `MDFN_FASTCALL` moved to between function type and function name, as needed by `__fastcall`
* Fixed libflac bug where it did not return the handle value
* Suppressed a compiler error in `GetTexel` by assigning an uninitialized variable to NULL.  An invalid `TexMode_TA` value will now segfault from a NULL pointer instead of using some random memory.
* Suppressed a compiler error in `firmware_is_present`
* Suppressed a compiler error in `IntrusivePtrEnabled` involving variable-not-found errors within the static assert
* Removed "Compiling with MSVC" disclaimer
* Add `#include <algorithm>` to files which use `std::min` and `std::max`
* Changed the order of include files for `parallel-psx/vulkan/vulkan.hpp`.  For some reason, MSVC chokes if the standard header files are included after the others, so moving them up makes it compile correctly.
* Implemented the MSVC instrinsics for counting zeroes in `parallel-psx/vulkan/util.hpp` (because it said `#error implement me`)
* Changed the shaders to not contain preprocessor commands within the text body of a stringize macro.  MSVC just doesn't support it.