### PR TITLE
Mask bits support using OpenGL stencil buffer

### DIFF
--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -268,10 +268,6 @@ void rsx_intf_set_mask_setting(uint32_t mask_set_or, uint32_t mask_eval_and)
       case RSX_SOFTWARE:
          break;
       case RSX_OPENGL:
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
-         /* We'll do it like Vulkan and...not do it all */
-         //rsx_gl_set_mask_setting(mask_set_or, mask_eval_and);
-#endif
          break;
       case RSX_VULKAN:
          /* TODO/FIXME */
@@ -395,7 +391,7 @@ void rsx_intf_push_triangle(
                texture_blend_mode,
                depth_shift,
                dither,
-               blend_mode, mask_test, set_mask);
+               blend_mode, mask_test != 0, set_mask != 0);
 #endif
          break;
       case RSX_VULKAN:
@@ -458,7 +454,7 @@ void rsx_intf_push_quad(
 			texture_blend_mode,
 			depth_shift,
 			dither,
-			blend_mode, mask_test, set_mask);
+			blend_mode, mask_test != 0, set_mask != 0);
 #endif
 		break;
    case RSX_VULKAN:
@@ -498,7 +494,7 @@ void rsx_intf_push_line(int16_t p0x, int16_t p0y,
          break;
       case RSX_OPENGL:
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
-         rsx_gl_push_line(p0x, p0y, p1x, p1y, c0, c1, dither, blend_mode, mask_test, set_mask);
+         rsx_gl_push_line(p0x, p0y, p1x, p1y, c0, c1, dither, blend_mode, mask_test != 0, set_mask != 0);
 #endif
          break;
       case RSX_VULKAN:

--- a/rsx/rsx_lib_gl.h
+++ b/rsx/rsx_lib_gl.h
@@ -21,7 +21,6 @@ void rsx_gl_finalize_frame(   const void *fb, unsigned width,
 void rsx_gl_set_tex_window(   uint8_t tww, uint8_t twh,
                               uint8_t twx, uint8_t twy);
 
-void rsx_gl_set_mask_setting(uint32_t mask_eval_and, uint32_t mask_set_or);
 void rsx_gl_set_draw_offset(int16_t x, int16_t y);
 
 void rsx_gl_set_draw_area( uint16_t x, uint16_t y,
@@ -46,7 +45,7 @@ void rsx_gl_push_triangle( float p0x, float p0y, float p0w,
                            uint8_t depth_shift,
                            bool dither,
                            int blend_mode, 
-                           uint32_t mask_eval_and, uint32_t mask_set_or);
+						   bool mask_test, bool set_mask);
 
 void rsx_gl_push_quad(  float p0x, float p0y, float p0w,
                         float p1x, float p1y, float p1w,
@@ -66,7 +65,7 @@ void rsx_gl_push_quad(  float p0x, float p0y, float p0w,
                         uint8_t depth_shift,
                         bool dither,
                         int blend_mode, 
-                        uint32_t mask_eval_and, uint32_t mask_set_or);
+						bool mask_test, bool set_mask);
 
 
 void rsx_gl_push_line(  int16_t p0x, int16_t p0y,
@@ -74,7 +73,7 @@ void rsx_gl_push_line(  int16_t p0x, int16_t p0y,
                         uint32_t c0,
                         uint32_t c1,
                         bool dither, int blend_mode, 
-                        uint32_t mask_eval_and, uint32_t mask_set_or);
+						bool mask_test, bool set_mask);
 
 void rsx_gl_load_image( uint16_t x, uint16_t y,
                         uint16_t w, uint16_t h,


### PR DESCRIPTION
Changed the way primitives are stored and the order in which they are drawn. Needed for
proper masking between opaque and semi-transparent primitives.
Probably not 100% correct but seems to fix the fog issue in Silent Hill (Issue #306)