### PR TITLE
Implement framebuffer height padding for GL renderer

### DIFF
--- a/mednafen/psx/gpu.cpp
+++ b/mednafen/psx/gpu.cpp
@@ -1122,6 +1122,7 @@ void GPU_Write(const int32_t timestamp, uint32_t A, uint32_t V)
             GPU_SoftReset();
              rsx_intf_set_draw_area(GPU.ClipX0, GPU.ClipY0,
                                     GPU.ClipX1, GPU.ClipY1);
+             rsx_intf_set_display_range(GPU.VertStart, GPU.VertEnd); //0x10, 0x100 set by GPU_SoftReset()
              UpdateDisplayMode();
             break;
 

--- a/rsx/rsx_dump.cpp
+++ b/rsx/rsx_dump.cpp
@@ -130,7 +130,15 @@ void rsx_dump_set_draw_area(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
    write_u32(y1);
 }
 
-void rsx_dump_set_display_mode(uint16_t x, uint16_t y, uint16_t w, uint16_t h, bool depth_24bpp)
+void rsx_dump_set_display_range(uint16_t y1, uint16_t y2)
+{
+   if (!file)
+      return;
+   write_u32(y1);
+   write_u32(y2);
+}
+
+void rsx_dump_set_display_mode(uint16_t x, uint16_t y, uint16_t w, uint16_t h, bool depth_24bpp, bool is_pal, bool is_480i)
 {
    if (!file)
       return;
@@ -140,6 +148,8 @@ void rsx_dump_set_display_mode(uint16_t x, uint16_t y, uint16_t w, uint16_t h, b
    write_u32(w);
    write_u32(h);
    write_u32(depth_24bpp);
+   write_u32(is_pal);
+   write_u32(is_480i);
 }
 
 void rsx_dump_triangle(const struct rsx_dump_vertex *vertices, const struct rsx_render_state *state)

--- a/rsx/rsx_dump.h
+++ b/rsx/rsx_dump.h
@@ -16,7 +16,8 @@ void rsx_dump_finalize_frame(void);
 void rsx_dump_set_tex_window(uint8_t tww, uint8_t twh, uint8_t twx, uint8_t twy);
 void rsx_dump_set_draw_offset(int16_t x, int16_t y);
 void rsx_dump_set_draw_area(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
-void rsx_dump_set_display_mode(uint16_t x, uint16_t y, uint16_t w, uint16_t h, bool depth_24bpp);
+void rsx_dump_set_display_range(uint16_t y1, uint16_t y2);
+void rsx_dump_set_display_mode(uint16_t x, uint16_t y, uint16_t w, uint16_t h, bool depth_24bpp, bool is_pal, bool is_480i);
 
 struct rsx_dump_vertex
 {

--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -224,6 +224,9 @@ struct DrawConfig
    int16_t  draw_offset[2];
    uint16_t draw_area_top_left[2];
    uint16_t draw_area_bot_right[2];
+   uint16_t display_area_yrange[2];
+   bool     is_pal;
+   bool     is_480i;
 };
 
 struct Texture
@@ -344,6 +347,9 @@ static DrawConfig persistent_config = {
    {0, 0},         /* draw_area_top_left */
    {0, 0},         /* draw_area_dimensions */
    {0, 0},         /* draw_offset */
+   {0, 0},         /* display_area_yrange (verify if these values are appropriate)*/ 
+   false,          /* is_pal */
+   false,          /* is_480i */
 };
 
 static RetroGl static_renderer;
@@ -1457,6 +1463,11 @@ static void bind_libretro_framebuffer(GlRenderer *renderer)
    float aspect_ratio = widescreen_hack ? 16.0 / 9.0 : 
       MEDNAFEN_CORE_GEOMETRY_ASPECT_RATIO;
 
+   /* Padding vars */
+   uint32_t unpadded_h;
+   uint32_t top_pad = 0;
+   uint32_t bottom_pad = 0;
+
    if (renderer->display_vram)
    {
       _w           = VRAM_WIDTH_PIXELS;
@@ -1464,9 +1475,41 @@ static void bind_libretro_framebuffer(GlRenderer *renderer)
       /* Is this accurate? */
       aspect_ratio = 2.0 / 1.0;
    }
+   else
+   {
+      /* Height padding for non-standard framebuffer heights 
+       *
+       * We check the config.is_pal set by UpdateDisplayMode 
+       * instead of querying content_is_pal since config.is_pal
+       * is a runtime GPU value while content_is_pal is only set
+       * at load time */
+
+      uint16_t first_line = renderer->config.is_pal ? 20 : 16;
+      uint16_t last_line = renderer->config.is_pal ? 308 : 256; //non-inclusive bound
+
+      if (renderer->config.display_area_yrange[0] > first_line) //check bounds
+         top_pad = (uint32_t) (renderer->config.display_area_yrange[0] - first_line);
+      if (renderer->config.display_area_yrange[1] < last_line)
+         bottom_pad = (uint32_t) (last_line - renderer->config.display_area_yrange[1]);
+
+      if (renderer->config.is_480i) //double padding if 480-line mode
+      {
+         top_pad *= 2;
+         bottom_pad *= 2;
+      }
+   }
 
    w       = (uint32_t) _w * upscale;
    h       = (uint32_t) _h * upscale;
+
+   //printf("VertStart = %3u, VertEnd = %3u\n", renderer->config.display_area_yrange[0], renderer->config.display_area_yrange[1]);
+   //printf("_w = %3u, _h = %3u, top_pad = %3u, bottom_pad = %3u\n", _w, _h, top_pad, bottom_pad);
+
+   /* Scale pad heights up and add to scaled height */
+   unpadded_h = h;
+   top_pad     *= upscale;
+   bottom_pad  *= upscale;
+   h += (top_pad + bottom_pad);
 
    if (w != f_w || h != f_h)
    {
@@ -1490,7 +1533,7 @@ static void bind_libretro_framebuffer(GlRenderer *renderer)
    /* Bind the output framebuffer provided by the frontend */
    fbo = glsm_get_current_framebuffer();
    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo);
-   glViewport(0, 0, (GLsizei) w, (GLsizei) h);
+   glViewport(0, (GLsizei) bottom_pad, (GLsizei) w, (GLsizei) unpadded_h);
 }
 
 static bool retro_refresh_variables(GlRenderer *renderer)
@@ -2144,6 +2187,12 @@ static void rsx_gl_finalize_frame(const void *fb, unsigned width,
    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
    glDisable(GL_DEPTH_TEST);
    glDisable(GL_BLEND);
+
+   /* Clear the screen no matter what: prevents possible leftover 
+      pixels from previous frame when loading save state for any 
+      games not using standard framebuffer heights */
+   glClearColor(0.0, 0.0, 0.0, 0.0);
+   glClear(GL_COLOR_BUFFER_BIT);
 
    /* If the display is off, just clear the screen */
    if (renderer->config.display_off && !renderer->display_vram)
@@ -3733,9 +3782,40 @@ void rsx_intf_set_draw_area(uint16_t x0, uint16_t y0,
    }
 }
 
+void rsx_intf_set_display_range(uint16_t y1, uint16_t y2)
+{
+   /* No corresponding rsx_dump at the moment,
+      implement rsx_dump_set_display_range */
+
+   switch (rsx_type)
+   {
+      case RSX_SOFTWARE:
+         break;
+      case RSX_OPENGL:
+#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
+         {
+            GlRenderer *renderer = static_renderer.state_data;
+            if (static_renderer.state != GlState_Invalid
+                  && renderer)
+            {
+               renderer->config.display_area_yrange[0] = y1;
+               renderer->config.display_area_yrange[1] = y2;
+            }
+         }
+#endif
+         break;
+      case RSX_VULKAN:
+         //implement me for Vulkan and set HAVE_VULKAN define check
+         break;
+   }
+}
+
+
 void rsx_intf_set_display_mode(uint16_t x, uint16_t y,
                                uint16_t w, uint16_t h,
-                               bool depth_24bpp)
+                               bool depth_24bpp,
+                               bool is_pal, 
+                               bool is_480i)
 {
 #ifdef RSX_DUMP
    rsx_dump_set_display_mode(x, y, w, h, depth_24bpp);
@@ -3758,6 +3838,9 @@ void rsx_intf_set_display_mode(uint16_t x, uint16_t y,
                renderer->config.display_resolution[0] = w;
                renderer->config.display_resolution[1] = h;
                renderer->config.display_24bpp         = depth_24bpp;
+
+               renderer->config.is_pal  = is_pal;
+               renderer->config.is_480i = is_480i;
             }
          }
 #endif

--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -347,7 +347,7 @@ static DrawConfig persistent_config = {
    {0, 0},         /* draw_area_top_left */
    {0, 0},         /* draw_area_dimensions */
    {0, 0},         /* draw_offset */
-   {0, 0},         /* display_area_yrange (verify if these values are appropriate)*/ 
+   {0x10, 0x100},  /* display_area_yrange (hardware reset values)*/ 
    false,          /* is_pal */
    false,          /* is_480i */
 };

--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -3784,8 +3784,9 @@ void rsx_intf_set_draw_area(uint16_t x0, uint16_t y0,
 
 void rsx_intf_set_display_range(uint16_t y1, uint16_t y2)
 {
-   /* No corresponding rsx_dump at the moment,
-      implement rsx_dump_set_display_range */
+#ifdef RSX_DUMP
+   rsx_dump_set_display_range(y1, y2);
+#endif
 
    switch (rsx_type)
    {
@@ -3818,7 +3819,7 @@ void rsx_intf_set_display_mode(uint16_t x, uint16_t y,
                                bool is_480i)
 {
 #ifdef RSX_DUMP
-   rsx_dump_set_display_mode(x, y, w, h, depth_24bpp);
+   rsx_dump_set_display_mode(x, y, w, h, depth_24bpp, is_pal, is_480i);
 #endif
 
    switch (rsx_type)

--- a/rsx/rsx_intf.h
+++ b/rsx/rsx_intf.h
@@ -45,9 +45,12 @@ void rsx_intf_set_mask_setting(uint32_t mask_set_or, uint32_t mask_eval_and);
 void rsx_intf_set_draw_offset(int16_t x, int16_t y);
 void rsx_intf_set_draw_area(uint16_t x0, uint16_t y0,
                             uint16_t x1, uint16_t y1);
+void rsx_intf_set_display_range(uint16_t y1, uint16_t y2);
 void rsx_intf_set_display_mode(uint16_t x, uint16_t y,
                                uint16_t w, uint16_t h,
-                               bool depth_24bpp);
+                               bool depth_24bpp,
+                               bool is_pal,
+                               bool is_480i);
 
 void rsx_intf_push_triangle(float p0x, float p0y, float p0w,
                             float p1x, float p1y, float p1w,


### PR DESCRIPTION
PR implements height padding for GL renderer. This fixes display height for games that don't draw to a full 240 lines framebuffer on original hardware and rely on what seems to be analog encoding to fill in the rest of the lines. Related to issue #525 though this PR only fixes it for the GL renderer and not the Vulkan one.

e.g. Wild Arms (draws to 232 height framebuffer)
**GL Renderer Before**: only framebuffer contents are displayed
![](https://user-images.githubusercontent.com/45282415/67061084-01011980-f114-11e9-9f60-3d0a0a85e8d4.png)

**GL Renderer After**: properly letterboxed
![](https://user-images.githubusercontent.com/45282415/67061176-59d0b200-f114-11e9-8b64-8bc0de71c2e3.png)


Some lingering issues with the implementation: ~~loading save states can cause previous pixels to remain in the extra padded height area (might need to always clear the screen in rsx_gl_finalize_frame before calling bind_libretro_framebuffer, I'll test this out soon)~~ fixed and initial/last scanline options not working (they never worked with the GL renderer anyway; just a TODO).