### PR TITLE
Fixing UWP build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -553,7 +553,9 @@ FLAGS += -D_CRT_SECURE_NO_WARNINGS \
 	 -DNOMINMAX \
 	 //utf-8 \
 	 //std:c++17
-LDFLAGS += "opengl32.lib"
+	 ifeq (,$(findstring windows_msvc2017_uwp,$(platform)))
+	 	 LDFLAGS += opengl32.lib
+	 endif
 endif
 
 ifeq ($(HAVE_VULKAN),1)


### PR DESCRIPTION
Trying to fix this again, hopefully without spillover this time.

UWP has no opengl32.lib and the software renderer does not require it anyways.

I am removing `LDFLAGS += opengl32.lib` if and only if `windows_msvc2017_uwp` is specified as part of the platform. This should not affect anything but
a. UWP builds
b. Visual Studio builds (see enclosing `ifneq (,$(findstring windows_msvc2017,$(platform)))` block