### PR TITLE
Remove HW-specific core options from SW build

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -2799,28 +2799,35 @@ static void check_variables(bool startup)
    {
       var.key = BEETLE_OPT(renderer);
 
-      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value && !strcmp(var.value, "software"))
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       {
-         var.key = BEETLE_OPT(internal_resolution);
-
-         if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+         if (!strcmp(var.value, "software"))
          {
-            uint8_t new_upscale_shift;
-            uint8_t val = atoi(var.value);
+            var.key = BEETLE_OPT(internal_resolution);
 
-            // Upscale must be a power of two
-            assert((val & (val - 1)) == 0);
+            if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+            {
+               uint8_t new_upscale_shift;
+               uint8_t val = atoi(var.value);
 
-            // Crappy "ffs" implementation since the standard function is not
-            // widely supported by libc in the wild
-            for (new_upscale_shift = 0; (val & 1) == 0; ++new_upscale_shift)
-               val >>= 1;
-            psx_gpu_upscale_shift = new_upscale_shift;
+               // Upscale must be a power of two
+               assert((val & (val - 1)) == 0);
+
+               // Crappy "ffs" implementation since the standard function is not
+               // widely supported by libc in the wild
+               for (new_upscale_shift = 0; (val & 1) == 0; ++new_upscale_shift)
+                  val >>= 1;
+               psx_gpu_upscale_shift = new_upscale_shift;
+            }
+            else
+               psx_gpu_upscale_shift = 0;
          }
          else
             psx_gpu_upscale_shift = 0;
       }
       else
+         /* If 'BEETLE_OPT(renderer)' option is not found, then
+          * we are running in software mode */
          psx_gpu_upscale_shift = 0;
    }
    else

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -50,27 +50,6 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "enabled"
    },
-#else
-   {
-      BEETLE_OPT(renderer),
-      "Renderer (restart)",
-      "Choose which video renderer will be used. Software is the most accurate renderer. However, it is also the most demanding renderer at higher resolutions than native",
-      {
-         { "software",      "Software" },
-         { NULL, NULL },
-      },
-      "software"
-   },
-   {
-      BEETLE_OPT(renderer_software_fb),
-      "Software framebuffer",
-      "If off, the software renderer will skip some steps. Potential speedup. Causes bad graphics when doing framebuffer readbacks.",
-      {
-         { "enabled",   NULL },
-         { NULL, NULL },
-      },
-      "enabled"
-   },
 #endif
 #ifdef HAVE_VULKAN
    {

--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -1509,6 +1509,10 @@ static bool retro_refresh_variables(GlRenderer *renderer)
       else
          has_software_fb = false;
    }
+   else
+      /* If 'BEETLE_OPT(renderer_software_fb)' option is not found, then
+       * we are running in software mode */
+      has_software_fb = true;
 
    get_variables(&upscaling, &display_vram);
 
@@ -2967,6 +2971,10 @@ static void rsx_vulkan_refresh_variables(void)
       else
          has_software_fb = false;
    }
+   else
+      /* If 'BEETLE_OPT(renderer_software_fb)' option is not found, then
+       * we are running in software mode */
+      has_software_fb = true;
 
    unsigned old_scaling = scaling;
    unsigned old_msaa = msaa;
@@ -3411,8 +3419,14 @@ bool rsx_intf_open(bool is_pal, bool force_software)
    var.key                   = BEETLE_OPT(renderer);
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
       if (!strcmp(var.value, "software") || force_software)
          software_selected = true;
+   }
+   else
+      /* If 'BEETLE_OPT(renderer)' option is not found, then
+       * we are running in software mode */
+      software_selected = true;
 
 #if defined(HAVE_VULKAN)
    if (!software_selected && rsx_vulkan_open(is_pal))


### PR DESCRIPTION
This PR removes the hardware-specific core options `Renderer (restart)` and `Software framebuffer` from the non-hardware build (since they serve no purpose for the non-hardware build)

This fixes the display of core options when running the non-hardware build using frontends that require the old v0 core options API.