### PR TITLE
add checking against NULL

### DIFF
--- a/mednafen/tremor/block.c
+++ b/mednafen/tremor/block.c
@@ -242,9 +242,10 @@ void vorbis_dsp_clear(vorbis_dsp_state *v){
 
     if(v->pcm)
     {
-       for(i=0;i<vi->channels;i++)
-          if(v->pcm[i])
-             free(v->pcm[i]);
+       if(vi)
+          for(i=0;i<vi->channels;i++)
+             if(v->pcm[i])
+                free(v->pcm[i]);
        free(v->pcm);
        if(v->pcmret)
           free(v->pcmret);


### PR DESCRIPTION
Hi all,
There is a possible null pointer deference issue found by Qihoo360 CodeSafe Team.
Details as bellow:

in line 240, the condition expression, pointer 'vi' may be a null pointer.
in line 245 (246 repaired), directly deference it as the condition of 'for' statement, which may cause null pointer deference.

Cheers
Qihoo360 CodeSafe Team