### PR TITLE
Implement display range code for Vulkan renderer

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3583,8 +3583,6 @@ bool retro_load_game(const struct retro_game_info *info)
          option_display.key = BEETLE_OPT(display_vram);
          environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 
-         option_display.key = BEETLE_OPT(crop_overscan);
-         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
          option_display.key = BEETLE_OPT(image_offset);
          environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
          option_display.key = BEETLE_OPT(image_crop);

--- a/parallel-psx/main.cpp
+++ b/parallel-psx/main.cpp
@@ -443,8 +443,12 @@ static bool read_command(const CLIArguments &args, FILE *file, Device &device, R
 		auto w = read_u32(file);
 		auto h = read_u32(file);
 		auto depth_24bpp = read_u32(file);
+		auto is_pal = readu32(file);
+		auto is_480i = readu32(file);
+		auto width_mode = readu32(file);
 
-		renderer.set_display_mode({ x, y, w, h }, depth_24bpp != 0);
+		renderer.set_display_mode({ x, y, w, h }, depth_24bpp != 0, is_pal != 0, is_480i != 0,
+		                          static_cast<Renderer::WidthMode>(width_mode));
 		break;
 	}
 


### PR DESCRIPTION
Should be safe to merge, but I'll leave open to feedback for a bit.

There's two issues, one that's newly introduced and one that's a preexisting issue. 

The newly introduced issue is that with Crop Overscan **Off**, if a game tries to scroll itself outside of the maximum displayable horizontal area (e.g. when doing screen adjustment in Tomb Raider II) there's some minor flickering alongside the edge it's scrolling out of, possibly due to some rounding error logic that was already in the hardware renderer code. I'll look into this but it's not a priority as no game should really be displaying that close to the edge unless it's programmed poorly or it's trying to do screen adjustment for poorly calibrated CRTs.

The preexisting issue is that this implementation does not respect the horizontal display range values when Crop Overscan is **On**. This isn't a regression, just something that hasn't been fully implemented even for the GL renderer. Most games don't adjust the horizontal display range so the current behavior covers most cases but this is something to look into for future improvements.

Resolves #346 , resolves #495 , and resolves #525.