### PR TITLE
Revert "Merge pull request #335 from Aftnet/master"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -550,9 +550,7 @@ FLAGS += -D_CRT_SECURE_NO_WARNINGS \
 	 -DNOMINMAX \
 	 //utf-8 \
 	 //std:c++17
-    ifneq (,$(findstring windows_msvc2017_desktop,$(platform)))
-        LDFLAGS += "opengl32.lib"
-    endif
+LDFLAGS += "opengl32.lib"
 endif
 
 ifeq ($(HAVE_VULKAN),1)


### PR DESCRIPTION
This reverts commit 3eac43eeef117c93139536873beb124a903ecb44, reversing
changes made to 4a75947e0f979c10ab0337d9bbd7b4f485674537.

@claudiuslollarius It seems this was falsely detecting our buildbot builds as UWP and thus failing to link GL on them, as well, since we're building it with MSVC2017. Got any other ideas to differentiate?