### PR TITLE
Fix issue #368 and enhance flipped sprite detection

### DIFF
--- a/mednafen/psx/gpu.cpp
+++ b/mednafen/psx/gpu.cpp
@@ -646,6 +646,8 @@ void GPU_Init(bool pal_clock_and_tv,
 
    GPU.upscale_shift = upscale_shift;
    GPU.dither_upscale_shift = 0;
+
+   GPU.killQuadPart = 0;
 }
 
 void GPU_RecalcClockRatio(void) {

--- a/mednafen/psx/gpu.h
+++ b/mednafen/psx/gpu.h
@@ -147,6 +147,7 @@ struct PS_GPU
    tri_vertex InQuad_F3Vertices[3];
    uint32 InQuad_clut;
    bool InQuad_invalidW;
+   uint32 killQuadPart;	// bit flags for tris in quad that are to be culled
 
    // primitive UV offsets (used to correct flipped sprites)
    uint16_t off_u, off_v;

--- a/mednafen/psx/gpu_polygon.cpp
+++ b/mednafen/psx/gpu_polygon.cpp
@@ -533,8 +533,11 @@ void Calc_UVOffsets(PS_GPU *gpu, tri_vertex *vertices, unsigned count)
 		// iCB: Detect and reject any triangles with 0 size texture area
 		float texArea = (vertices[1].u - vertices[0].u) * (vertices[2].v - vertices[0].v) - (vertices[2].u - vertices[0].u) * (vertices[1].v - vertices[0].v);
 
+		// Leverage PGXP to further avoid 3D polygons that just happen to align this way after projection
+		bool is3D = ((vertices[0].precise[2] != vertices[1].precise[2]) || (vertices[1].precise[2] != vertices[2].precise[2]));
+		
 		// Shouldn't matter as degenerate primitives will be culled anyways.
-		if ((area != 0.0f) && (texArea != 0.0f))
+		if ((area != 0.0f) && (texArea != 0.0f) && !is3D)
 		{
 			float inv_area = 1.0f / area;
 			dudx *= inv_area;


### PR DESCRIPTION
- Should now correctly cull leaves in Silent Hill in hardware renderers
- Further improves visual stability of 3D objects (particularly notable in Tomb Raider and Xenogears where 3D quads regularly align on screen)