### PR TITLE
Prevent crash when cue sheet references a non-existant file

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3290,6 +3290,9 @@ static MDFNGI *MDFNI_LoadCD(const char *devicename)
 #else
          CDIF *image  = CDIF_Open(&success, devicename, false, old_cdimagecache);
 #endif
+         if (!success)
+            return(0);
+
          CDInterfaces.push_back(image);
       }
    }

--- a/mednafen/cdrom/CDAccess_Image.cpp
+++ b/mednafen/cdrom/CDAccess_Image.cpp
@@ -639,6 +639,9 @@ bool CDAccess_Image::ImageOpen(const char *path, bool image_memcache)
             TmpTrack.fp = new FileStream(efn.c_str(), MODE_READ);
             TmpTrack.FirstFileInstance = 1;
 
+            if (TmpTrack.fp->tell() == UINT64_C(-1))
+               return false;
+
             if(image_memcache)
                TmpTrack.fp = new MemoryStream(TmpTrack.fp);
 


### PR DESCRIPTION
Prevents the following crash when a cue sheet references a non-existant file:

```
Microsoft Visual C++ Runtime Library
This application has requested the Runtime to terminate it in an unusual way.
Please contact the application's support team for more information.
```

```
Attempt to read LBA 16, >= LBA 0
CDIF Raw Read error
terminate called after throwing an instance of 'MDFN_Error'
```