### PR TITLE
Gl crop overscan accuracy additions

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3564,6 +3564,11 @@ bool retro_load_game(const struct retro_game_info *info)
          option_display.key = BEETLE_OPT(mdec_yuv);
          environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 
+         option_display.key = BEETLE_OPT(image_offset);
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+         option_display.key = BEETLE_OPT(image_crop);
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+
          break;
       }
       case RSX_VULKAN:
@@ -3576,6 +3581,22 @@ bool retro_load_game(const struct retro_game_info *info)
          option_display.key = BEETLE_OPT(wireframe);
          environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
          option_display.key = BEETLE_OPT(display_vram);
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+
+         option_display.key = BEETLE_OPT(crop_overscan);
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+         option_display.key = BEETLE_OPT(image_offset);
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+         option_display.key = BEETLE_OPT(image_crop);
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+
+         option_display.key = BEETLE_OPT(initial_scanline);
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+         option_display.key = BEETLE_OPT(last_scanline);
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+         option_display.key = BEETLE_OPT(initial_scanline_pal);
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+         option_display.key = BEETLE_OPT(last_scanline_pal);
          environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 
          break;

--- a/mednafen/psx/gpu.cpp
+++ b/mednafen/psx/gpu.cpp
@@ -555,10 +555,13 @@ static void UpdateDisplayMode(void)
 
    unsigned pixelclock_divider;
 
+   enum width_modes curr_width_mode;
+
    if ((GPU.DisplayMode >> 6) & 1)
    {
       // HRes ~ 368pixels
       pixelclock_divider = 7;
+      curr_width_mode = WIDTH_MODE_368;
    }
    else
    {
@@ -567,18 +570,22 @@ static void UpdateDisplayMode(void)
          case 0:
             // Hres ~ 256pixels
             pixelclock_divider = 10;
+            curr_width_mode = WIDTH_MODE_256;
             break;
          case 1:
             // Hres ~ 320pixels
             pixelclock_divider = 8;
+            curr_width_mode = WIDTH_MODE_320;
             break;
          case 2:
             // Hres ~ 512pixels
             pixelclock_divider = 5;
+            curr_width_mode = WIDTH_MODE_512;
             break;
          default:
             // Hres ~ 640pixels
             pixelclock_divider = 4;
+            curr_width_mode = WIDTH_MODE_640;
             break;
       }
    }
@@ -598,7 +605,8 @@ static void UpdateDisplayMode(void)
          xres, yres,
          depth_24bpp,
          is_pal_mode, 
-         is_480i_mode);
+         is_480i_mode,
+         curr_width_mode);
 }
 
 /* Forward decls */
@@ -1122,7 +1130,8 @@ void GPU_Write(const int32_t timestamp, uint32_t A, uint32_t V)
             GPU_SoftReset();
              rsx_intf_set_draw_area(GPU.ClipX0, GPU.ClipY0,
                                     GPU.ClipX1, GPU.ClipY1);
-             rsx_intf_set_display_range(GPU.VertStart, GPU.VertEnd); //0x10, 0x100 set by GPU_SoftReset()
+             rsx_intf_set_horizontal_display_range(GPU.HorizStart, GPU.HorizEnd); //0x200, 0xC00 set by GPU_SoftReset()
+             rsx_intf_set_vertical_display_range(GPU.VertStart, GPU.VertEnd); //0x10, 0x100 set by GPU_SoftReset()
              UpdateDisplayMode();
             break;
 
@@ -1156,12 +1165,13 @@ void GPU_Write(const int32_t timestamp, uint32_t A, uint32_t V)
          case 0x06:  // Horizontal display range
             GPU.HorizStart = V & 0xFFF;
             GPU.HorizEnd = (V >> 12) & 0xFFF;
+            rsx_intf_set_horizontal_display_range(GPU.HorizStart, GPU.HorizEnd);
             break;
 
          case 0x07:
             GPU.VertStart = V & 0x3FF;
             GPU.VertEnd = (V >> 10) & 0x3FF;
-            rsx_intf_set_display_range(GPU.VertStart, GPU.VertEnd);
+            rsx_intf_set_vertical_display_range(GPU.VertStart, GPU.VertEnd);
             break;
 
          case 0x08:
@@ -1866,7 +1876,8 @@ void GPU_RestoreStateP3(void)
                         1024, 512,
                         GPU.vram, false, false);
 
-   rsx_intf_set_display_range(GPU.VertStart, GPU.VertEnd);
+   rsx_intf_set_horizontal_display_range(GPU.HorizStart, GPU.HorizEnd);
+   rsx_intf_set_vertical_display_range(GPU.VertStart, GPU.VertEnd);
 
    UpdateDisplayMode();
 }

--- a/rsx/rsx_dump.cpp
+++ b/rsx/rsx_dump.cpp
@@ -130,7 +130,15 @@ void rsx_dump_set_draw_area(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
    write_u32(y1);
 }
 
-void rsx_dump_set_display_range(uint16_t y1, uint16_t y2)
+void rsx_dump_set_horizontal_display_range(uint16_t x1, uint16_t x2);
+{
+   if (!file)
+      return;
+   write_u32(x1);
+   write_u32(x2);
+}
+
+void rsx_dump_set_vertical_display_range(uint16_t y1, uint16_t y2);
 {
    if (!file)
       return;
@@ -138,7 +146,7 @@ void rsx_dump_set_display_range(uint16_t y1, uint16_t y2)
    write_u32(y2);
 }
 
-void rsx_dump_set_display_mode(uint16_t x, uint16_t y, uint16_t w, uint16_t h, bool depth_24bpp, bool is_pal, bool is_480i)
+void rsx_dump_set_display_mode(uint16_t x, uint16_t y, uint16_t w, uint16_t h, bool depth_24bpp, bool is_pal, bool is_480i, int width_mode)
 {
    if (!file)
       return;
@@ -150,6 +158,7 @@ void rsx_dump_set_display_mode(uint16_t x, uint16_t y, uint16_t w, uint16_t h, b
    write_u32(depth_24bpp);
    write_u32(is_pal);
    write_u32(is_480i);
+   write_u32(width_mode);
 }
 
 void rsx_dump_triangle(const struct rsx_dump_vertex *vertices, const struct rsx_render_state *state)

--- a/rsx/rsx_dump.h
+++ b/rsx/rsx_dump.h
@@ -16,8 +16,9 @@ void rsx_dump_finalize_frame(void);
 void rsx_dump_set_tex_window(uint8_t tww, uint8_t twh, uint8_t twx, uint8_t twy);
 void rsx_dump_set_draw_offset(int16_t x, int16_t y);
 void rsx_dump_set_draw_area(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
-void rsx_dump_set_display_range(uint16_t y1, uint16_t y2);
-void rsx_dump_set_display_mode(uint16_t x, uint16_t y, uint16_t w, uint16_t h, bool depth_24bpp, bool is_pal, bool is_480i);
+void rsx_dump_set_horizontal_display_range(uint16_t x1, uint16_t x2);
+void rsx_dump_set_vertical_display_range(uint16_t y1, uint16_t y2);
+void rsx_dump_set_display_mode(uint16_t x, uint16_t y, uint16_t w, uint16_t h, bool depth_24bpp, bool is_pal, bool is_480i, int width_mode);
 
 struct rsx_dump_vertex
 {

--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -1551,10 +1551,8 @@ static void bind_libretro_framebuffer(GlRenderer *renderer)
       uint16_t first_line = renderer->config.is_pal ? 20 : 16;
       uint16_t last_line = renderer->config.is_pal ? 308 : 256; //non-inclusive bound
 
-      if (renderer->config.display_area_yrange[0] > first_line) //check bounds
-         top_pad = (int32_t) (renderer->config.display_area_yrange[0] - first_line);
-      if (renderer->config.display_area_yrange[1] < last_line)
-         bottom_pad = (int32_t) (last_line - renderer->config.display_area_yrange[1]);
+      top_pad = (int32_t) (renderer->config.display_area_yrange[0] - first_line);
+      bottom_pad = (int32_t) (last_line - renderer->config.display_area_yrange[1]);
 
       top_pad -= (renderer->config.is_pal ? renderer->initial_scanline_pal : renderer->initial_scanline);
       bottom_pad -= (renderer->config.is_pal ? 287 - renderer->last_scanline_pal : 239 - renderer->last_scanline);

--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -224,7 +224,8 @@ struct DrawConfig
    int16_t  draw_offset[2];
    uint16_t draw_area_top_left[2];
    uint16_t draw_area_bot_right[2];
-   uint16_t display_area_yrange[2];
+   uint16_t display_area_hrange[2];
+   uint16_t display_area_vrange[2];
    bool     is_pal;
    bool     is_480i;
 };
@@ -330,9 +331,13 @@ struct GlRenderer {
     * the visible area */
    bool display_vram;
 
+   /* Display Mode - GP1(08h) */
+   enum width_modes curr_width_mode;
+
    /* When true we perform no horizontal padding */
    bool crop_overscan;
 
+   /* Scanline core options */
    int32_t initial_scanline;
    int32_t initial_scanline_pal;
    int32_t last_scanline;
@@ -355,7 +360,8 @@ static DrawConfig persistent_config = {
    {0, 0},         /* draw_area_top_left */
    {0, 0},         /* draw_area_dimensions */
    {0, 0},         /* draw_offset */
-   {0x10, 0x100},  /* display_area_yrange (hardware reset values)*/ 
+   {0x200, 0xC00}, /* display_area_hrange (hardware reset values)*/
+   {0x10, 0x100},  /* display_area_vrange (hardware reset values)*/ 
    false,          /* is_pal */
    false,          /* is_480i */
 };
@@ -1423,6 +1429,7 @@ static bool GlRenderer_new(GlRenderer *renderer, DrawConfig config)
    renderer->internal_upscaling = upscaling;
    renderer->internal_color_depth = depth;
    renderer->crop_overscan = crop_overscan;
+   renderer->curr_width_mode = WIDTH_MODE_320;
    renderer->initial_scanline = initial_scanline;
    renderer->last_scanline = last_scanline;
    renderer->initial_scanline_pal = initial_scanline_pal;
@@ -1530,7 +1537,8 @@ static void bind_libretro_framebuffer(GlRenderer *renderer)
    uint32_t unpadded_h;
    int32_t top_pad = 0;
    int32_t bottom_pad = 0;
-   uint32_t left_pad = 0;
+   int32_t left_pad = 0;
+   int32_t right_pad = 0;
 
    if (renderer->display_vram)
    {
@@ -1551,8 +1559,8 @@ static void bind_libretro_framebuffer(GlRenderer *renderer)
       uint16_t first_line = renderer->config.is_pal ? 20 : 16;
       uint16_t last_line = renderer->config.is_pal ? 308 : 256; //non-inclusive bound
 
-      top_pad = (int32_t) (renderer->config.display_area_yrange[0] - first_line);
-      bottom_pad = (int32_t) (last_line - renderer->config.display_area_yrange[1]);
+      top_pad = (int32_t) (renderer->config.display_area_vrange[0] - first_line);
+      bottom_pad = (int32_t) (last_line - renderer->config.display_area_vrange[1]);
 
       top_pad -= (renderer->config.is_pal ? renderer->initial_scanline_pal : renderer->initial_scanline);
       bottom_pad -= (renderer->config.is_pal ? 287 - renderer->last_scanline_pal : 239 - renderer->last_scanline);
@@ -1563,49 +1571,52 @@ static void bind_libretro_framebuffer(GlRenderer *renderer)
          bottom_pad *= 2;
       }
 
-      /* Overscan cropping code
-       * Centers PAL games, but on real hardware PAL games are often times miscentered.
-       * Need to use horizontal display range if we want real miscentered behavior, but
-       * real behavior might be undesired for emulation. */
+      /* Overscan cropping code */
       if (!renderer->crop_overscan) //reverse case of software renderer: here we calculate how much padding to add, rather than how much to remove
       {
-         switch (_w)
+         int32_t pix_clk;
+         switch (renderer->curr_width_mode)
          {
-            case 256:
-               left_pad = 12;
+            case WIDTH_MODE_256:
+               pix_clk = 10;
                break;
 
-            case 320:
-               left_pad = 15;
+            case WIDTH_MODE_320:
+               pix_clk = 8;
                break;
 
-            /* The unusual case: 368px mode. Width is 364 for
-             * typical 368 mode games. Technically should have
-             * something like 1.7 blank pixels more on the
-             * right-hand side but not super important for
-             * emulation. Some games using this mode might bug
-             * out or not get padded at all, needs further 
-             * testing.*/
-            case 364:
-               left_pad = 16;
+            case WIDTH_MODE_512:
+               pix_clk = 5;
                break;
 
-            case 512:
-               left_pad = 24;
+            case WIDTH_MODE_640:
+               pix_clk = 4;
                break;
 
-            case 640:
-               left_pad = 30;
+            /* The unusual case: 368px mode. Width is 364 px for
+             * typical 368 mode games but often times something
+             * different, which necessitates checking width mode 
+             * rather than calculated pixel width */
+            case WIDTH_MODE_368:
+               pix_clk = 7;
+               break;
+
+            default: //should never be here -- if we're here, something is terribly wrong
                break;
          }
+         int32_t line_width = 2800 / pix_clk; //width of line measured in pixels outputted by psx
+         left_pad = (renderer->config.display_area_hrange[0] - 488) / pix_clk;
+         right_pad = line_width - ((renderer->config.display_area_hrange[1] - 488) / pix_clk);
       }
    }
 
    w       = (uint32_t) _w * upscale;
    h       = (uint32_t) _h * upscale;
 
-   //printf("VertStart = %3u, VertEnd = %3u\n", renderer->config.display_area_yrange[0], renderer->config.display_area_yrange[1]);
+   //printf("VertStart = %3u, VertEnd = %3u\n", renderer->config.display_area_vrange[0], renderer->config.display_area_vrange[1]);
    //printf("_w = %3d, _h = %3d, top_pad = %3d, bottom_pad = %3d\n", _w, _h, top_pad, bottom_pad);
+   //printf("HorizStart = %4u, HorizEnd = %4u\n", renderer->config.display_area_hrange[0], renderer->config.display_area_hrange[1]);
+   //printf("_w = %3d, left_pad = %3d, right_pad = %3d\n", _w, left_pad, right_pad);
 
    /* Scale pad heights up and add to scaled height */
    unpadded_h = h;
@@ -1616,7 +1627,8 @@ static void bind_libretro_framebuffer(GlRenderer *renderer)
    /* Scale horizontal padding up and add to scaled width */
    unpadded_w = w;
    left_pad *= upscale;
-   w += (2 * left_pad);
+   right_pad *= upscale;
+   w += (left_pad + right_pad);
 
    if (w != f_w || h != f_h)
    {
@@ -3932,10 +3944,10 @@ void rsx_intf_set_draw_area(uint16_t x0, uint16_t y0,
    }
 }
 
-void rsx_intf_set_display_range(uint16_t y1, uint16_t y2)
+void rsx_intf_set_horizontal_display_range(uint16_t x1, uint16_t x2)
 {
 #ifdef RSX_DUMP
-   rsx_dump_set_display_range(y1, y2);
+   rsx_dump_set_horizontal_display_range(x1, x2);
 #endif
 
    switch (rsx_type)
@@ -3949,8 +3961,37 @@ void rsx_intf_set_display_range(uint16_t y1, uint16_t y2)
             if (static_renderer.state != GlState_Invalid
                   && renderer)
             {
-               renderer->config.display_area_yrange[0] = y1;
-               renderer->config.display_area_yrange[1] = y2;
+               renderer->config.display_area_hrange[0] = x1;
+               renderer->config.display_area_hrange[1] = x2;
+            }
+         }
+#endif
+         break;
+      case RSX_VULKAN:
+         //implement me for Vulkan and set HAVE_VULKAN define check
+         break;
+   }
+}
+
+void rsx_intf_set_vertical_display_range(uint16_t y1, uint16_t y2)
+{
+#ifdef RSX_DUMP
+   rsx_dump_set_vertical_display_range(y1, y2);
+#endif
+
+   switch (rsx_type)
+   {
+      case RSX_SOFTWARE:
+         break;
+      case RSX_OPENGL:
+#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
+         {
+            GlRenderer *renderer = static_renderer.state_data;
+            if (static_renderer.state != GlState_Invalid
+                  && renderer)
+            {
+               renderer->config.display_area_vrange[0] = y1;
+               renderer->config.display_area_vrange[1] = y2;
             }
          }
 #endif
@@ -3966,10 +4007,11 @@ void rsx_intf_set_display_mode(uint16_t x, uint16_t y,
                                uint16_t w, uint16_t h,
                                bool depth_24bpp,
                                bool is_pal, 
-                               bool is_480i)
+                               bool is_480i,
+                               int width_mode)
 {
 #ifdef RSX_DUMP
-   rsx_dump_set_display_mode(x, y, w, h, depth_24bpp, is_pal, is_480i);
+   rsx_dump_set_display_mode(x, y, w, h, depth_24bpp, is_pal, is_480i, width_mode);
 #endif
 
    switch (rsx_type)
@@ -3992,6 +4034,8 @@ void rsx_intf_set_display_mode(uint16_t x, uint16_t y,
 
                renderer->config.is_pal  = is_pal;
                renderer->config.is_480i = is_480i;
+
+               renderer->curr_width_mode = (enum width_modes) width_mode;
             }
          }
 #endif

--- a/rsx/rsx_intf.h
+++ b/rsx/rsx_intf.h
@@ -26,6 +26,15 @@ enum blending_modes
    BLEND_MODE_ADD_FOURTH =  3
 };
 
+enum width_modes
+{
+    WIDTH_MODE_256 = 0,
+    WIDTH_MODE_320,
+    WIDTH_MODE_512,
+    WIDTH_MODE_640,
+    WIDTH_MODE_368
+};
+
 void rsx_intf_set_environment(retro_environment_t cb);
 void rsx_intf_set_video_refresh(retro_video_refresh_t cb);
 void rsx_intf_get_system_av_info(struct retro_system_av_info *info);
@@ -45,12 +54,14 @@ void rsx_intf_set_mask_setting(uint32_t mask_set_or, uint32_t mask_eval_and);
 void rsx_intf_set_draw_offset(int16_t x, int16_t y);
 void rsx_intf_set_draw_area(uint16_t x0, uint16_t y0,
                             uint16_t x1, uint16_t y1);
-void rsx_intf_set_display_range(uint16_t y1, uint16_t y2);
+void rsx_intf_set_horizontal_display_range(uint16_t x1, uint16_t x2);
+void rsx_intf_set_vertical_display_range(uint16_t y1, uint16_t y2);
 void rsx_intf_set_display_mode(uint16_t x, uint16_t y,
                                uint16_t w, uint16_t h,
                                bool depth_24bpp,
                                bool is_pal,
-                               bool is_480i);
+                               bool is_480i,
+                               int width_mode); //enum
 
 void rsx_intf_push_triangle(float p0x, float p0y, float p0w,
                             float p1x, float p1y, float p1w,


### PR DESCRIPTION
PR does three things:

1. Hides overscan and scanline options currently not respected by each hardware renderer

2. Minor fix to properly handle games that try to display outside of the visible scanline region

3. Brings the GL renderer's **Crop Overscan: Off** to almost the same accuracy level as the Software Renderer's **Crop Overscan: Off** (barring differences related to the sw renderer updating on a scanline granularity versus the hw renderer copying the emulated vram fb as a texture)

Point number three was accomplished by modifying `UpdateDisplayMode()` and by extension `rsx_intf_set_display_mode()` to pass down an enum containing the width mode of the image to the renderer, analogous to how the GP1(08h) command sets a width mode of the image. This gives us a more reliable method for detecting the width mode of the image instead of using the unreliable `_w` variable as a heuristic. 

`rsx_intf_set_horizontal_display_range()` method was also added, which passes the horizontal start/end values down to the hw renderers and allows us to calculate how much horizontal padding is needed on each side at cycles-to-pixels granularity.