### PR TITLE
Don't expose 32x resolution.

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3926,7 +3926,7 @@ void retro_set_environment(retro_environment_t cb)
 #ifdef HAVE_VULKAN
       { BEETLE_OPT(adaptive_smoothing), "Adaptive smoothing; enabled|disabled" },
 #endif
-      { BEETLE_OPT(internal_resolution), "Internal GPU resolution; 1x(native)|2x|4x|8x|16x|32x" },
+      { BEETLE_OPT(internal_resolution), "Internal GPU resolution; 1x(native)|2x|4x|8x|16x" },
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
       // Only used in GL renderer for now.
       { BEETLE_OPT(depth), "Internal color depth; dithered 16bpp (native)|32bpp" },

--- a/rsx/rsx_lib_gl.cpp
+++ b/rsx/rsx_lib_gl.cpp
@@ -1165,9 +1165,6 @@ static void get_variables(uint8_t *upscaling, bool *display_vram)
          {
             *upscaling  = (var.value[0] - '0') * 10;
             *upscaling += var.value[1] - '0';
-
-            if (*upscaling == 32) /* Too high for GL */
-               *upscaling = 16;
          }
       }
    }
@@ -1664,8 +1661,6 @@ static bool retro_refresh_variables(GlRenderer *renderer)
 
    return reconfigure_frontend;
 }
-
-
 
 static void vertex_preprocessing(
       GlRenderer *renderer,


### PR DESCRIPTION
In retrospect perhaps adding this wasn't the best idea? Please see @Themaister's comment here https://github.com/libretro/beetle-psx-libretro/issues/456#issuecomment-444689501.

Fixes https://github.com/libretro/beetle-psx-libretro/issues/456
Reverts https://github.com/libretro/beetle-psx-libretro/commit/3c853b340dbc41df17740e084919dac1e962b06f