### PR TITLE
Update core options sublabels

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3863,11 +3863,12 @@ void retro_run(void)
 
       if (crop_overscan)
       {
-         // 320 width -> 350 width.
-         // 364 width -> 400 width.
-         // 256 width -> 280 width.
+         // Crop total # of pixels output by PSX in active scanline region down to # of pixels in corresponding horizontal display mode
+         // 280 width -> 256 width.
+         // 350 width -> 320 width.
+         // 400 width -> 364 width.
          // 560 width -> 512 width.
-         // 640 width -> 700 width.
+         // 700 width -> 640 width.
          // Rectify this.
          switch (width)
          {

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -55,7 +55,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       BEETLE_OPT(renderer),
       "Renderer (Restart)",
-      "Choose video renderer. 'Software' is the most accurate but has the highest performance requirements when running at increased internal GPU resolutions. 'Hardware' selects automatically the 'OpenGL' or 'Vulkan' renderer, depending upon the current RetroArch video driver setting. While less accurate, these renderers improve performance and enable various enhancements such as texture filtering and perspective correction. Core will automatically fall back to the software renderer if 'Hardware' is selected but the RetroArch video driver is not set to Vulkan or an OpenGL 3.3-compatible driver.",
+      "Choose video renderer. 'Software' is the most accurate but has the highest performance requirements when running at increased internal GPU resolutions. 'Hardware' automatically selects the 'Vulkan' or 'OpenGL' renderer depending upon the current libretro frontend video driver. If the provided video driver is not Vulkan or OpenGL 3.3-compatible then the core will fall back to the software renderer. While less accurate, the hardware renderers improve performance and enable various enhancements such as texture filtering and perspective correction.",
       {
          { "hardware", "Hardware" },
          { "software", "Software" },
@@ -405,7 +405,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       BEETLE_OPT(image_offset),
       "Offset Cropped Image",
-      "When 'Crop Overscan' is enabled, allows the resultant cropped image to be offset horizontally to the right by the specified number of pixels. May be used to correct alignment issues. As with 'Crop Overscan', currently only supported by the software renderer.",
+      "When 'Crop Overscan' is enabled, allows the resultant cropped image to be offset horizontally to the right (positive) or left (negative) by the specified number of pixels. May be used to correct alignment issues. As with 'Crop Overscan', currently only supported by the software renderer.",
       {
          { "disabled", NULL },
          { "-4 px",    NULL },

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -55,7 +55,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       BEETLE_OPT(renderer),
       "Renderer (Restart)",
-      "Choose video renderer. 'Software' is the most accurate but has the highest performance requirements when running at increased internal GPU resolutions. 'Hardware' selects automatically the 'OpenGL' or 'Vulkan' renderer, depending upon the current RetroArch video driver setting. While less accurate, these renderers improve performance and enable various enhancements such as texture filtering and perspective correction.",
+      "Choose video renderer. 'Software' is the most accurate but has the highest performance requirements when running at increased internal GPU resolutions. 'Hardware' selects automatically the 'OpenGL' or 'Vulkan' renderer, depending upon the current RetroArch video driver setting. While less accurate, these renderers improve performance and enable various enhancements such as texture filtering and perspective correction. Core will automatically fall back to the software renderer if 'Hardware' is selected but the RetroArch video driver is not set to Vulkan or an OpenGL 3.3-compatible driver.",
       {
          { "hardware", "Hardware" },
          { "software", "Software" },
@@ -261,7 +261,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       BEETLE_OPT(cpu_freq_scale),
       "CPU Frequency Scaling (Overclock)",
-      "Enable overclocking (or underclocking) of the emulated PSX's central processing unit. The default frequency of the MIPS R3000A-compatible 32-bit RISC CPU is 33.8688 MHz; running at higher frequencies can eliminate slowdown and improve frame rates in certain games at the expense of increased performance requirements. Note that some games have an internal frame rate limiter, and may not benefit from overclocking.",
+      "Enable overclocking (or underclocking) of the emulated PSX's central processing unit. The default frequency of the MIPS R3000A-compatible 32-bit RISC CPU is 33.8688 MHz; running at higher frequencies can eliminate slowdown and improve frame rates in certain games at the expense of increased performance requirements. Note that some games have an internal frame rate limiter, and may not benefit from overclocking. May cause certain effects to animate faster than intended in some titles when overclocked.",
       {
          { "50%",           NULL },
          { "60%",           NULL },
@@ -376,7 +376,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       BEETLE_OPT(crop_overscan),
       "Crop Overscan",
-      "By default, the core adds horizontal padding (black bars or 'pillarboxes' either side of the screen) to simulate the horizontal overscan region of the NTSC or PAL broadcast signal (this is normally hidden by the bezel around the edge of a standard-definition television). It does not, however, add padding to simulate *vertical* overscan. This means video output is horizontally compressed, and thus presented with an incorrect aspect ratio. When 'Crop Overscan' is enabled, the horizontal padding is automatically removed, ensuring correct display dimensions.",
+      "By default, the software renderer adds horizontal padding (black bars or 'pillarboxes' on either side of the screen) to emulate the same black bars generated in analog video output by real PSX hardware. Enabling 'Crop Overscan' will remove horizontal padding and stretch the remaining output to the full window width. This option does not affect vertical overscan. Currently only supported by the software renderer, as the hardware renderers will always output without pillarboxing.",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
@@ -387,7 +387,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       BEETLE_OPT(image_crop),
       "Additional Cropping",
-      "When 'Crop Overscan' is enabled, further reduces the width of the cropped image by the specified number of pixels. Note: This can have unintended consequences. While the absolute width is reduced, the resultant video is still scaled to the currently set aspect ratio. Enabling 'Additional Cropping' may therefore cause horizontal stretching.",
+      "When 'Crop Overscan' is enabled, this option further reduces the width of the cropped image by the specified number of pixels. Note: This can have unintended consequences. While the absolute width is reduced, the resultant video is still scaled to the currently set aspect ratio. Enabling 'Additional Cropping' may therefore cause horizontal stretching. As with 'Crop Overscan', currently only supported by the software renderer.",
       {
          { "disabled", NULL },
          { "1 px",     NULL },
@@ -405,7 +405,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       BEETLE_OPT(image_offset),
       "Offset Cropped Image",
-      "When 'Crop Overscan' is enabled, allows the resultant cropped image to be offset horizontally by the specified number of pixels. May be used to correct alignment issues.",
+      "When 'Crop Overscan' is enabled, allows the resultant cropped image to be offset horizontally to the right by the specified number of pixels. May be used to correct alignment issues. As with 'Crop Overscan', currently only supported by the software renderer.",
       {
          { "disabled", NULL },
          { "-4 px",    NULL },


### PR DESCRIPTION
This PR does the following:

1. Updates a few core option sublabels to be more descriptive, such as certain options not working with the hardware renderer at the moment
2. Removes some erroneous information regarding horizontal overscan cropping and rewrites that option sublabel
3. Fixes and clarifies overscan cropping comment in libretro.cpp (hopefully to aid in fixing a crop_overscan alignment issue; I'll open an issue for this when I have some more specifics I can point to)

Will follow up by updating the core's libretro doc page with pictures and better descriptions and open an issue for the aforementioned crop_overscan option in the near future.