### PR TITLE
Remove conflicting PAL overscan crop code in SW renderer

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3900,16 +3900,6 @@ void retro_run(void)
                // This shouldn't happen.
                break;
          }
-
-
-         if (is_pal)
-         {
-            // Attempt to remove black bars.
-            // These numbers are arbitrary since the bars differ some by game.
-            // Changes aspect ratio in the process.
-            height -= 36;
-            pix_offset += 5 * (MEDNAFEN_CORE_GEOMETRY_MAX_W << 2);
-         }
       }
 
 


### PR DESCRIPTION
Reverts 236c81f

When `Crop Overscan` option is enabled, the software renderer tries to also automatically remove vertical overscan from PAL content, which it doesn't try to do for NTSC content. This automatic removal works kind of decently sometimes ([before crop](https://user-images.githubusercontent.com/45282415/67516084-d9024080-f654-11e9-9c77-f326f025e3d0.png), [after crop](https://user-images.githubusercontent.com/45282415/67516090-dacc0400-f654-11e9-970c-3a89ba1b2919.png)) but can also give really poor results other times ([before crop](https://user-images.githubusercontent.com/45282415/67516253-35656000-f655-11e9-97bc-67588b247411.png), [after crop](https://user-images.githubusercontent.com/45282415/67516260-37c7ba00-f655-11e9-87ed-ff5eea8d0ee7.png) - note the miscentered vertical cropping here).

This cropping behavior also conflicts with the `Initial/Last Scanline - PAL` options where those options aren't actually setting the first and last line to be displayed by the frontend anymore, just cropping additional lines off whatever `Crop Overscan` already removed.

Removing this code allows PAL content to have horizontal overscan cropping and vertical overscan cropping adjusted independently of each other in the `Crop Overscan` and `Initial/Last Scanline - PAL` options respectively.