### PR TITLE
Make sure has_software_fb is set by GLRenderer_new

### DIFF
--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -1196,6 +1196,17 @@ static bool GlRenderer_new(GlRenderer *renderer, DrawConfig config)
    if (!renderer)
       return false;
 
+   var.key = BEETLE_OPT(renderer_software_fb);
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "enabled"))
+         has_software_fb = true;
+      else
+         has_software_fb = false;
+   }
+   else
+      has_software_fb = true;
+
    get_variables(&upscaling, &display_vram);
 
    var.key = BEETLE_OPT(filter);


### PR DESCRIPTION
Fixes #246
Fixes #427 

`GLRenderer_new` method was not setting `has_software_fb`, meaning that regardless of what the option was set to by the user, the GL renderer would always start with the software framebuffer off. The software framebuffer would have to be forced on by toggling any core option, causing `retro_refresh_variables` to be called, which has a check for `renderer_software_fb` in it. This PR fixes this issue by making sure `renderer_software_fb` is checked and `has_software_fb` is appropriately set by `GLRenderer_new`.

Also fixes the BIOS screen glitches since it turns out the "Sony Computer Entertainment" text requires software framebuffer to be on.