### PR TITLE
Fix chain allocator behaviour

### DIFF
--- a/parallel-psx/renderer/renderer.cpp
+++ b/parallel-psx/renderer/renderer.cpp
@@ -1276,10 +1276,10 @@ void Renderer::render_semi_transparent_primitives()
 	cmd->set_vertex_attrib(2, 0, VK_FORMAT_R8G8B8A8_UINT, offsetof(BufferVertex, window));
 	cmd->set_vertex_attrib(3, 0, VK_FORMAT_R16G16B16A16_SINT, offsetof(BufferVertex, pal_x));
 	cmd->set_vertex_attrib(4, 0, VK_FORMAT_R16G16B16A16_SINT, offsetof(BufferVertex, u));
-	cmd->set_vertex_attrib(5, 0, VK_FORMAT_R32G32B32A32_SFLOAT, offsetof(BufferVertex, min_u));
-	cmd->set_vertex_attrib(6, 0, VK_FORMAT_R32G32B32A32_SFLOAT, offsetof(BufferVertex, min_v));
-	cmd->set_vertex_attrib(7, 0, VK_FORMAT_R32G32B32A32_SFLOAT, offsetof(BufferVertex, max_u));
-	cmd->set_vertex_attrib(8, 0, VK_FORMAT_R32G32B32A32_SFLOAT, offsetof(BufferVertex, max_v));
+	cmd->set_vertex_attrib(5, 0, VK_FORMAT_R32_SFLOAT, offsetof(BufferVertex, min_u));
+	cmd->set_vertex_attrib(6, 0, VK_FORMAT_R32_SFLOAT, offsetof(BufferVertex, min_v));
+	cmd->set_vertex_attrib(7, 0, VK_FORMAT_R32_SFLOAT, offsetof(BufferVertex, max_u));
+	cmd->set_vertex_attrib(8, 0, VK_FORMAT_R32_SFLOAT, offsetof(BufferVertex, max_v));
 	cmd->set_texture(0, 0, framebuffer->get_view(), StockSampler::NearestClamp);
 
 	auto size = queue.semi_transparent.size() * sizeof(BufferVertex);
@@ -1452,10 +1452,10 @@ void Renderer::render_semi_transparent_opaque_texture_primitives()
 	cmd->set_vertex_attrib(2, 0, VK_FORMAT_R8G8B8A8_UINT, offsetof(BufferVertex, window));
 	cmd->set_vertex_attrib(3, 0, VK_FORMAT_R16G16B16A16_SINT, offsetof(BufferVertex, pal_x));
 	cmd->set_vertex_attrib(4, 0, VK_FORMAT_R16G16B16A16_SINT, offsetof(BufferVertex, u));
-	cmd->set_vertex_attrib(5, 0, VK_FORMAT_R32G32B32A32_SFLOAT, offsetof(BufferVertex, min_u));
-	cmd->set_vertex_attrib(6, 0, VK_FORMAT_R32G32B32A32_SFLOAT, offsetof(BufferVertex, min_v));
-	cmd->set_vertex_attrib(7, 0, VK_FORMAT_R32G32B32A32_SFLOAT, offsetof(BufferVertex, max_u));
-	cmd->set_vertex_attrib(8, 0, VK_FORMAT_R32G32B32A32_SFLOAT, offsetof(BufferVertex, max_v));
+	cmd->set_vertex_attrib(5, 0, VK_FORMAT_R32_SFLOAT, offsetof(BufferVertex, min_u));
+	cmd->set_vertex_attrib(6, 0, VK_FORMAT_R32_SFLOAT, offsetof(BufferVertex, min_v));
+	cmd->set_vertex_attrib(7, 0, VK_FORMAT_R32_SFLOAT, offsetof(BufferVertex, max_u));
+	cmd->set_vertex_attrib(8, 0, VK_FORMAT_R32_SFLOAT, offsetof(BufferVertex, max_v));
 	cmd->set_texture(0, 0, framebuffer->get_view(), StockSampler::NearestClamp);
 
 	dispatch(vertices, scissors);
@@ -1478,10 +1478,10 @@ void Renderer::render_opaque_texture_primitives()
 	cmd->set_vertex_attrib(2, 0, VK_FORMAT_R8G8B8A8_UINT, offsetof(BufferVertex, window));
 	cmd->set_vertex_attrib(3, 0, VK_FORMAT_R16G16B16A16_SINT, offsetof(BufferVertex, pal_x)); // Pad to support AMD
 	cmd->set_vertex_attrib(4, 0, VK_FORMAT_R16G16B16A16_SINT, offsetof(BufferVertex, u));
-	cmd->set_vertex_attrib(5, 0, VK_FORMAT_R32G32B32A32_SFLOAT, offsetof(BufferVertex, min_u));
-	cmd->set_vertex_attrib(6, 0, VK_FORMAT_R32G32B32A32_SFLOAT, offsetof(BufferVertex, min_v));
-	cmd->set_vertex_attrib(7, 0, VK_FORMAT_R32G32B32A32_SFLOAT, offsetof(BufferVertex, max_u));
-	cmd->set_vertex_attrib(8, 0, VK_FORMAT_R32G32B32A32_SFLOAT, offsetof(BufferVertex, max_v));
+	cmd->set_vertex_attrib(5, 0, VK_FORMAT_R32_SFLOAT, offsetof(BufferVertex, min_u));
+	cmd->set_vertex_attrib(6, 0, VK_FORMAT_R32_SFLOAT, offsetof(BufferVertex, min_v));
+	cmd->set_vertex_attrib(7, 0, VK_FORMAT_R32_SFLOAT, offsetof(BufferVertex, max_u));
+	cmd->set_vertex_attrib(8, 0, VK_FORMAT_R32_SFLOAT, offsetof(BufferVertex, max_v));
 	cmd->set_texture(0, 0, framebuffer->get_view(), StockSampler::NearestClamp);
 
 	dispatch(vertices, scissors);

--- a/parallel-psx/vulkan/chain_allocator.hpp
+++ b/parallel-psx/vulkan/chain_allocator.hpp
@@ -31,11 +31,11 @@ private:
 	VkBufferUsageFlags usage;
 
 	std::vector<BufferHandle> buffers;
+	std::vector<uint8_t *> hostPtrs;
 	std::vector<BufferHandle> large_buffers;
 	unsigned chain_index = 0;
 	unsigned start_flush_index = 0;
 	VkDeviceSize offset = 0;
 	VkDeviceSize size = 0;
-	uint8_t *host = nullptr;
 };
 }


### PR DESCRIPTION
- Originally had a single host pointer to the last block allocated. If more than one block was allocated when the allocator was reset using discard() this caused a mismatch between the block allocated from and the one written to.
- Now stores a pointer to the data in each block and returns the correct one when allocating.

Should fix issues #445 and #422

Also changed the vertex declaration for UV clamping values to be single channel floats (doesn't appear to have been causing errors, but seems more correct).