### PR TITLE
Fix crash when loading Audio CD

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1266,6 +1266,8 @@ static const char *CalcDiscSCEx_BySYSTEMCNF(CDIF *c, unsigned *rr)
    fp = c->MakeStream(0, ~0U);
    fp->seek(0x8000, SEEK_SET);
 
+   try // Added this back to fix audio-cd loading issue
+   {
    do
    {
       if((pvd_search_count++) == 32)
@@ -1377,6 +1379,15 @@ static const char *CalcDiscSCEx_BySYSTEMCNF(CDIF *c, unsigned *rr)
          //puts("ASOFKOASDFKO");
       }
    }
+   } // try
+   catch(std::exception &e)
+   {
+      //
+   }
+      catch(...)
+   {
+   }
+       
 
 Breakout:
    if(fp)


### PR DESCRIPTION
Proposed fix for the crash that happens when loading a fuill audio cd (all tracks are audio, no mixed modes)
Original problem started here (you need to add/fix recover-raw.h though from a later commit)
https://github.com/libretro/beetle-psx-libretro/commit/3da0bba3d58994d1d46b13e3f4f87dadde3a884d

here's how i came up with this possible fix:
https://github.com/libretro/beetle-psx-libretro/issues/227#issuecomment-456209778

This does cause to generate a few lines like **Attempt to read LBA -5, >= LBA 225249** but not to much that its continous. Only happens when loading audiocd (or probably when track 1 is AUDIO type)

~~One other issue is that with this fix it does directly load AudioCD and go into the cdplayer in the bios, but the framerate there is unstable causing audio problems on playback, but when playing this on VIB Ribbon (where the inpiration came to find a fix or workaround for this), the audio playback is OK, clean and correct tempo.~~ (this was an error in my testing and playback should work whichever region/bios you use)

This does not cause problems with other games that i have so far (but i havent played or finished a game yet, and since this fix is somewhat a revert of what it originally was its probably not that big issue, hopefully).

For review and possible better solution:
@twinaphex @simias and @rz5 and anyone who is involved/interested
