### PR TITLE
vulkan: Remove assert.

### DIFF
--- a/parallel-psx/vulkan/semaphore.hpp
+++ b/parallel-psx/vulkan/semaphore.hpp
@@ -37,7 +37,6 @@ public:
 	{
 		auto ret = semaphore;
 		VK_ASSERT(semaphore);
-		VK_ASSERT(signalled);
 		semaphore = VK_NULL_HANDLE;
 		signalled = false;
 		return ret;


### PR DESCRIPTION
Warning: Please review and test this, I am not sure that its correct, only that it boots games with amdgpu and vulkan now.
```
Vulkan error at parallel-psx/vulkan/semaphore.hpp:40.
terminate called without an active exception
```