### PR TITLE
Fixes to code to compile for MSVC + changes to makefile + projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,6 +514,17 @@ FLAGS += $(ENDIANNESS_DEFINES) \
          -D_FILE_OFFSET_BITS=64 \
          -D__STDC_CONSTANT_MACROS
 
+ifneq (,$(findstring windows_msvc2017,$(platform)))
+FLAGS += -D_CRT_SECURE_NO_WARNINGS \
+	 -D_CRT_NONSTDC_NO_DEPRECATE \
+	 -D__ORDER_LITTLE_ENDIAN__ \
+	 -D__BYTE_ORDER__=__ORDER_LITTLE_ENDIAN__ \
+	 -DNOMINMAX \
+	 //utf-8 \
+	 //std:c++17
+LDFLAGS += "opengl32.lib"
+endif
+
 ifeq ($(HAVE_VULKAN),1)
    FLAGS += -DHAVE_VULKAN
 endif

--- a/deps/flac-1.3.2/src/libFLAC/windows_unicode_filenames.c
+++ b/deps/flac-1.3.2/src/libFLAC/windows_unicode_filenames.c
@@ -194,6 +194,8 @@ HANDLE WINAPI flac_internal_CreateFile_utf8(const char *lpFileName, DWORD dwDesi
 		handle = CreateFile2(wname, dwDesiredAccess, dwShareMode, CREATE_ALWAYS, NULL);
 		free(wname);
 	}
+
+	return handle;
 #else
 	if (!utf8_filenames) {
 		return CreateFileA(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -94,7 +94,7 @@ static bool firmware_is_present(unsigned region)
    char bios_path[4096];
    static const size_t list_size = 10;
    const char *bios_name_list[list_size];
-   const char *bios_sha1;
+   const char *bios_sha1 = NULL;
 
    log_cb(RETRO_LOG_INFO, "Checking if required firmware is present.\n");
 

--- a/mednafen/mednafen-types.h
+++ b/mednafen/mednafen-types.h
@@ -176,7 +176,6 @@ typedef uint64_t uint64;
   //
   // Begin MSVC
   //
-  #pragma message("Compiling with MSVC, untested")
 
   #define INLINE __forceinline
   #define NO_INLINE __declspec(noinline)

--- a/mednafen/mednafen-types.h
+++ b/mednafen/mednafen-types.h
@@ -255,6 +255,10 @@ template<typename T> typename std::remove_all_extents<T>::type* MDAP(T* v) { ret
 #endif
 #endif /* NOT_LIBRETRO */
 
+#ifndef _MSC_VER
 #define MDFN_ALIGN(n)        __attribute__ ((aligned (n)))
+#else
+#define MDFN_ALIGN(n)        __declspec(align(n))
+#endif
 
 #endif

--- a/mednafen/psx/cpu.h
+++ b/mednafen/psx/cpu.h
@@ -222,7 +222,7 @@ class PS_CPU
 
  uint32 Exception(uint32 code, uint32 PC, const uint32 NP, const uint32 instr) MDFN_WARN_UNUSED_RESULT;
 
- template<bool DebugMode, bool BIOSPrintMode, bool ILHMode> pscpu_timestamp_t RunReal(pscpu_timestamp_t timestamp_in) NO_INLINE;
+ template<bool DebugMode, bool BIOSPrintMode, bool ILHMode> NO_INLINE pscpu_timestamp_t RunReal(pscpu_timestamp_t timestamp_in);
 
  template<typename T> T PeekMemory(uint32 address) MDFN_COLD;
  template<typename T> void PokeMemory(uint32 address, T value) MDFN_COLD;

--- a/mednafen/psx/gpu_common.h
+++ b/mednafen/psx/gpu_common.h
@@ -194,7 +194,7 @@ static INLINE uint16_t GetTexel(PS_GPU *g, int32_t u_arg, int32_t v_arg)
      uint32_t gro = fbtex_y * 1024U + fbtex_x;
 
      PS_GPU::TexCache_t *TexCache = &g->TexCache[0];
-     PS_GPU::TexCache_t *c;
+     PS_GPU::TexCache_t *c = NULL;  //assigned to NULL to suppress potentially uninitialized variable error
 
      switch(TexMode_TA)
      {

--- a/mednafen/psx/gpu_common.h
+++ b/mednafen/psx/gpu_common.h
@@ -194,7 +194,7 @@ static INLINE uint16_t GetTexel(PS_GPU *g, int32_t u_arg, int32_t v_arg)
      uint32_t gro = fbtex_y * 1024U + fbtex_x;
 
      PS_GPU::TexCache_t *TexCache = &g->TexCache[0];
-     PS_GPU::TexCache_t *c = NULL;  //assigned to NULL to suppress potentially uninitialized variable error
+     PS_GPU::TexCache_t *c = NULL;
 
      switch(TexMode_TA)
      {

--- a/mednafen/psx/mdec.cpp
+++ b/mednafen/psx/mdec.cpp
@@ -36,7 +36,7 @@
 
      // This condition when InFIFO.CanWrite() != 0 is a bit buggy on real hardware, decoding loop *seems* to be reading too
      // much and pulling garbage from the FIFO.
-     if(InCounter == 0xFFFF)	
+     if(InCounter == 0xFFFF)
       InFIFOReady = true;
     }
 
@@ -87,12 +87,12 @@ static bool InCommand;
 static uint8 QMatrix[2][64];
 static uint32 QMIndex;
 
-static int16 IDCTMatrix[64] MDFN_ALIGN(16);
+MDFN_ALIGN(16) static int16 IDCTMatrix[64];
 static uint32 IDCTMIndex;
 
 static uint8 QScale;
 
-static int16 Coeff[64] MDFN_ALIGN(16);
+MDFN_ALIGN(16) static int16 Coeff[64];
 static uint32 CoeffIndex;
 static uint32 DecodeWB;
 
@@ -113,14 +113,14 @@ static uint8 RAMOffsetWWS;
 
 static const uint8 ZigZag[64] =
 {
- 0x00, 0x08, 0x01, 0x02, 0x09, 0x10, 0x18, 0x11, 
- 0x0a, 0x03, 0x04, 0x0b, 0x12, 0x19, 0x20, 0x28, 
- 0x21, 0x1a, 0x13, 0x0c, 0x05, 0x06, 0x0d, 0x14, 
- 0x1b, 0x22, 0x29, 0x30, 0x38, 0x31, 0x2a, 0x23, 
- 0x1c, 0x15, 0x0e, 0x07, 0x0f, 0x16, 0x1d, 0x24, 
- 0x2b, 0x32, 0x39, 0x3a, 0x33, 0x2c, 0x25, 0x1e, 
- 0x17, 0x1f, 0x26, 0x2d, 0x34, 0x3b, 0x3c, 0x35, 
- 0x2e, 0x27, 0x2f, 0x36, 0x3d, 0x3e, 0x37, 0x3f, 
+ 0x00, 0x08, 0x01, 0x02, 0x09, 0x10, 0x18, 0x11,
+ 0x0a, 0x03, 0x04, 0x0b, 0x12, 0x19, 0x20, 0x28,
+ 0x21, 0x1a, 0x13, 0x0c, 0x05, 0x06, 0x0d, 0x14,
+ 0x1b, 0x22, 0x29, 0x30, 0x38, 0x31, 0x2a, 0x23,
+ 0x1c, 0x15, 0x0e, 0x07, 0x0f, 0x16, 0x1d, 0x24,
+ 0x2b, 0x32, 0x39, 0x3a, 0x33, 0x2c, 0x25, 0x1e,
+ 0x17, 0x1f, 0x26, 0x2d, 0x34, 0x3b, 0x3c, 0x35,
+ 0x2e, 0x27, 0x2f, 0x36, 0x3d, 0x3e, 0x37, 0x3f,
 };
 
 void MDEC_Power(void)
@@ -251,7 +251,7 @@ static void IDCT_1D_Multi(int16 *in_coeff, T *out_coeff)
       for( x = 0; x < 8; x++)
       {
 #ifdef __SSE2__
-         int32 tmp[4] MDFN_ALIGN(16);
+         MDFN_ALIGN(16) int32 tmp[4];
          __m128i m   = _mm_load_si128((__m128i *)&IDCTMatrix[(x * 8)]);
          __m128i sum = _mm_madd_epi16(m, c);
          sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, (3 << 0) | (2 << 2) | (1 << 4) | (0 << 6)));
@@ -281,7 +281,7 @@ static void IDCT_1D_Multi(int16 *in_coeff, T *out_coeff)
 
 static void IDCT(int16 *in_coeff, int8 *out_coeff)
 {
-   int16 tmpbuf[64] MDFN_ALIGN(16);
+   MDFN_ALIGN(16) int16 tmpbuf[64];
 
    IDCT_1D_Multi<int16>(in_coeff, tmpbuf);
    IDCT_1D_Multi<int8>(tmpbuf, out_coeff);
@@ -505,10 +505,10 @@ static INLINE void WriteImageData(uint16 V, int32* eat_cycles)
          case 5:
             IDCT(Coeff, &block_y[0][0]);
             break;
-      }   
+      }
 
       // Timing in the actual PS1 MDEC is complex due to (apparent) pipelining, but the average when decoding a large number of blocks is
-      // about 512.  
+      // about 512.
       *eat_cycles += 512;
 
       if(DecodeWB >= 2)

--- a/mednafen/psx/timer.cpp
+++ b/mednafen/psx/timer.cpp
@@ -144,7 +144,7 @@ static uint32_t CalcNextEvent(void)
       const uint32_t target = ((Timers[i].Mode & 0x18) && (Timers[i].Counter < Timers[i].Target)) ? Timers[i].Target : 0x10000;
       const uint32_t count_delta = target - Timers[i].Counter;
       uint32_t tmp_clocks;
-         
+
       if((i == 0x2) && (Timers[i].Mode & 0x200))
          tmp_clocks = (count_delta * 8) - Timers[i].Div8Counter;
       else
@@ -159,7 +159,7 @@ static uint32_t CalcNextEvent(void)
    return(next_event);
 }
 
-static MDFN_FASTCALL bool TimerMatch(unsigned i)
+static bool MDFN_FASTCALL TimerMatch(unsigned i)
 {
    bool irq_exact = false;
 
@@ -190,7 +190,7 @@ static MDFN_FASTCALL bool TimerMatch(unsigned i)
    return irq_exact;
 }
 
-static MDFN_FASTCALL bool TimerOverflow(unsigned i)
+static bool MDFN_FASTCALL TimerOverflow(unsigned i)
 {
    bool irq_exact = false;
 
@@ -215,7 +215,7 @@ static MDFN_FASTCALL bool TimerOverflow(unsigned i)
    return irq_exact;
 }
 
-static MDFN_FASTCALL void ClockTimer(int i, uint32_t clocks)
+static void MDFN_FASTCALL ClockTimer(int i, uint32_t clocks)
 {
    int32_t before = Timers[i].Counter;
    int32_t target = 0x10000;
@@ -270,7 +270,7 @@ static MDFN_FASTCALL void ClockTimer(int i, uint32_t clocks)
    }
 }
 
-MDFN_FASTCALL void TIMER_SetVBlank(bool status)
+void MDFN_FASTCALL TIMER_SetVBlank(bool status)
 {
    switch(Timers[1].Mode & 0x7)
    {
@@ -313,7 +313,7 @@ MDFN_FASTCALL void TIMER_SetVBlank(bool status)
    vblank = status;
 }
 
-MDFN_FASTCALL void TIMER_SetHRetrace(bool status)
+void MDFN_FASTCALL TIMER_SetHRetrace(bool status)
 {
    if(hretrace && !status)
    {
@@ -329,7 +329,7 @@ MDFN_FASTCALL void TIMER_SetHRetrace(bool status)
    hretrace = status;
 }
 
-MDFN_FASTCALL void TIMER_AddDotClocks(uint32_t count)
+void MDFN_FASTCALL TIMER_AddDotClocks(uint32_t count)
 {
    if(Timers[0].Mode & 0x100)
       ClockTimer(0, count);
@@ -341,7 +341,7 @@ void TIMER_ClockHRetrace(void)
       ClockTimer(1, 1);
 }
 
-MDFN_FASTCALL int32_t TIMER_Update(const int32_t timestamp)
+int32_t MDFN_FASTCALL TIMER_Update(const int32_t timestamp)
 {
    int32_t cpu_clocks = timestamp - lastts;
 
@@ -361,7 +361,7 @@ MDFN_FASTCALL int32_t TIMER_Update(const int32_t timestamp)
    return(timestamp + CalcNextEvent());
 }
 
-static MDFN_FASTCALL void CalcCountingStart(unsigned which)
+static void MDFN_FASTCALL CalcCountingStart(unsigned which)
 {
    Timers[which].DoZeCounting = true;
 
@@ -395,8 +395,8 @@ void TIMER_Write(const int32_t timestamp, uint32_t A, uint16_t V)
 
    V <<= (A & 3) * 8;
 
-   /* 
-   PSX_DBGINFO("[TIMER] Write: %08x %04x\n", A, V); 
+   /*
+   PSX_DBGINFO("[TIMER] Write: %08x %04x\n", A, V);
    */
 
    if(which >= 3)
@@ -428,7 +428,7 @@ void TIMER_Write(const int32_t timestamp, uint32_t A, uint16_t V)
    PSX_SetEventNT(PSX_EVENT_TIMER, timestamp + CalcNextEvent());
 }
 
-MDFN_FASTCALL uint16_t TIMER_Read(const int32_t timestamp, uint32_t A)
+uint16_t MDFN_FASTCALL TIMER_Read(const int32_t timestamp, uint32_t A)
 {
    uint16_t ret = 0;
    int which = (A >> 4) & 0x3;

--- a/mednafen/psx/timer.cpp
+++ b/mednafen/psx/timer.cpp
@@ -387,7 +387,7 @@ static void MDFN_FASTCALL CalcCountingStart(unsigned which)
 
 }
 
-void TIMER_Write(const int32_t timestamp, uint32_t A, uint16_t V)
+void MDFN_FASTCALL TIMER_Write(const int32_t timestamp, uint32_t A, uint16_t V)
 {
    TIMER_Update(timestamp);
 

--- a/mednafen/psx/timer.h
+++ b/mednafen/psx/timer.h
@@ -22,15 +22,15 @@ uint32_t TIMER_GetRegister(unsigned int which, char *special, const uint32_t spe
 void TIMER_SetRegister(unsigned int which, uint32_t value);
 
 
-MDFN_FASTCALL void TIMER_Write(const int32_t timestamp, uint32_t A, uint16_t V);
-MDFN_FASTCALL uint16_t TIMER_Read(const int32_t timestamp, uint32_t A);
+void MDFN_FASTCALL TIMER_Write(const int32_t timestamp, uint32_t A, uint16_t V);
+uint16_t MDFN_FASTCALL TIMER_Read(const int32_t timestamp, uint32_t A);
 
-MDFN_FASTCALL void TIMER_AddDotClocks(uint32_t count);
+void MDFN_FASTCALL TIMER_AddDotClocks(uint32_t count);
 void TIMER_ClockHRetrace(void);
-MDFN_FASTCALL void TIMER_SetHRetrace(bool status);
-MDFN_FASTCALL void TIMER_SetVBlank(bool status);
+void MDFN_FASTCALL TIMER_SetHRetrace(bool status);
+void MDFN_FASTCALL TIMER_SetVBlank(bool status);
 
-MDFN_FASTCALL int32_t TIMER_Update(const int32_t);
+int32_t MDFN_FASTCALL TIMER_Update(const int32_t);
 void TIMER_ResetTS(void);
 
 void TIMER_Power(void) MDFN_COLD;

--- a/msvc/mednafen_psx_hw_libretro.sln
+++ b/msvc/mednafen_psx_hw_libretro.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27428.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mednafen_psx_hw_libretro", "mednafen_psx_hw_libretro.vcxproj", "{9CA79DB2-1585-44DB-98E8-A0E8139B905A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9CA79DB2-1585-44DB-98E8-A0E8139B905A}.Debug|x64.ActiveCfg = Debug|x64
+		{9CA79DB2-1585-44DB-98E8-A0E8139B905A}.Debug|x64.Build.0 = Debug|x64
+		{9CA79DB2-1585-44DB-98E8-A0E8139B905A}.Debug|x86.ActiveCfg = Debug|Win32
+		{9CA79DB2-1585-44DB-98E8-A0E8139B905A}.Debug|x86.Build.0 = Debug|Win32
+		{9CA79DB2-1585-44DB-98E8-A0E8139B905A}.Release|x64.ActiveCfg = Release|x64
+		{9CA79DB2-1585-44DB-98E8-A0E8139B905A}.Release|x64.Build.0 = Release|x64
+		{9CA79DB2-1585-44DB-98E8-A0E8139B905A}.Release|x86.ActiveCfg = Release|Win32
+		{9CA79DB2-1585-44DB-98E8-A0E8139B905A}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A8EAEDB8-2574-46D3-AC88-9B124F9F0EFE}
+	EndGlobalSection
+EndGlobal

--- a/msvc/mednafen_psx_hw_libretro.vcxproj
+++ b/msvc/mednafen_psx_hw_libretro.vcxproj
@@ -1,0 +1,372 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\deps\crypto\md5.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)crypto\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)crypto\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)crypto\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)crypto\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\deps\crypto\sha1.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)crypto\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)crypto\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)crypto\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)crypto\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\bitmath.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\bitreader.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\cpu.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)flac\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\crc.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\fixed.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\fixed_intrin_sse2.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\fixed_intrin_ssse3.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\float.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\format.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc_intrin_avx2.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc_intrin_sse.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc_intrin_sse2.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc_intrin_sse41.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\md5.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)flac\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\memory.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\metadata_iterators.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\metadata_object.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\stream_decoder.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\window.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)flac\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\windows_unicode_filenames.c" />
+    <ClCompile Include="..\deps\libchdr\bitstream.c" />
+    <ClCompile Include="..\deps\libchdr\cdrom.c" />
+    <ClCompile Include="..\deps\libchdr\chd.c" />
+    <ClCompile Include="..\deps\libchdr\flac.c" />
+    <ClCompile Include="..\deps\libchdr\huffman.c" />
+    <ClCompile Include="..\deps\libkirk\aes.c" />
+    <ClCompile Include="..\deps\libkirk\amctrl.c" />
+    <ClCompile Include="..\deps\libkirk\bn.c" />
+    <ClCompile Include="..\deps\libkirk\des.c" />
+    <ClCompile Include="..\deps\libkirk\ec.c" />
+    <ClCompile Include="..\deps\libkirk\kirk_engine.c" />
+    <ClCompile Include="..\deps\libkirk\sha1.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)libkirk\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)libkirk\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)libkirk\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)libkirk\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\Alloc.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\Bra.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\Bra86.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\BraIA64.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\CpuArch.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\Delta.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\LzFind.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\Lzma86Dec.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\Lzma86Enc.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\LzmaDec.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\LzmaEnc.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\LzmaLib.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\Sort.c" />
+    <ClCompile Include="..\deps\zlib\adler32.c" />
+    <ClCompile Include="..\deps\zlib\compress.c" />
+    <ClCompile Include="..\deps\zlib\crc32.c" />
+    <ClCompile Include="..\deps\zlib\deflate.c" />
+    <ClCompile Include="..\deps\zlib\gzclose.c" />
+    <ClCompile Include="..\deps\zlib\gzlib.c" />
+    <ClCompile Include="..\deps\zlib\gzread.c" />
+    <ClCompile Include="..\deps\zlib\gzwrite.c" />
+    <ClCompile Include="..\deps\zlib\inffast.c" />
+    <ClCompile Include="..\deps\zlib\inflate.c" />
+    <ClCompile Include="..\deps\zlib\inftrees.c" />
+    <ClCompile Include="..\deps\zlib\trees.c" />
+    <ClCompile Include="..\deps\zlib\uncompr.c" />
+    <ClCompile Include="..\deps\zlib\zutil.c" />
+    <ClCompile Include="..\input.cpp" />
+    <ClCompile Include="..\libretro-common\compat\compat_posix_string.c" />
+    <ClCompile Include="..\libretro-common\compat\compat_strcasestr.c" />
+    <ClCompile Include="..\libretro-common\compat\compat_strl.c" />
+    <ClCompile Include="..\libretro-common\compat\fopen_utf8.c" />
+    <ClCompile Include="..\libretro-common\encodings\encoding_utf.c" />
+    <ClCompile Include="..\libretro-common\glsm\glsm.c" />
+    <ClCompile Include="..\libretro-common\glsym\glsym_gl.c" />
+    <ClCompile Include="..\libretro-common\glsym\rglgen.c" />
+    <ClCompile Include="..\libretro-common\hash\rhash.c" />
+    <ClCompile Include="..\libretro-common\rthreads\rthreads.c" />
+    <ClCompile Include="..\libretro-common\streams\file_stream.c" />
+    <ClCompile Include="..\libretro-common\streams\file_stream_transforms.c" />
+    <ClCompile Include="..\libretro-common\string\stdstring.c" />
+    <ClCompile Include="..\libretro-common\vfs\vfs_implementation.c" />
+    <ClCompile Include="..\libretro.cpp" />
+    <ClCompile Include="..\libretro_cbs.c" />
+    <ClCompile Include="..\mednafen\cdrom\audioreader.cpp" />
+    <ClCompile Include="..\mednafen\cdrom\CDAccess.cpp" />
+    <ClCompile Include="..\mednafen\cdrom\CDAccess_CCD.cpp" />
+    <ClCompile Include="..\mednafen\cdrom\CDAccess_CHD.cpp" />
+    <ClCompile Include="..\mednafen\cdrom\CDAccess_Image.cpp" />
+    <ClCompile Include="..\mednafen\cdrom\CDAccess_PBP.cpp" />
+    <ClCompile Include="..\mednafen\cdrom\cdromif.cpp" />
+    <ClCompile Include="..\mednafen\cdrom\CDUtility.c" />
+    <ClCompile Include="..\mednafen\cdrom\edc_crc32.c" />
+    <ClCompile Include="..\mednafen\cdrom\galois.c" />
+    <ClCompile Include="..\mednafen\cdrom\l-ec.c" />
+    <ClCompile Include="..\mednafen\cdrom\lec.c" />
+    <ClCompile Include="..\mednafen\cdrom\misc.cpp" />
+    <ClCompile Include="..\mednafen\cdrom\recover-raw.c" />
+    <ClCompile Include="..\mednafen\error.cpp" />
+    <ClCompile Include="..\mednafen\FileStream.cpp" />
+    <ClCompile Include="..\mednafen\general.cpp" />
+    <ClCompile Include="..\mednafen\md5.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)mednafen\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)mednafen\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)mednafen\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)mednafen\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\mednafen-endian.cpp" />
+    <ClCompile Include="..\mednafen\MemoryStream.cpp" />
+    <ClCompile Include="..\mednafen\mempatcher.cpp" />
+    <ClCompile Include="..\mednafen\psx\cdc.cpp" />
+    <ClCompile Include="..\mednafen\psx\cpu.cpp" />
+    <ClCompile Include="..\mednafen\psx\dma.cpp" />
+    <ClCompile Include="..\mednafen\psx\frontio.cpp" />
+    <ClCompile Include="..\mednafen\psx\gpu.cpp" />
+    <ClCompile Include="..\mednafen\psx\gte.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\dualanalog.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\dualshock.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\gamepad.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\guncon.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\justifier.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\memcard.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\mouse.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\multitap.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\negcon.cpp" />
+    <ClCompile Include="..\mednafen\psx\irq.cpp" />
+    <ClCompile Include="..\mednafen\psx\mdec.cpp" />
+    <ClCompile Include="..\mednafen\psx\sio.cpp" />
+    <ClCompile Include="..\mednafen\psx\spu.cpp" />
+    <ClCompile Include="..\mednafen\psx\timer.cpp" />
+    <ClCompile Include="..\mednafen\settings.cpp" />
+    <ClCompile Include="..\mednafen\state.cpp" />
+    <ClCompile Include="..\mednafen\Stream.cpp" />
+    <ClCompile Include="..\mednafen\tremor\bitwise.c" />
+    <ClCompile Include="..\mednafen\tremor\block.c" />
+    <ClCompile Include="..\mednafen\tremor\codebook.c" />
+    <ClCompile Include="..\mednafen\tremor\floor0.c" />
+    <ClCompile Include="..\mednafen\tremor\floor1.c" />
+    <ClCompile Include="..\mednafen\tremor\framing.c" />
+    <ClCompile Include="..\mednafen\tremor\info.c" />
+    <ClCompile Include="..\mednafen\tremor\mapping0.c" />
+    <ClCompile Include="..\mednafen\tremor\mdct.c" />
+    <ClCompile Include="..\mednafen\tremor\registry.c" />
+    <ClCompile Include="..\mednafen\tremor\res012.c" />
+    <ClCompile Include="..\mednafen\tremor\sharedbook.c" />
+    <ClCompile Include="..\mednafen\tremor\synthesis.c" />
+    <ClCompile Include="..\mednafen\tremor\vorbisfile.c" />
+    <ClCompile Include="..\mednafen\tremor\window.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)tremor\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)tremor\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)tremor\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)tremor\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\video\Deinterlacer.cpp" />
+    <ClCompile Include="..\mednafen\video\surface.cpp" />
+    <ClCompile Include="..\parallel-psx\atlas\atlas.cpp" />
+    <ClCompile Include="..\parallel-psx\renderer\renderer.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\buffer.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\chain_allocator.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\command_buffer.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\command_pool.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\cookie.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\descriptor_set.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\device.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\fence_manager.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\image.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\memory_allocator.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\render_pass.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\sampler.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\semaphore.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\semaphore_manager.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\shader.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\SPIRV-Cross\spirv_cross.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\vulkan.cpp" />
+    <ClCompile Include="..\parallel-psx\vulkan\vulkan_symbol_wrapper.cpp" />
+    <ClCompile Include="..\pgxp\pgxp_cpu.c" />
+    <ClCompile Include="..\pgxp\pgxp_debug.c" />
+    <ClCompile Include="..\pgxp\pgxp_gpu.c" />
+    <ClCompile Include="..\pgxp\pgxp_gte.c" />
+    <ClCompile Include="..\pgxp\pgxp_main.c" />
+    <ClCompile Include="..\pgxp\pgxp_mem.c" />
+    <ClCompile Include="..\pgxp\pgxp_value.c" />
+    <ClCompile Include="..\rsx\rsx_intf.cpp" />
+    <ClCompile Include="..\rsx\rsx_lib_gl.cpp" />
+    <ClCompile Include="..\rsx\rsx_lib_soft.c" />
+    <ClCompile Include="..\rsx\rsx_lib_vulkan.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{9CA79DB2-1585-44DB-98E8-A0E8139B905A}</ProjectGuid>
+    <RootNamespace>mednafenpsxlibretro</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)$(SolutionName)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionName)\build\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)$(SolutionName)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionName)\build\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)$(SolutionName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionName)\build\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)$(SolutionName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionName)\build\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)../;$(ProjectDir)../mednafen;$(ProjectDir)../mednafen/include;$(ProjectDir)../mednafen/intl;$(ProjectDir)../mednafen/hw_sound;$(ProjectDir)../mednafen/hw_cpu;$(ProjectDir)../mednafen/hw_misc;$(ProjectDir)../libretro-common/include;$(ProjectDir)../deps/zlib;$(ProjectDir)../deps/crypto;$(ProjectDir)../deps/flac-1.3.2/include;$(ProjectDir)../deps/flac-1.3.2/src/libFLAC/include;$(ProjectDir)../deps/lzma-16.04/C;$(ProjectDir)../deps/libchdr;$(ProjectDir);$(ProjectDir)../parallel-psx/vulkan/SPIRV-Cross;$(ProjectDir)../parallel-psx/renderer;$(ProjectDir)../parallel-psx/khronos/include;$(ProjectDir)../parallel-psx/atlas;$(ProjectDir)../parallel-psx/glsl/prebuilt;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_OPENGL;CORE;HAVE_HW;HAVE_PBP;HAVE_THREADS;NEED_DEINTERLACER;WANT_32BPP;NEED_CD;HAVE_CHD;_7ZIP_ST;PACKAGE_VERSION="1.3.2";FLAC_API_EXPORTS;FLAC__HAS_OGG=0;HAVE_LROUND;HAVE_STDINT_H;HAVE_SYS_PARAM_H;HAVE_FSEEKO;PACKAGE="mednafen";MEDNAFEN_VERSION_NUMERIC=9386;__LIBRETRO__;_LOW_ACCURACY_;_FILE_OFFSET_BITS=64;__STDC_CONSTANT_MACROS;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;__ORDER_LITTLE_ENDIAN__;__BYTE_ORDER__=__ORDER_LITTLE_ENDIAN__;HAVE_VULKAN;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)../;$(ProjectDir)../mednafen;$(ProjectDir)../mednafen/include;$(ProjectDir)../mednafen/intl;$(ProjectDir)../mednafen/hw_sound;$(ProjectDir)../mednafen/hw_cpu;$(ProjectDir)../mednafen/hw_misc;$(ProjectDir)../libretro-common/include;$(ProjectDir)../deps/zlib;$(ProjectDir)../deps/crypto;$(ProjectDir)../deps/flac-1.3.2/include;$(ProjectDir)../deps/flac-1.3.2/src/libFLAC/include;$(ProjectDir)../deps/lzma-16.04/C;$(ProjectDir)../deps/libchdr;$(ProjectDir);$(ProjectDir)../parallel-psx/vulkan/SPIRV-Cross;$(ProjectDir)../parallel-psx/renderer;$(ProjectDir)../parallel-psx/khronos/include;$(ProjectDir)../parallel-psx/atlas;$(ProjectDir)../parallel-psx/glsl/prebuilt;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_OPENGL;CORE;HAVE_HW;HAVE_PBP;HAVE_THREADS;NEED_DEINTERLACER;WANT_32BPP;NEED_CD;HAVE_CHD;_7ZIP_ST;PACKAGE_VERSION="1.3.2";FLAC_API_EXPORTS;FLAC__HAS_OGG=0;HAVE_LROUND;HAVE_STDINT_H;HAVE_SYS_PARAM_H;HAVE_FSEEKO;PACKAGE="mednafen";MEDNAFEN_VERSION_NUMERIC=9386;__LIBRETRO__;_LOW_ACCURACY_;_FILE_OFFSET_BITS=64;__STDC_CONSTANT_MACROS;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;__ORDER_LITTLE_ENDIAN__;__BYTE_ORDER__=__ORDER_LITTLE_ENDIAN__;HAVE_VULKAN;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)../;$(ProjectDir)../mednafen;$(ProjectDir)../mednafen/include;$(ProjectDir)../mednafen/intl;$(ProjectDir)../mednafen/hw_sound;$(ProjectDir)../mednafen/hw_cpu;$(ProjectDir)../mednafen/hw_misc;$(ProjectDir)../libretro-common/include;$(ProjectDir)../deps/zlib;$(ProjectDir)../deps/crypto;$(ProjectDir)../deps/flac-1.3.2/include;$(ProjectDir)../deps/flac-1.3.2/src/libFLAC/include;$(ProjectDir)../deps/lzma-16.04/C;$(ProjectDir)../deps/libchdr;$(ProjectDir);$(ProjectDir)../parallel-psx/vulkan/SPIRV-Cross;$(ProjectDir)../parallel-psx/renderer;$(ProjectDir)../parallel-psx/khronos/include;$(ProjectDir)../parallel-psx/atlas;$(ProjectDir)../parallel-psx/glsl/prebuilt;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_OPENGL;CORE;HAVE_HW;HAVE_PBP;HAVE_THREADS;NEED_DEINTERLACER;WANT_32BPP;NEED_CD;HAVE_CHD;_7ZIP_ST;PACKAGE_VERSION="1.3.2";FLAC_API_EXPORTS;FLAC__HAS_OGG=0;HAVE_LROUND;HAVE_STDINT_H;HAVE_SYS_PARAM_H;HAVE_FSEEKO;PACKAGE="mednafen";MEDNAFEN_VERSION_NUMERIC=9386;__LIBRETRO__;_LOW_ACCURACY_;_FILE_OFFSET_BITS=64;__STDC_CONSTANT_MACROS;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;__ORDER_LITTLE_ENDIAN__;__BYTE_ORDER__=__ORDER_LITTLE_ENDIAN__;HAVE_VULKAN;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)../;$(ProjectDir)../mednafen;$(ProjectDir)../mednafen/include;$(ProjectDir)../mednafen/intl;$(ProjectDir)../mednafen/hw_sound;$(ProjectDir)../mednafen/hw_cpu;$(ProjectDir)../mednafen/hw_misc;$(ProjectDir)../libretro-common/include;$(ProjectDir)../deps/zlib;$(ProjectDir)../deps/crypto;$(ProjectDir)../deps/flac-1.3.2/include;$(ProjectDir)../deps/flac-1.3.2/src/libFLAC/include;$(ProjectDir)../deps/lzma-16.04/C;$(ProjectDir)../deps/libchdr;$(ProjectDir);$(ProjectDir)../parallel-psx/vulkan/SPIRV-Cross;$(ProjectDir)../parallel-psx/renderer;$(ProjectDir)../parallel-psx/khronos/include;$(ProjectDir)../parallel-psx/atlas;$(ProjectDir)../parallel-psx/glsl/prebuilt;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_OPENGL;CORE;HAVE_HW;HAVE_PBP;HAVE_THREADS;NEED_DEINTERLACER;WANT_32BPP;NEED_CD;HAVE_CHD;_7ZIP_ST;PACKAGE_VERSION="1.3.2";FLAC_API_EXPORTS;FLAC__HAS_OGG=0;HAVE_LROUND;HAVE_STDINT_H;HAVE_SYS_PARAM_H;HAVE_FSEEKO;PACKAGE="mednafen";MEDNAFEN_VERSION_NUMERIC=9386;__LIBRETRO__;_LOW_ACCURACY_;_FILE_OFFSET_BITS=64;__STDC_CONSTANT_MACROS;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;__ORDER_LITTLE_ENDIAN__;__BYTE_ORDER__=__ORDER_LITTLE_ENDIAN__;HAVE_VULKAN;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/mednafen_psx_hw_libretro.vcxproj.filters
+++ b/msvc/mednafen_psx_hw_libretro.vcxproj.filters
@@ -1,0 +1,622 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="libretro-common">
+      <UniqueIdentifier>{403444dc-ce2c-401e-b023-f0bf843e483e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\file">
+      <UniqueIdentifier>{13cb015d-eec5-445a-a7ff-c276953dc698}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\rthreads">
+      <UniqueIdentifier>{2bec7374-d33e-4807-a98c-ef47f98dac74}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\streams">
+      <UniqueIdentifier>{856825ad-d503-4c13-9cc9-d907ee37a4b7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="mednafen">
+      <UniqueIdentifier>{88d44dbf-9f5e-4a8f-95d8-e37789fe183f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="mednafen\psx">
+      <UniqueIdentifier>{91e055eb-9178-46b8-967b-4600d1368577}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="mednafen\psx\input">
+      <UniqueIdentifier>{8ded46e8-a8e5-4310-a9dd-3ac13a40c5f9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="mednafen\video">
+      <UniqueIdentifier>{1e2dc216-8cd7-4d0b-809c-d86ef961b732}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="mednafen\cdrom">
+      <UniqueIdentifier>{dba242e6-9e7c-4dbd-b765-b7bde9be02c9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="mednafen\tremor">
+      <UniqueIdentifier>{94006258-544b-43db-9ada-8e4d16ba43d3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rsx">
+      <UniqueIdentifier>{5706070e-2064-4681-ac4b-8132fcbdc25f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rustation-libretro">
+      <UniqueIdentifier>{04c78d13-b2e5-4857-8f04-175ed5ba34fc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rustation-libretro\src">
+      <UniqueIdentifier>{9614183f-6ab8-4598-95af-9db7e2c11e52}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rustation-libretro\src\retrogl">
+      <UniqueIdentifier>{4ea17930-f57f-4e40-bb5b-2ec1b2224247}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rustation-libretro\src\renderer">
+      <UniqueIdentifier>{84492a7d-6517-4300-990c-1c6b3b5c6316}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rustation-libretro\src\renderer\shaders">
+      <UniqueIdentifier>{ae4c2f1c-fa30-4aa8-a219-32141f74b36c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\glsm">
+      <UniqueIdentifier>{98be3e51-e68d-4fd3-a638-848668999fb6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\glsym">
+      <UniqueIdentifier>{27deff3a-b402-46a1-ae77-ede6e59c6552}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="deps">
+      <UniqueIdentifier>{eebe808e-91a2-45d0-bed2-980d59d3372b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="deps\zlib">
+      <UniqueIdentifier>{62b46b56-0d74-49ff-800a-07247d7f3227}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="deps\libkirk">
+      <UniqueIdentifier>{334e85ce-3ac8-4d20-bba8-da1a8dcaf58d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\string">
+      <UniqueIdentifier>{d52b2ce6-db41-40b7-8ee9-110a48e5793a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="pgxp">
+      <UniqueIdentifier>{939be7e9-0bc9-40c1-986c-b59770f862cc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="flac">
+      <UniqueIdentifier>{7278a27a-27eb-4eac-a72a-ce980cad47e2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="deps\lzma">
+      <UniqueIdentifier>{71f90571-86cb-4be6-9515-d348773a924c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\hash">
+      <UniqueIdentifier>{a5cc2532-f602-4180-805d-c9ee63636ffc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\encodings">
+      <UniqueIdentifier>{18421ee3-eea8-4fd8-8334-50a662013ccd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\compat">
+      <UniqueIdentifier>{9bb44ae3-51e1-489a-8043-62823bab3dc4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="deps\crypto">
+      <UniqueIdentifier>{fedca8ab-b89c-443b-afe8-879e86b7fd26}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="deps\libchdr">
+      <UniqueIdentifier>{12aef0cf-2af1-44f6-8b66-748afdb139a4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\vfs">
+      <UniqueIdentifier>{b2c8ed6d-a8b0-4db4-98bc-bb9dc77672f2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="parallel-psx">
+      <UniqueIdentifier>{ddfa7c72-b054-4952-92e3-ec6ada0ebfa7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="parallel-psx\atlas">
+      <UniqueIdentifier>{865987f1-1e9e-4925-bb32-fdc964572eb5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="parallel-psx\vulkan">
+      <UniqueIdentifier>{909627a8-f2dd-494d-807f-0dedd08d8fbd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="parallel-psx\renderer">
+      <UniqueIdentifier>{856e1122-cfd8-47d5-a8f0-a22962339f13}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="parallel-psx\vulkan\SPIRV-Cross">
+      <UniqueIdentifier>{1206038d-6a45-4f62-97d2-90ed16bcd5f2}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\libretro-common\rthreads\rthreads.c">
+      <Filter>libretro-common\rthreads</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\streams\file_stream.c">
+      <Filter>libretro-common\streams</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\error.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\FileStream.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\general.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\md5.c">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\MemoryStream.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\mempatcher.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\settings.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\state.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\Stream.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\cdc.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\cpu.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\dma.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\frontio.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\gpu.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\gte.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\irq.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\mdec.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\sio.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\spu.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\timer.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\dualanalog.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\dualshock.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\gamepad.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\guncon.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\justifier.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\memcard.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\mouse.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\multitap.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\negcon.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\video\Deinterlacer.cpp">
+      <Filter>mednafen\video</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\video\surface.cpp">
+      <Filter>mednafen\video</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\audioreader.cpp">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\CDAccess.cpp">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\CDAccess_CCD.cpp">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\CDAccess_Image.cpp">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\cdromif.cpp">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\CDUtility.c">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\edc_crc32.c">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\galois.c">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\l-ec.c">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\lec.c">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\misc.cpp">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\recover-raw.c">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\bitwise.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\block.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\codebook.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\floor0.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\floor1.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\framing.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\info.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\mapping0.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\mdct.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\registry.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\res012.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\sharedbook.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\synthesis.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\vorbisfile.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\window.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro.cpp" />
+    <ClCompile Include="..\rsx\rsx_intf.cpp">
+      <Filter>rsx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rsx\rsx_lib_gl.cpp">
+      <Filter>rsx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rsx\rsx_lib_soft.c">
+      <Filter>rsx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\glsm\glsm.c">
+      <Filter>libretro-common\glsm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\glsym\glsym_gl.c">
+      <Filter>libretro-common\glsym</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\glsym\rglgen.c">
+      <Filter>libretro-common\glsym</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\CDAccess_PBP.cpp">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\gzread.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\gzwrite.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\inffast.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\inflate.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\inftrees.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\trees.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\uncompr.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\zutil.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\adler32.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\compress.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\crc32.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\deflate.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\gzclose.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\gzlib.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libkirk\bn.c">
+      <Filter>deps\libkirk</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libkirk\des.c">
+      <Filter>deps\libkirk</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libkirk\ec.c">
+      <Filter>deps\libkirk</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libkirk\kirk_engine.c">
+      <Filter>deps\libkirk</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libkirk\sha1.c">
+      <Filter>deps\libkirk</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libkirk\aes.c">
+      <Filter>deps\libkirk</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libkirk\amctrl.c">
+      <Filter>deps\libkirk</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\string\stdstring.c">
+      <Filter>libretro-common\string</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pgxp\pgxp_cpu.c">
+      <Filter>pgxp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pgxp\pgxp_debug.c">
+      <Filter>pgxp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pgxp\pgxp_gte.c">
+      <Filter>pgxp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pgxp\pgxp_mem.c">
+      <Filter>pgxp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pgxp\pgxp_value.c">
+      <Filter>pgxp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pgxp\pgxp_gpu.c">
+      <Filter>pgxp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pgxp\pgxp_main.c">
+      <Filter>pgxp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro_cbs.c" />
+    <ClCompile Include="..\input.cpp" />
+    <ClCompile Include="..\deps\lzma-16.04\C\Alloc.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\Bra.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\Bra86.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\BraIA64.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\CpuArch.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\Delta.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\LzFind.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\Lzma86Dec.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\Lzma86Enc.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\LzmaDec.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\LzmaEnc.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\LzmaLib.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\Sort.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\bitmath.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\bitreader.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\cpu.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\crc.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\fixed.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\fixed_intrin_sse2.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\fixed_intrin_ssse3.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\float.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc_intrin_avx2.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc_intrin_sse.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc_intrin_sse2.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc_intrin_sse41.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\md5.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\memory.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\window.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\windows_unicode_filenames.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\stream_decoder.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\metadata_object.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\metadata_iterators.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\hash\rhash.c">
+      <Filter>libretro-common\hash</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\encodings\encoding_utf.c">
+      <Filter>libretro-common\encodings</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\compat\compat_posix_string.c">
+      <Filter>libretro-common\compat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\compat\compat_strcasestr.c">
+      <Filter>libretro-common\compat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\compat\compat_strl.c">
+      <Filter>libretro-common\compat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\crypto\sha1.c">
+      <Filter>deps\crypto</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\crypto\md5.c">
+      <Filter>deps\crypto</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libchdr\bitstream.c">
+      <Filter>deps\libchdr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libchdr\cdrom.c">
+      <Filter>deps\libchdr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libchdr\chd.c">
+      <Filter>deps\libchdr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libchdr\flac.c">
+      <Filter>deps\libchdr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libchdr\huffman.c">
+      <Filter>deps\libchdr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\vfs\vfs_implementation.c">
+      <Filter>libretro-common\vfs</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\compat\fopen_utf8.c">
+      <Filter>libretro-common\compat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\streams\file_stream_transforms.c">
+      <Filter>libretro-common\streams</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\CDAccess_CHD.cpp">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\format.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\mednafen-endian.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\atlas\atlas.cpp">
+      <Filter>parallel-psx\atlas</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\buffer.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\chain_allocator.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\command_buffer.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\command_pool.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\cookie.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\descriptor_set.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\device.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\fence_manager.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\image.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\memory_allocator.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\render_pass.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\renderer\renderer.cpp">
+      <Filter>parallel-psx\renderer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rsx\rsx_lib_vulkan.cpp">
+      <Filter>rsx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\sampler.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\SPIRV-Cross\spirv_cross.cpp">
+      <Filter>parallel-psx\vulkan\SPIRV-Cross</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\semaphore.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\semaphore_manager.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\shader.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\vulkan.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="..\parallel-psx\vulkan\vulkan_symbol_wrapper.cpp">
+      <Filter>parallel-psx\vulkan</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/msvc/mednafen_psx_libretro.sln
+++ b/msvc/mednafen_psx_libretro.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27428.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mednafen_psx_libretro", "mednafen_psx_libretro.vcxproj", "{9CA79DB2-1585-44DB-98E8-A0E8139B905A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9CA79DB2-1585-44DB-98E8-A0E8139B905A}.Debug|x64.ActiveCfg = Debug|x64
+		{9CA79DB2-1585-44DB-98E8-A0E8139B905A}.Debug|x64.Build.0 = Debug|x64
+		{9CA79DB2-1585-44DB-98E8-A0E8139B905A}.Debug|x86.ActiveCfg = Debug|Win32
+		{9CA79DB2-1585-44DB-98E8-A0E8139B905A}.Debug|x86.Build.0 = Debug|Win32
+		{9CA79DB2-1585-44DB-98E8-A0E8139B905A}.Release|x64.ActiveCfg = Release|x64
+		{9CA79DB2-1585-44DB-98E8-A0E8139B905A}.Release|x64.Build.0 = Release|x64
+		{9CA79DB2-1585-44DB-98E8-A0E8139B905A}.Release|x86.ActiveCfg = Release|Win32
+		{9CA79DB2-1585-44DB-98E8-A0E8139B905A}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A8EAEDB8-2574-46D3-AC88-9B124F9F0EFE}
+	EndGlobalSection
+EndGlobal

--- a/msvc/mednafen_psx_libretro.vcxproj
+++ b/msvc/mednafen_psx_libretro.vcxproj
@@ -1,0 +1,335 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\deps\crypto\md5.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)crypto\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)crypto\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)crypto\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)crypto\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\deps\crypto\sha1.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)crypto\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)crypto\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)crypto\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)crypto\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\bitmath.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\bitreader.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\cpu.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)flac\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\crc.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\fixed.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\fixed_intrin_sse2.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\fixed_intrin_ssse3.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\float.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\format.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc_intrin_avx2.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc_intrin_sse.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc_intrin_sse2.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc_intrin_sse41.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\md5.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)flac\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\memory.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\metadata_iterators.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\metadata_object.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\stream_decoder.c" />
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\window.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)flac\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)flac\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\windows_unicode_filenames.c" />
+    <ClCompile Include="..\deps\libchdr\bitstream.c" />
+    <ClCompile Include="..\deps\libchdr\cdrom.c" />
+    <ClCompile Include="..\deps\libchdr\chd.c" />
+    <ClCompile Include="..\deps\libchdr\flac.c" />
+    <ClCompile Include="..\deps\libchdr\huffman.c" />
+    <ClCompile Include="..\deps\libkirk\aes.c" />
+    <ClCompile Include="..\deps\libkirk\amctrl.c" />
+    <ClCompile Include="..\deps\libkirk\bn.c" />
+    <ClCompile Include="..\deps\libkirk\des.c" />
+    <ClCompile Include="..\deps\libkirk\ec.c" />
+    <ClCompile Include="..\deps\libkirk\kirk_engine.c" />
+    <ClCompile Include="..\deps\libkirk\sha1.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)libkirk\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)libkirk\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)libkirk\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)libkirk\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\Alloc.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\Bra.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\Bra86.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\BraIA64.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\CpuArch.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\Delta.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\LzFind.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\Lzma86Dec.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\Lzma86Enc.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\LzmaDec.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\LzmaEnc.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\LzmaLib.c" />
+    <ClCompile Include="..\deps\lzma-16.04\C\Sort.c" />
+    <ClCompile Include="..\deps\zlib\adler32.c" />
+    <ClCompile Include="..\deps\zlib\compress.c" />
+    <ClCompile Include="..\deps\zlib\crc32.c" />
+    <ClCompile Include="..\deps\zlib\deflate.c" />
+    <ClCompile Include="..\deps\zlib\gzclose.c" />
+    <ClCompile Include="..\deps\zlib\gzlib.c" />
+    <ClCompile Include="..\deps\zlib\gzread.c" />
+    <ClCompile Include="..\deps\zlib\gzwrite.c" />
+    <ClCompile Include="..\deps\zlib\inffast.c" />
+    <ClCompile Include="..\deps\zlib\inflate.c" />
+    <ClCompile Include="..\deps\zlib\inftrees.c" />
+    <ClCompile Include="..\deps\zlib\trees.c" />
+    <ClCompile Include="..\deps\zlib\uncompr.c" />
+    <ClCompile Include="..\deps\zlib\zutil.c" />
+    <ClCompile Include="..\input.cpp" />
+    <ClCompile Include="..\libretro-common\compat\compat_posix_string.c" />
+    <ClCompile Include="..\libretro-common\compat\compat_strcasestr.c" />
+    <ClCompile Include="..\libretro-common\compat\compat_strl.c" />
+    <ClCompile Include="..\libretro-common\compat\fopen_utf8.c" />
+    <ClCompile Include="..\libretro-common\encodings\encoding_utf.c" />
+    <ClCompile Include="..\libretro-common\hash\rhash.c" />
+    <ClCompile Include="..\libretro-common\rthreads\rthreads.c" />
+    <ClCompile Include="..\libretro-common\streams\file_stream.c" />
+    <ClCompile Include="..\libretro-common\streams\file_stream_transforms.c" />
+    <ClCompile Include="..\libretro-common\string\stdstring.c" />
+    <ClCompile Include="..\libretro-common\vfs\vfs_implementation.c" />
+    <ClCompile Include="..\libretro.cpp" />
+    <ClCompile Include="..\libretro_cbs.c" />
+    <ClCompile Include="..\mednafen\cdrom\audioreader.cpp" />
+    <ClCompile Include="..\mednafen\cdrom\CDAccess.cpp" />
+    <ClCompile Include="..\mednafen\cdrom\CDAccess_CCD.cpp" />
+    <ClCompile Include="..\mednafen\cdrom\CDAccess_CHD.cpp" />
+    <ClCompile Include="..\mednafen\cdrom\CDAccess_Image.cpp" />
+    <ClCompile Include="..\mednafen\cdrom\CDAccess_PBP.cpp" />
+    <ClCompile Include="..\mednafen\cdrom\cdromif.cpp" />
+    <ClCompile Include="..\mednafen\cdrom\CDUtility.c" />
+    <ClCompile Include="..\mednafen\cdrom\edc_crc32.c" />
+    <ClCompile Include="..\mednafen\cdrom\galois.c" />
+    <ClCompile Include="..\mednafen\cdrom\l-ec.c" />
+    <ClCompile Include="..\mednafen\cdrom\lec.c" />
+    <ClCompile Include="..\mednafen\cdrom\misc.cpp" />
+    <ClCompile Include="..\mednafen\cdrom\recover-raw.c" />
+    <ClCompile Include="..\mednafen\error.cpp" />
+    <ClCompile Include="..\mednafen\FileStream.cpp" />
+    <ClCompile Include="..\mednafen\general.cpp" />
+    <ClCompile Include="..\mednafen\md5.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)mednafen\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)mednafen\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)mednafen\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)mednafen\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\mednafen-endian.cpp" />
+    <ClCompile Include="..\mednafen\MemoryStream.cpp" />
+    <ClCompile Include="..\mednafen\mempatcher.cpp" />
+    <ClCompile Include="..\mednafen\psx\cdc.cpp" />
+    <ClCompile Include="..\mednafen\psx\cpu.cpp" />
+    <ClCompile Include="..\mednafen\psx\dma.cpp" />
+    <ClCompile Include="..\mednafen\psx\frontio.cpp" />
+    <ClCompile Include="..\mednafen\psx\gpu.cpp" />
+    <ClCompile Include="..\mednafen\psx\gte.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\dualanalog.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\dualshock.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\gamepad.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\guncon.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\justifier.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\memcard.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\mouse.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\multitap.cpp" />
+    <ClCompile Include="..\mednafen\psx\input\negcon.cpp" />
+    <ClCompile Include="..\mednafen\psx\irq.cpp" />
+    <ClCompile Include="..\mednafen\psx\mdec.cpp" />
+    <ClCompile Include="..\mednafen\psx\sio.cpp" />
+    <ClCompile Include="..\mednafen\psx\spu.cpp" />
+    <ClCompile Include="..\mednafen\psx\timer.cpp" />
+    <ClCompile Include="..\mednafen\settings.cpp" />
+    <ClCompile Include="..\mednafen\state.cpp" />
+    <ClCompile Include="..\mednafen\Stream.cpp" />
+    <ClCompile Include="..\mednafen\tremor\bitwise.c" />
+    <ClCompile Include="..\mednafen\tremor\block.c" />
+    <ClCompile Include="..\mednafen\tremor\codebook.c" />
+    <ClCompile Include="..\mednafen\tremor\floor0.c" />
+    <ClCompile Include="..\mednafen\tremor\floor1.c" />
+    <ClCompile Include="..\mednafen\tremor\framing.c" />
+    <ClCompile Include="..\mednafen\tremor\info.c" />
+    <ClCompile Include="..\mednafen\tremor\mapping0.c" />
+    <ClCompile Include="..\mednafen\tremor\mdct.c" />
+    <ClCompile Include="..\mednafen\tremor\registry.c" />
+    <ClCompile Include="..\mednafen\tremor\res012.c" />
+    <ClCompile Include="..\mednafen\tremor\sharedbook.c" />
+    <ClCompile Include="..\mednafen\tremor\synthesis.c" />
+    <ClCompile Include="..\mednafen\tremor\vorbisfile.c" />
+    <ClCompile Include="..\mednafen\tremor\window.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)tremor\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)tremor\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)tremor\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)tremor\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\video\Deinterlacer.cpp" />
+    <ClCompile Include="..\mednafen\video\surface.cpp" />
+    <ClCompile Include="..\pgxp\pgxp_cpu.c" />
+    <ClCompile Include="..\pgxp\pgxp_debug.c" />
+    <ClCompile Include="..\pgxp\pgxp_gpu.c" />
+    <ClCompile Include="..\pgxp\pgxp_gte.c" />
+    <ClCompile Include="..\pgxp\pgxp_main.c" />
+    <ClCompile Include="..\pgxp\pgxp_mem.c" />
+    <ClCompile Include="..\pgxp\pgxp_value.c" />
+    <ClCompile Include="..\rsx\rsx_intf.cpp" />
+    <ClCompile Include="..\rsx\rsx_lib_soft.c" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{9CA79DB2-1585-44DB-98E8-A0E8139B905A}</ProjectGuid>
+    <RootNamespace>mednafenpsxlibretro</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)$(SolutionName)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionName)\build\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)$(SolutionName)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionName)\build\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)$(SolutionName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionName)\build\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)$(SolutionName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionName)\build\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)../;$(ProjectDir)../mednafen;$(ProjectDir)../mednafen/include;$(ProjectDir)../mednafen/intl;$(ProjectDir)../mednafen/hw_sound;$(ProjectDir)../mednafen/hw_cpu;$(ProjectDir)../mednafen/hw_misc;$(ProjectDir)../libretro-common/include;$(ProjectDir)../deps/zlib;$(ProjectDir)../deps/crypto;$(ProjectDir)../deps/flac-1.3.2/include;$(ProjectDir)../deps/flac-1.3.2/src/libFLAC/include;$(ProjectDir)../deps/lzma-16.04/C;$(ProjectDir)../deps/libchdr;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE__MKDIR;HAVE_PBP;WANT_THREADING;HAVE_THREADS;NEED_DEINTERLACER;ARCH_X86;WANT_32BPP;WANT_NEW_API;FRONTEND_SUPPORTS_RGB565;NEED_CD;HAVE_CHD;_7ZIP_ST;PACKAGE_VERSION="1.3.2";FLAC_API_EXPORTS;FLAC__HAS_OGG=0;HAVE_LROUND;HAVE_STDINT_H;HAVE_STDLIB_H;HAVE_SYS_PARAM_H;HAVE_FSEEKO;NEED_TREMOR;SIZEOF_DOUBLE=8;MEDNAFEN_VERSION="0.9.38.6";PACKAGE="mednafen";MEDNAFEN_VERSION_NUMERIC=9386;PSS_STYLE=1;MPC_FIXED_POINT;WANT_PSX_EMU;STDC_HEADERS;__STDC_LIMIT_MACROS;__LIBRETRO__;_LOW_ACCURACY_;_FILE_OFFSET_BITS=64;__STDC_CONSTANT_MACROS;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;__ORDER_LITTLE_ENDIAN__;__BYTE_ORDER__=__ORDER_LITTLE_ENDIAN__;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)../;$(ProjectDir)../mednafen;$(ProjectDir)../mednafen/include;$(ProjectDir)../mednafen/intl;$(ProjectDir)../mednafen/hw_sound;$(ProjectDir)../mednafen/hw_cpu;$(ProjectDir)../mednafen/hw_misc;$(ProjectDir)../libretro-common/include;$(ProjectDir)../deps/zlib;$(ProjectDir)../deps/crypto;$(ProjectDir)../deps/flac-1.3.2/include;$(ProjectDir)../deps/flac-1.3.2/src/libFLAC/include;$(ProjectDir)../deps/lzma-16.04/C;$(ProjectDir)../deps/libchdr;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE__MKDIR;HAVE_PBP;WANT_THREADING;HAVE_THREADS;NEED_DEINTERLACER;ARCH_X86;WANT_32BPP;WANT_NEW_API;FRONTEND_SUPPORTS_RGB565;NEED_CD;HAVE_CHD;_7ZIP_ST;PACKAGE_VERSION="1.3.2";FLAC_API_EXPORTS;FLAC__HAS_OGG=0;HAVE_LROUND;HAVE_STDINT_H;HAVE_STDLIB_H;HAVE_SYS_PARAM_H;HAVE_FSEEKO;NEED_TREMOR;SIZEOF_DOUBLE=8;MEDNAFEN_VERSION="0.9.38.6";PACKAGE="mednafen";MEDNAFEN_VERSION_NUMERIC=9386;PSS_STYLE=1;MPC_FIXED_POINT;WANT_PSX_EMU;STDC_HEADERS;__STDC_LIMIT_MACROS;__LIBRETRO__;_LOW_ACCURACY_;_FILE_OFFSET_BITS=64;__STDC_CONSTANT_MACROS;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;__ORDER_LITTLE_ENDIAN__;__BYTE_ORDER__=__ORDER_LITTLE_ENDIAN__;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)../;$(ProjectDir)../mednafen;$(ProjectDir)../mednafen/include;$(ProjectDir)../mednafen/intl;$(ProjectDir)../mednafen/hw_sound;$(ProjectDir)../mednafen/hw_cpu;$(ProjectDir)../mednafen/hw_misc;$(ProjectDir)../libretro-common/include;$(ProjectDir)../deps/zlib;$(ProjectDir)../deps/crypto;$(ProjectDir)../deps/flac-1.3.2/include;$(ProjectDir)../deps/flac-1.3.2/src/libFLAC/include;$(ProjectDir)../deps/lzma-16.04/C;$(ProjectDir)../deps/libchdr;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE__MKDIR;HAVE_PBP;WANT_THREADING;HAVE_THREADS;NEED_DEINTERLACER;ARCH_X86;WANT_32BPP;WANT_NEW_API;FRONTEND_SUPPORTS_RGB565;NEED_CD;HAVE_CHD;_7ZIP_ST;PACKAGE_VERSION="1.3.2";FLAC_API_EXPORTS;FLAC__HAS_OGG=0;HAVE_LROUND;HAVE_STDINT_H;HAVE_STDLIB_H;HAVE_SYS_PARAM_H;HAVE_FSEEKO;NEED_TREMOR;SIZEOF_DOUBLE=8;MEDNAFEN_VERSION="0.9.38.6";PACKAGE="mednafen";MEDNAFEN_VERSION_NUMERIC=9386;PSS_STYLE=1;MPC_FIXED_POINT;WANT_PSX_EMU;STDC_HEADERS;__STDC_LIMIT_MACROS;__LIBRETRO__;_LOW_ACCURACY_;_FILE_OFFSET_BITS=64;__STDC_CONSTANT_MACROS;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;__ORDER_LITTLE_ENDIAN__;__BYTE_ORDER__=__ORDER_LITTLE_ENDIAN__;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)../;$(ProjectDir)../mednafen;$(ProjectDir)../mednafen/include;$(ProjectDir)../mednafen/intl;$(ProjectDir)../mednafen/hw_sound;$(ProjectDir)../mednafen/hw_cpu;$(ProjectDir)../mednafen/hw_misc;$(ProjectDir)../libretro-common/include;$(ProjectDir)../deps/zlib;$(ProjectDir)../deps/crypto;$(ProjectDir)../deps/flac-1.3.2/include;$(ProjectDir)../deps/flac-1.3.2/src/libFLAC/include;$(ProjectDir)../deps/lzma-16.04/C;$(ProjectDir)../deps/libchdr;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE__MKDIR;HAVE_PBP;WANT_THREADING;HAVE_THREADS;NEED_DEINTERLACER;ARCH_X86;WANT_32BPP;WANT_NEW_API;FRONTEND_SUPPORTS_RGB565;NEED_CD;HAVE_CHD;_7ZIP_ST;PACKAGE_VERSION="1.3.2";FLAC_API_EXPORTS;FLAC__HAS_OGG=0;HAVE_LROUND;HAVE_STDINT_H;HAVE_STDLIB_H;HAVE_SYS_PARAM_H;HAVE_FSEEKO;NEED_TREMOR;SIZEOF_DOUBLE=8;MEDNAFEN_VERSION="0.9.38.6";PACKAGE="mednafen";MEDNAFEN_VERSION_NUMERIC=9386;PSS_STYLE=1;MPC_FIXED_POINT;WANT_PSX_EMU;STDC_HEADERS;__STDC_LIMIT_MACROS;__LIBRETRO__;_LOW_ACCURACY_;_FILE_OFFSET_BITS=64;__STDC_CONSTANT_MACROS;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;__ORDER_LITTLE_ENDIAN__;__BYTE_ORDER__=__ORDER_LITTLE_ENDIAN__;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/mednafen_psx_libretro.vcxproj.filters
+++ b/msvc/mednafen_psx_libretro.vcxproj.filters
@@ -1,0 +1,508 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="libretro-common">
+      <UniqueIdentifier>{403444dc-ce2c-401e-b023-f0bf843e483e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\rthreads">
+      <UniqueIdentifier>{2bec7374-d33e-4807-a98c-ef47f98dac74}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\streams">
+      <UniqueIdentifier>{856825ad-d503-4c13-9cc9-d907ee37a4b7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="mednafen">
+      <UniqueIdentifier>{88d44dbf-9f5e-4a8f-95d8-e37789fe183f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="mednafen\psx">
+      <UniqueIdentifier>{91e055eb-9178-46b8-967b-4600d1368577}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="mednafen\psx\input">
+      <UniqueIdentifier>{8ded46e8-a8e5-4310-a9dd-3ac13a40c5f9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="mednafen\video">
+      <UniqueIdentifier>{1e2dc216-8cd7-4d0b-809c-d86ef961b732}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="mednafen\cdrom">
+      <UniqueIdentifier>{dba242e6-9e7c-4dbd-b765-b7bde9be02c9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="mednafen\tremor">
+      <UniqueIdentifier>{94006258-544b-43db-9ada-8e4d16ba43d3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rsx">
+      <UniqueIdentifier>{5706070e-2064-4681-ac4b-8132fcbdc25f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="deps">
+      <UniqueIdentifier>{eebe808e-91a2-45d0-bed2-980d59d3372b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="deps\zlib">
+      <UniqueIdentifier>{62b46b56-0d74-49ff-800a-07247d7f3227}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="deps\libkirk">
+      <UniqueIdentifier>{334e85ce-3ac8-4d20-bba8-da1a8dcaf58d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\string">
+      <UniqueIdentifier>{d52b2ce6-db41-40b7-8ee9-110a48e5793a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="pgxp">
+      <UniqueIdentifier>{939be7e9-0bc9-40c1-986c-b59770f862cc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="flac">
+      <UniqueIdentifier>{7278a27a-27eb-4eac-a72a-ce980cad47e2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="deps\lzma">
+      <UniqueIdentifier>{71f90571-86cb-4be6-9515-d348773a924c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\hash">
+      <UniqueIdentifier>{a5cc2532-f602-4180-805d-c9ee63636ffc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\encodings">
+      <UniqueIdentifier>{18421ee3-eea8-4fd8-8334-50a662013ccd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\compat">
+      <UniqueIdentifier>{9bb44ae3-51e1-489a-8043-62823bab3dc4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="deps\crypto">
+      <UniqueIdentifier>{fedca8ab-b89c-443b-afe8-879e86b7fd26}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="deps\libchdr">
+      <UniqueIdentifier>{12aef0cf-2af1-44f6-8b66-748afdb139a4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libretro-common\vfs">
+      <UniqueIdentifier>{b2c8ed6d-a8b0-4db4-98bc-bb9dc77672f2}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\libretro-common\rthreads\rthreads.c">
+      <Filter>libretro-common\rthreads</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\streams\file_stream.c">
+      <Filter>libretro-common\streams</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\error.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\FileStream.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\general.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\md5.c">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\MemoryStream.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\mempatcher.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\settings.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\state.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\Stream.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\cdc.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\cpu.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\dma.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\frontio.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\gpu.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\gte.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\irq.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\mdec.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\sio.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\spu.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\timer.cpp">
+      <Filter>mednafen\psx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\dualanalog.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\dualshock.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\gamepad.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\guncon.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\justifier.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\memcard.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\mouse.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\multitap.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\psx\input\negcon.cpp">
+      <Filter>mednafen\psx\input</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\video\Deinterlacer.cpp">
+      <Filter>mednafen\video</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\video\surface.cpp">
+      <Filter>mednafen\video</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\audioreader.cpp">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\CDAccess.cpp">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\CDAccess_CCD.cpp">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\CDAccess_Image.cpp">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\cdromif.cpp">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\CDUtility.c">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\edc_crc32.c">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\galois.c">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\l-ec.c">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\lec.c">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\misc.cpp">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\recover-raw.c">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\bitwise.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\block.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\codebook.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\floor0.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\floor1.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\framing.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\info.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\mapping0.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\mdct.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\registry.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\res012.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\sharedbook.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\synthesis.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\vorbisfile.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\tremor\window.c">
+      <Filter>mednafen\tremor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro.cpp" />
+    <ClCompile Include="..\rsx\rsx_intf.cpp">
+      <Filter>rsx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rsx\rsx_lib_soft.c">
+      <Filter>rsx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\CDAccess_PBP.cpp">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\gzread.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\gzwrite.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\inffast.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\inflate.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\inftrees.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\trees.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\uncompr.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\zutil.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\adler32.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\compress.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\crc32.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\deflate.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\gzclose.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\zlib\gzlib.c">
+      <Filter>deps\zlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libkirk\bn.c">
+      <Filter>deps\libkirk</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libkirk\des.c">
+      <Filter>deps\libkirk</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libkirk\ec.c">
+      <Filter>deps\libkirk</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libkirk\kirk_engine.c">
+      <Filter>deps\libkirk</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libkirk\sha1.c">
+      <Filter>deps\libkirk</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libkirk\aes.c">
+      <Filter>deps\libkirk</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libkirk\amctrl.c">
+      <Filter>deps\libkirk</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\string\stdstring.c">
+      <Filter>libretro-common\string</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pgxp\pgxp_cpu.c">
+      <Filter>pgxp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pgxp\pgxp_debug.c">
+      <Filter>pgxp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pgxp\pgxp_gte.c">
+      <Filter>pgxp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pgxp\pgxp_mem.c">
+      <Filter>pgxp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pgxp\pgxp_value.c">
+      <Filter>pgxp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pgxp\pgxp_gpu.c">
+      <Filter>pgxp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pgxp\pgxp_main.c">
+      <Filter>pgxp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro_cbs.c" />
+    <ClCompile Include="..\input.cpp" />
+    <ClCompile Include="..\deps\lzma-16.04\C\Alloc.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\Bra.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\Bra86.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\BraIA64.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\CpuArch.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\Delta.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\LzFind.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\Lzma86Dec.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\Lzma86Enc.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\LzmaDec.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\LzmaEnc.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\LzmaLib.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\lzma-16.04\C\Sort.c">
+      <Filter>deps\lzma</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\bitmath.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\bitreader.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\cpu.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\crc.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\fixed.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\fixed_intrin_sse2.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\fixed_intrin_ssse3.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\float.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc_intrin_avx2.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc_intrin_sse.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc_intrin_sse2.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\lpc_intrin_sse41.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\md5.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\memory.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\window.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\windows_unicode_filenames.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\stream_decoder.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\metadata_object.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\metadata_iterators.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\hash\rhash.c">
+      <Filter>libretro-common\hash</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\encodings\encoding_utf.c">
+      <Filter>libretro-common\encodings</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\compat\compat_posix_string.c">
+      <Filter>libretro-common\compat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\compat\compat_strcasestr.c">
+      <Filter>libretro-common\compat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\compat\compat_strl.c">
+      <Filter>libretro-common\compat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\crypto\sha1.c">
+      <Filter>deps\crypto</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\crypto\md5.c">
+      <Filter>deps\crypto</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libchdr\bitstream.c">
+      <Filter>deps\libchdr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libchdr\cdrom.c">
+      <Filter>deps\libchdr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libchdr\chd.c">
+      <Filter>deps\libchdr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libchdr\flac.c">
+      <Filter>deps\libchdr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\libchdr\huffman.c">
+      <Filter>deps\libchdr</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\vfs\vfs_implementation.c">
+      <Filter>libretro-common\vfs</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\compat\fopen_utf8.c">
+      <Filter>libretro-common\compat</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libretro-common\streams\file_stream_transforms.c">
+      <Filter>libretro-common\streams</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\cdrom\CDAccess_CHD.cpp">
+      <Filter>mednafen\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\deps\flac-1.3.2\src\libFLAC\format.c">
+      <Filter>flac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mednafen\mednafen-endian.cpp">
+      <Filter>mednafen</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/parallel-psx/atlas/atlas.hpp
+++ b/parallel-psx/atlas/atlas.hpp
@@ -2,6 +2,7 @@
 
 #include <stdint.h>
 #include <vector>
+#include <algorithm>
 
 namespace PSX
 {

--- a/parallel-psx/vulkan/command_buffer.hpp
+++ b/parallel-psx/vulkan/command_buffer.hpp
@@ -410,8 +410,11 @@ private:
 	{
 		float blend_constants[4];
 	} potential_static_state = {};
+#ifndef _MSC_VER
+	//suppress compiler error on MSVC by ommitting this check
 	static_assert(sizeof(static_state.words) >= sizeof(static_state.state),
 	              "Hashable pipeline state is not large enough!");
+#endif
 
 	struct DynamicState
 	{

--- a/parallel-psx/vulkan/image.hpp
+++ b/parallel-psx/vulkan/image.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+
 #include "cookie.hpp"
 #include "format.hpp"
 #include "intrusive.hpp"

--- a/parallel-psx/vulkan/shader.cpp
+++ b/parallel-psx/vulkan/shader.cpp
@@ -2,6 +2,10 @@
 #include "device.hpp"
 #include "spirv_cross.hpp"
 
+#include <algorithm>
+using std::min;
+using std::max;
+
 using namespace std;
 using namespace spirv_cross;
 

--- a/parallel-psx/vulkan/util.hpp
+++ b/parallel-psx/vulkan/util.hpp
@@ -9,7 +9,27 @@ namespace Vulkan
 #define trailing_zeroes(x) ((x) == 0 ? 32 : __builtin_ctz(x))
 #define trailing_ones(x) __builtin_ctz(~(x))
 #else
+#ifdef _MSC_VER
+#include <intrin.h>
+static __inline uint32_t leading_zeroes(uint32_t x)
+{
+	if (x == 0) return 32;
+	return __lzcnt(x);
+}
+static __inline uint32_t trailing_zeroes(uint32_t x)
+{
+	if (x == 0) return 32;
+	unsigned long index = 0;
+	_BitScanForward(&index, x);
+	return (uint32_t)index;
+}
+static __inline uint32_t trailing_ones(uint32_t x)
+{
+	return trailing_zeroes(~x);
+}
+#else
 #error "Implement me."
+#endif
 #endif
 
 template <typename T>

--- a/parallel-psx/vulkan/vulkan.hpp
+++ b/parallel-psx/vulkan/vulkan.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "util.hpp"
-#include "vulkan_symbol_wrapper.h"
 #include <memory>
 #include <stdexcept>
+#include "util.hpp"
+#include "vulkan_symbol_wrapper.h"
 
 #define STRINGIFY(x) #x
 

--- a/rsx/shaders_gl/command_vertex.glsl.h
+++ b/rsx/shaders_gl/command_vertex.glsl.h
@@ -1,10 +1,13 @@
 #include "shaders_common.h"
 
+#undef command_vertex_name_
 #if defined(FILTER_SABR) || defined(FILTER_XBR)
-static const char * command_vertex_xbr = GLSL(
+#define command_vertex_name_ command_vertex_xbr
 #else
-static const char *command_vertex = GLSL(
+#define command_vertex_name_ command_vertex
 #endif
+
+static const char * command_vertex_name_ = GLSL(
 // Vertex shader for rendering GPU draw commands in the framebuffer
 in vec4 position;
 in uvec3 color;
@@ -29,8 +32,10 @@ flat out uint frag_depth_shift;
 flat out uint frag_dither;
 flat out uint frag_semi_transparent;
 flat out uvec4 frag_texture_window;
+)
 
 #if defined(FILTER_SABR) || defined(FILTER_XBR)
+STRINGIZE(
 out vec2 tc;
 out vec4 xyp_1_2_3;
 out vec4 xyp_6_7_8;
@@ -39,8 +44,9 @@ out vec4 xyp_16_17_18;
 out vec4 xyp_21_22_23;
 out vec4 xyp_5_10_15;
 out vec4 xyp_9_14_9;
+)
 #endif
-
+STRINGIZE(
 void main() {
    vec2 pos = position.xy + vec2(offset);
 
@@ -70,9 +76,10 @@ void main() {
    frag_dither = dither;
    frag_semi_transparent = semi_transparent;
    frag_texture_window = texture_window;
-
+)
 #if defined(FILTER_SABR) || defined(FILTER_XBR)
-   tc = frag_texture_coord.xy;
+STRINGIZE(
+	tc = frag_texture_coord.xy;
    xyp_1_2_3    = tc.xxxy + vec4(-1.,  0., 1., -2.);
    xyp_6_7_8    = tc.xxxy + vec4(-1.,  0., 1., -1.);
    xyp_11_12_13 = tc.xxxy + vec4(-1.,  0., 1.,  0.);
@@ -80,7 +87,10 @@ void main() {
    xyp_21_22_23 = tc.xxxy + vec4(-1.,  0., 1.,  2.);
    xyp_5_10_15  = tc.xyyy + vec4(-2., -1., 0.,  1.);
    xyp_9_14_9   = tc.xyyy + vec4( 2., -1., 0.,  1.);
+)
 #endif
+STRINGIZE(
 }
-
 );
+
+#undef command_vertex_name_

--- a/rsx/shaders_gl/shaders_common.h
+++ b/rsx/shaders_gl/shaders_common.h
@@ -2,5 +2,6 @@
 #define _SHADERS_COMMON
 
 #define GLSL(src) "#version 330 core\n" #src
+#define STRINGIZE(src) #src
 
 #endif


### PR DESCRIPTION
Fixes to source code to compile on MSVC 2017, plus changes to the makefile to compile on MSVC 2017, plus additional Project files for the HW and SW rendering versions of the program.

These changes were also tested on mingw64, and still built okay.  Have not tested the impact on CLANG builds or other compilers.

* `MDFN_ALIGN` is defined for MSVC now as `__declspec(align(n))`
* `MDFN_ALIGN` moved to beginning of variable declaration, as needed by `__declspec(align(n))`
* `NO_INLINE` moved to before the type of the function, as needed by `__declspec(noinline)`
* `MDFN_FASTCALL` moved to between function type and function name, as needed by `__fastcall`
* Fixed libflac bug where it did not return the handle value
* Suppressed a compiler error in `GetTexel` by assigning an uninitialized variable to NULL.  An invalid `TexMode_TA` value will now segfault from a NULL pointer instead of using some random memory.
* Suppressed a compiler error in `firmware_is_present`
* Suppressed a compiler error in `IntrusivePtrEnabled` involving variable-not-found errors within the static assert
* Removed "Compiling with MSVC" disclaimer
* Add `#include <algorithm>` to files which use `std::min` and `std::max`
* Changed the order of include files for `parallel-psx/vulkan/vulkan.hpp`.  For some reason, MSVC chokes if the standard header files are included after the others, so moving them up makes it compile correctly.
* Implemented the MSVC instrinsics for counting zeroes in `parallel-psx/vulkan/util.hpp` (because it said `#error implement me`)
* Changed the shaders to not contain preprocessor commands within the text body of a stringize macro.  MSVC just doesn't support it.