### PR TITLE
Fix filtering and vertex cache errors in issue #350 and similar

### DIFF
--- a/pgxp/pgxp_gpu.c
+++ b/pgxp/pgxp_gpu.c
@@ -235,7 +235,7 @@ int PGXP_GetVertex(const unsigned int offset, const unsigned int* addr, OGLVerte
 			pOutput->y = vert->y + yOffs;
 			pOutput->z = 0.95f;
 			pOutput->w = vert->z;
-			pOutput->valid_w = 1;
+			pOutput->valid_w = 0;	// iCB: Getting the wrong w component causes too great an error when using perspective correction so disable it
 		}
 		else
 		{

--- a/rsx/shaders_gl/command_fragment.glsl.h
+++ b/rsx/shaders_gl/command_fragment.glsl.h
@@ -45,6 +45,8 @@ flat in uint frag_dither;
 flat in uint frag_semi_transparent;
 // Texture window: [ X mask, X or, Y mask, Y or ]
 flat in uvec4 frag_texture_window;
+// Texture limits: [Umin, Vmin, Umax, Vmax]
+flat in uvec4 frag_texture_limits;
 
 out vec4 frag_color;
 
@@ -93,14 +95,16 @@ const int dither_pattern[16] =
            3, -1,  2, -2);
 
 vec4 sample_texel(vec2 coords) {
-   coords.x += 0.5 / 1024;
-   coords.y += 0.5 / 512;
    // Number of texel per VRAM 16bit "pixel" for the current depth
    uint pix_per_hw = 1U << frag_depth_shift;
 
    // Texture pages are limited to 256x256 pixels
    uint tex_x = clamp(uint(coords.x), 0x0U, 0xffU);
    uint tex_y = clamp(uint(coords.y), 0x0U, 0xffU);
+
+   // Clamp to primitive limits
+   tex_x = clamp(tex_x, frag_texture_limits[0], frag_texture_limits[2] - 1u);
+   tex_y = clamp(tex_y, frag_texture_limits[1], frag_texture_limits[3] - 1u);
 
    // Texture window adjustments
    tex_x = (tex_x & frag_texture_window[0]) | frag_texture_window[1];

--- a/rsx/shaders_gl/command_vertex.glsl.h
+++ b/rsx/shaders_gl/command_vertex.glsl.h
@@ -19,6 +19,7 @@ in uint depth_shift;
 in uint dither;
 in uint semi_transparent;
 in uvec4 texture_window;
+in uvec4 texture_limits;
 
 // Drawing offset
 uniform ivec2 offset;
@@ -32,6 +33,7 @@ flat out uint frag_depth_shift;
 flat out uint frag_dither;
 flat out uint frag_semi_transparent;
 flat out uvec4 frag_texture_window;
+flat out uvec4 frag_texture_limits;
 )
 
 #if defined(FILTER_SABR) || defined(FILTER_XBR)
@@ -76,6 +78,7 @@ void main() {
    frag_dither = dither;
    frag_semi_transparent = semi_transparent;
    frag_texture_window = texture_window;
+   frag_texture_limits = texture_limits;
 )
 #if defined(FILTER_SABR) || defined(FILTER_XBR)
 STRINGIZE(


### PR DESCRIPTION
- Clamp texture coordinates to avoid sampling incorrect values when using filtering options
(replaces the need to offset texcoords by 1/2 pixel for perspective correction)
- Invalidate w component of cached vertices to selectively disable perspective correction when using them.