### PR TITLE
Options cleanup & various miscellaneous fixes

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -1,4 +1,3 @@
-
 #include "libretro.h"
 #include "mednafen/mednafen-types.h"
 #include <math.h>
@@ -54,10 +53,10 @@ static int negcon_linearity = 1;
 
 typedef union
 {
-	uint8_t u8[ 10 * sizeof( uint32_t ) ];
-	uint32_t u32[ 10 ]; /* 1 + 8 + 1 */
-	uint16_t gun_pos[ 2 ];
-	uint16_t buttons;
+   uint8_t u8[ 10 * sizeof( uint32_t ) ];
+   uint32_t u32[ 10 ]; /* 1 + 8 + 1 */
+   uint16_t gun_pos[ 2 ];
+   uint16_t buttons;
 }
 INPUT_DATA;
 
@@ -66,9 +65,9 @@ static INPUT_DATA input_data[ MAX_CONTROLLERS ] = {0};
 
 struct analog_calibration
 {
-	float left;
-	float right;
-	float twist;
+   float left;
+   float right;
+   float twist;
 };
 
 static struct analog_calibration analog_calibration[MAX_CONTROLLERS];
@@ -94,45 +93,45 @@ enum { INPUT_DEVICE_TYPES_COUNT = 1 /*none*/ + 8 }; // <-- update me!
 
 static const struct retro_controller_description input_device_types[ INPUT_DEVICE_TYPES_COUNT ] =
 {
-	{ "PlayStation Controller", RETRO_DEVICE_JOYPAD },
-	{ "DualShock", RETRO_DEVICE_PS_DUALSHOCK },
-	{ "Analog Controller", RETRO_DEVICE_PS_ANALOG },
-	{ "Analog Joystick", RETRO_DEVICE_PS_ANALOG_JOYSTICK },
-	{ "Guncon / G-Con 45", RETRO_DEVICE_PS_GUNCON },
-	{ "Justifier", RETRO_DEVICE_PS_JUSTIFIER },
-	{ "Mouse", RETRO_DEVICE_PS_MOUSE },
-	{ "neGcon", RETRO_DEVICE_PS_NEGCON },
-	{ NULL, 0 },
+   { "PlayStation Controller", RETRO_DEVICE_JOYPAD },
+   { "DualShock", RETRO_DEVICE_PS_DUALSHOCK },
+   { "Analog Controller", RETRO_DEVICE_PS_ANALOG },
+   { "Analog Joystick", RETRO_DEVICE_PS_ANALOG_JOYSTICK },
+   { "Guncon / G-Con 45", RETRO_DEVICE_PS_GUNCON },
+   { "Justifier", RETRO_DEVICE_PS_JUSTIFIER },
+   { "Mouse", RETRO_DEVICE_PS_MOUSE },
+   { "neGcon", RETRO_DEVICE_PS_NEGCON },
+   { NULL, 0 },
 };
 
 static const struct retro_controller_info ports8[ 8 + 1 ] =
 {
-	{ input_device_types, INPUT_DEVICE_TYPES_COUNT },
-	{ input_device_types, INPUT_DEVICE_TYPES_COUNT },
-	{ input_device_types, INPUT_DEVICE_TYPES_COUNT },
-	{ input_device_types, INPUT_DEVICE_TYPES_COUNT },
-	{ input_device_types, INPUT_DEVICE_TYPES_COUNT },
-	{ input_device_types, INPUT_DEVICE_TYPES_COUNT },
-	{ input_device_types, INPUT_DEVICE_TYPES_COUNT },
-	{ input_device_types, INPUT_DEVICE_TYPES_COUNT },
-	{ 0 },
+   { input_device_types, INPUT_DEVICE_TYPES_COUNT },
+   { input_device_types, INPUT_DEVICE_TYPES_COUNT },
+   { input_device_types, INPUT_DEVICE_TYPES_COUNT },
+   { input_device_types, INPUT_DEVICE_TYPES_COUNT },
+   { input_device_types, INPUT_DEVICE_TYPES_COUNT },
+   { input_device_types, INPUT_DEVICE_TYPES_COUNT },
+   { input_device_types, INPUT_DEVICE_TYPES_COUNT },
+   { input_device_types, INPUT_DEVICE_TYPES_COUNT },
+   { 0 },
 };
 
 static const struct retro_controller_info ports5[ 5 + 1 ] =
 {
-	{ input_device_types, INPUT_DEVICE_TYPES_COUNT },
-	{ input_device_types, INPUT_DEVICE_TYPES_COUNT },
-	{ input_device_types, INPUT_DEVICE_TYPES_COUNT },
-	{ input_device_types, INPUT_DEVICE_TYPES_COUNT },
-	{ input_device_types, INPUT_DEVICE_TYPES_COUNT },
-	{ 0 },
+   { input_device_types, INPUT_DEVICE_TYPES_COUNT },
+   { input_device_types, INPUT_DEVICE_TYPES_COUNT },
+   { input_device_types, INPUT_DEVICE_TYPES_COUNT },
+   { input_device_types, INPUT_DEVICE_TYPES_COUNT },
+   { input_device_types, INPUT_DEVICE_TYPES_COUNT },
+   { 0 },
 };
 
 static const struct retro_controller_info ports2[ 2 + 1 ] =
 {
-	{ input_device_types, INPUT_DEVICE_TYPES_COUNT },
-	{ input_device_types, INPUT_DEVICE_TYPES_COUNT },
-	{ 0 },
+   { input_device_types, INPUT_DEVICE_TYPES_COUNT },
+   { input_device_types, INPUT_DEVICE_TYPES_COUNT },
+   { 0 },
 };
 
 
@@ -144,42 +143,42 @@ static const struct retro_controller_info ports2[ 2 + 1 ] =
 enum { INPUT_MAP_CONTROLLER_SIZE = 16 };
 static const unsigned input_map_controller[ INPUT_MAP_CONTROLLER_SIZE ] =
 {
-	// libretro input				 at position	|| maps to PS1			on bit
-	//-----------------------------------------------------------------------------
+ // libretro input                  at position   || maps to PS1         on bit
+ //-----------------------------------------------------------------------------
 #ifdef MSB_FIRST
-	RETRO_DEVICE_ID_JOYPAD_L2,		// L-trigger	-> L2
-	RETRO_DEVICE_ID_JOYPAD_R2,		// R-trigger	-> R2
-	RETRO_DEVICE_ID_JOYPAD_L,		// L-shoulder	-> L1
-	RETRO_DEVICE_ID_JOYPAD_R,		// R-shoulder	-> R1
-	RETRO_DEVICE_ID_JOYPAD_X,		// X(top)		-> Triangle
-	RETRO_DEVICE_ID_JOYPAD_A,		// A(right)		-> Circle
-	RETRO_DEVICE_ID_JOYPAD_B,		// B(down)		-> Cross
-	RETRO_DEVICE_ID_JOYPAD_Y,		// Y(left)		-> Square
-	RETRO_DEVICE_ID_JOYPAD_SELECT,	// Select		-> Select
-	RETRO_DEVICE_ID_JOYPAD_L3,		// L-thumb		-> L3
-	RETRO_DEVICE_ID_JOYPAD_R3,		// R-thumb		-> R3
-	RETRO_DEVICE_ID_JOYPAD_START,	// Start		-> Start
-	RETRO_DEVICE_ID_JOYPAD_UP,		// Pad-Up		-> Pad-Up
-	RETRO_DEVICE_ID_JOYPAD_RIGHT,	// Pad-Right	-> Pad-Right
-	RETRO_DEVICE_ID_JOYPAD_DOWN,	// Pad-Down		-> Pad-Down
-	RETRO_DEVICE_ID_JOYPAD_LEFT,	// Pad-Left		-> Pad-Left
+   RETRO_DEVICE_ID_JOYPAD_L2,       // L-trigger    -> L2
+   RETRO_DEVICE_ID_JOYPAD_R2,       // R-trigger    -> R2
+   RETRO_DEVICE_ID_JOYPAD_L,        // L-shoulder   -> L1
+   RETRO_DEVICE_ID_JOYPAD_R,        // R-shoulder   -> R1
+   RETRO_DEVICE_ID_JOYPAD_X,        // X(top)       -> Triangle
+   RETRO_DEVICE_ID_JOYPAD_A,        // A(right)     -> Circle
+   RETRO_DEVICE_ID_JOYPAD_B,        // B(down)      -> Cross
+   RETRO_DEVICE_ID_JOYPAD_Y,        // Y(left)      -> Square
+   RETRO_DEVICE_ID_JOYPAD_SELECT,   // Select       -> Select
+   RETRO_DEVICE_ID_JOYPAD_L3,       // L-thumb      -> L3
+   RETRO_DEVICE_ID_JOYPAD_R3,       // R-thumb      -> R3
+   RETRO_DEVICE_ID_JOYPAD_START,    // Start        -> Start
+   RETRO_DEVICE_ID_JOYPAD_UP,       // Pad-Up       -> Pad-Up
+   RETRO_DEVICE_ID_JOYPAD_RIGHT,    // Pad-Right    -> Pad-Right
+   RETRO_DEVICE_ID_JOYPAD_DOWN,     // Pad-Down     -> Pad-Down
+   RETRO_DEVICE_ID_JOYPAD_LEFT,     // Pad-Left     -> Pad-Left
 #else
-	RETRO_DEVICE_ID_JOYPAD_SELECT,	// Select		-> Select				0
-	RETRO_DEVICE_ID_JOYPAD_L3,		// L-thumb		-> L3					1
-	RETRO_DEVICE_ID_JOYPAD_R3,		// R-thumb		-> R3					2
-	RETRO_DEVICE_ID_JOYPAD_START,	// Start		-> Start				3
-	RETRO_DEVICE_ID_JOYPAD_UP,		// Pad-Up		-> Pad-Up				4
-	RETRO_DEVICE_ID_JOYPAD_RIGHT,	// Pad-Right	-> Pad-Right			5
-	RETRO_DEVICE_ID_JOYPAD_DOWN,	// Pad-Down		-> Pad-Down				6
-	RETRO_DEVICE_ID_JOYPAD_LEFT,	// Pad-Left		-> Pad-Left				7
-	RETRO_DEVICE_ID_JOYPAD_L2,		// L-trigger	-> L2					8
-	RETRO_DEVICE_ID_JOYPAD_R2,		// R-trigger	-> R2					9
-	RETRO_DEVICE_ID_JOYPAD_L,		// L-shoulder	-> L1					10
-	RETRO_DEVICE_ID_JOYPAD_R,		// R-shoulder	-> R1					11
-	RETRO_DEVICE_ID_JOYPAD_X,		// X(top)		-> Triangle				12
-	RETRO_DEVICE_ID_JOYPAD_A,		// A(right)		-> Circle				13
-	RETRO_DEVICE_ID_JOYPAD_B,		// B(down)		-> Cross				14
-	RETRO_DEVICE_ID_JOYPAD_Y,		// Y(left)		-> Square				15
+   RETRO_DEVICE_ID_JOYPAD_SELECT,   // Select       -> Select               0
+   RETRO_DEVICE_ID_JOYPAD_L3,       // L-thumb      -> L3                   1
+   RETRO_DEVICE_ID_JOYPAD_R3,       // R-thumb      -> R3                   2
+   RETRO_DEVICE_ID_JOYPAD_START,    // Start        -> Start                3
+   RETRO_DEVICE_ID_JOYPAD_UP,       // Pad-Up       -> Pad-Up               4
+   RETRO_DEVICE_ID_JOYPAD_RIGHT,    // Pad-Right    -> Pad-Right            5
+   RETRO_DEVICE_ID_JOYPAD_DOWN,     // Pad-Down     -> Pad-Down             6
+   RETRO_DEVICE_ID_JOYPAD_LEFT,     // Pad-Left     -> Pad-Left             7
+   RETRO_DEVICE_ID_JOYPAD_L2,       // L-trigger    -> L2                   8
+   RETRO_DEVICE_ID_JOYPAD_R2,       // R-trigger    -> R2                   9
+   RETRO_DEVICE_ID_JOYPAD_L,        // L-shoulder   -> L1                  10
+   RETRO_DEVICE_ID_JOYPAD_R,        // R-shoulder   -> R1                  11
+   RETRO_DEVICE_ID_JOYPAD_X,        // X(top)       -> Triangle            12
+   RETRO_DEVICE_ID_JOYPAD_A,        // A(right)     -> Circle              13
+   RETRO_DEVICE_ID_JOYPAD_B,        // B(down)      -> Cross               14
+   RETRO_DEVICE_ID_JOYPAD_Y,        // Y(left)      -> Square              15
 #endif
 };
 
@@ -219,35 +218,35 @@ static void SetInput(int port, const char *type, void *ptr)
 }
 
 static uint16_t get_analog_button( retro_input_state_t input_state_cb,
-								   int player_index,
-								   int id )
+                                   int player_index,
+                                   int id )
 {
-	uint16_t button;
+   uint16_t button;
 
-	// NOTE: Analog buttons were added Nov 2017. Not all front-ends support this
-	// feature (or pre-date it) so we need to handle this in a graceful way.
+   // NOTE: Analog buttons were added Nov 2017. Not all front-ends support this
+   // feature (or pre-date it) so we need to handle this in a graceful way.
 
-	// First, try and get an analog value using the new libretro API constant
-	button = input_state_cb( player_index,
-							 RETRO_DEVICE_ANALOG,
-							 RETRO_DEVICE_INDEX_ANALOG_BUTTON,
-							 id );
+   // First, try and get an analog value using the new libretro API constant
+   button = input_state_cb( player_index,
+                            RETRO_DEVICE_ANALOG,
+                            RETRO_DEVICE_INDEX_ANALOG_BUTTON,
+                            id );
 
-	if ( button == 0 )
-	{
-		// If we got exactly zero, we're either not pressing the button, or the front-end
-		// is not reporting analog values. We need to do a second check using the classic
-		// digital API method, to at least get some response - better than nothing.
+   if ( button == 0 )
+   {
+      // If we got exactly zero, we're either not pressing the button, or the front-end
+      // is not reporting analog values. We need to do a second check using the classic
+      // digital API method, to at least get some response - better than nothing.
 
-		// NOTE: If we're really just not holding the button, we're still going to get zero.
+      // NOTE: If we're really just not holding the button, we're still going to get zero.
 
-		button = input_state_cb( player_index,
-								 RETRO_DEVICE_JOYPAD,
-								 0,
-								 id ) ? 0x7FFF : 0;
-	}
+      button = input_state_cb( player_index,
+                               RETRO_DEVICE_JOYPAD,
+                               0,
+                               id ) ? 0x7FFF : 0;
+   }
 
-	return button;
+   return button;
 }
 
 
@@ -257,187 +256,187 @@ static uint16_t get_analog_button( retro_input_state_t input_state_cb,
 
 void input_init_env( retro_environment_t _environ_cb )
 {
-	// Cache this
-	environ_cb = _environ_cb;
+   // Cache this
+   environ_cb = _environ_cb;
 
-	struct retro_input_descriptor desc[] =
-	{
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Cross" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Circle" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Triangle" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Square" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "L1" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "L2" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "L3" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R1" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "R2" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "R3" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,    "Select" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
-		{ 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
-		{ 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
-		{ 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
-		{ 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
+   struct retro_input_descriptor desc[] =
+   {
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Cross" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Circle" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Triangle" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Square" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "L1" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "L2" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "L3" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R1" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "R2" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "R3" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,   "Select" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
+      { 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
+      { 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
+      { 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
+      { 0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
 
 
-		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
-		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
-		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
-		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
-		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Cross" },
-		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Circle" },
-		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Triangle" },
-		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Square" },
-		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "L1" },
-		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "L2" },
-		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "L3" },
-		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R1" },
-		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "R2" },
-		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "R3" },
-		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,    "Select" },
-		{ 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
-		{ 1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
-		{ 1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
-		{ 1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
-		{ 1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Cross" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Circle" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Triangle" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Square" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "L1" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "L2" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "L3" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R1" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "R2" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "R3" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,   "Select" },
+      { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
+      { 1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
+      { 1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
+      { 1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
+      { 1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
 
-		{ 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
-		{ 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
-		{ 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
-		{ 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
-		{ 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Cross" },
-		{ 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Circle" },
-		{ 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Triangle" },
-		{ 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Square" },
-		{ 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "L1" },
-		{ 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "L2" },
-		{ 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "L3" },
-		{ 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R1" },
-		{ 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "R2" },
-		{ 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "R3" },
-		{ 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,    "Select" },
-		{ 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
-		{ 2, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
-		{ 2, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
-		{ 2, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
-		{ 2, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
+      { 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
+      { 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
+      { 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
+      { 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
+      { 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Cross" },
+      { 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Circle" },
+      { 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Triangle" },
+      { 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Square" },
+      { 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "L1" },
+      { 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "L2" },
+      { 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "L3" },
+      { 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R1" },
+      { 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "R2" },
+      { 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "R3" },
+      { 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,   "Select" },
+      { 2, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
+      { 2, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
+      { 2, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
+      { 2, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
+      { 2, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
 
-		{ 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
-		{ 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
-		{ 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
-		{ 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
-		{ 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Cross" },
-		{ 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Circle" },
-		{ 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Triangle" },
-		{ 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Square" },
-		{ 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "L1" },
-		{ 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "L2" },
-		{ 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "L3" },
-		{ 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R1" },
-		{ 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "R2" },
-		{ 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "R3" },
-		{ 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,    "Select" },
-		{ 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
-		{ 3, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
-		{ 3, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
-		{ 3, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
-		{ 3, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
+      { 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
+      { 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
+      { 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
+      { 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
+      { 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Cross" },
+      { 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Circle" },
+      { 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Triangle" },
+      { 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Square" },
+      { 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "L1" },
+      { 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "L2" },
+      { 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "L3" },
+      { 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R1" },
+      { 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "R2" },
+      { 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "R3" },
+      { 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,   "Select" },
+      { 3, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
+      { 3, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
+      { 3, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
+      { 3, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
+      { 3, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
 
-		{ 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
-		{ 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
-		{ 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
-		{ 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
-		{ 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Cross" },
-		{ 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Circle" },
-		{ 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Triangle" },
-		{ 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Square" },
-		{ 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "L1" },
-		{ 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "L2" },
-		{ 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "L3" },
-		{ 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R1" },
-		{ 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "R2" },
-		{ 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "R3" },
-		{ 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,    "Select" },
-		{ 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
-		{ 4, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
-		{ 4, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
-		{ 4, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
-		{ 4, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
+      { 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
+      { 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
+      { 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
+      { 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
+      { 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Cross" },
+      { 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Circle" },
+      { 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Triangle" },
+      { 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Square" },
+      { 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "L1" },
+      { 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "L2" },
+      { 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "L3" },
+      { 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R1" },
+      { 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "R2" },
+      { 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "R3" },
+      { 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,   "Select" },
+      { 4, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
+      { 4, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
+      { 4, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
+      { 4, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
+      { 4, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
 
-		{ 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
-		{ 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
-		{ 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
-		{ 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
-		{ 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Cross" },
-		{ 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Circle" },
-		{ 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Triangle" },
-		{ 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Square" },
-		{ 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "L1" },
-		{ 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "L2" },
-		{ 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "L3" },
-		{ 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R1" },
-		{ 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "R2" },
-		{ 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "R3" },
-		{ 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,    "Select" },
-		{ 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
-		{ 5, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
-		{ 5, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
-		{ 5, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
-		{ 5, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
+      { 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
+      { 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
+      { 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
+      { 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
+      { 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Cross" },
+      { 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Circle" },
+      { 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Triangle" },
+      { 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Square" },
+      { 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "L1" },
+      { 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "L2" },
+      { 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "L3" },
+      { 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R1" },
+      { 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "R2" },
+      { 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "R3" },
+      { 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,   "Select" },
+      { 5, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
+      { 5, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
+      { 5, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
+      { 5, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
+      { 5, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
 
-		{ 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
-		{ 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
-		{ 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
-		{ 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
-		{ 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Cross" },
-		{ 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Circle" },
-		{ 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Triangle" },
-		{ 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Square" },
-		{ 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "L1" },
-		{ 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "L2" },
-		{ 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "L3" },
-		{ 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R1" },
-		{ 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "R2" },
-		{ 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "R3" },
-		{ 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,    "Select" },
-		{ 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
-		{ 6, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
-		{ 6, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
-		{ 6, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
-		{ 6, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
+      { 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
+      { 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
+      { 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
+      { 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
+      { 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Cross" },
+      { 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Circle" },
+      { 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Triangle" },
+      { 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Square" },
+      { 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "L1" },
+      { 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "L2" },
+      { 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "L3" },
+      { 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R1" },
+      { 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "R2" },
+      { 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "R3" },
+      { 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,   "Select" },
+      { 6, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
+      { 6, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
+      { 6, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
+      { 6, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
+      { 6, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
 
-		{ 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
-		{ 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
-		{ 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
-		{ 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
-		{ 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Cross" },
-		{ 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Circle" },
-		{ 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Triangle" },
-		{ 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Square" },
-		{ 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "L1" },
-		{ 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "L2" },
-		{ 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "L3" },
-		{ 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R1" },
-		{ 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "R2" },
-		{ 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "R3" },
-		{ 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,    "Select" },
-		{ 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
-		{ 7, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
-		{ 7, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
-		{ 7, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
-		{ 7, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
+      { 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,  "D-Pad Left" },
+      { 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "D-Pad Up" },
+      { 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "D-Pad Down" },
+      { 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "D-Pad Right" },
+      { 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Cross" },
+      { 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Circle" },
+      { 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Triangle" },
+      { 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Square" },
+      { 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,     "L1" },
+      { 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,    "L2" },
+      { 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,    "L3" },
+      { 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R1" },
+      { 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,    "R2" },
+      { 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,    "R3" },
+      { 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,   "Select" },
+      { 7, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
+      { 7, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X, "Left Analog X" },
+      { 7, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y, "Left Analog Y" },
+      { 7, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, "Right Analog X" },
+      { 7, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, "Right Analog Y" },
 
-		{ 0 },
-	};
+      { 0 },
+   };
 
-	environ_cb( RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, desc );
+   environ_cb( RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, desc );
 
-	if ( environ_cb( RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE, &rumble ) && log_cb )
-		log_cb(RETRO_LOG_INFO, "Rumble interface supported!\n");
+   if ( environ_cb( RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE, &rumble ) && log_cb )
+      log_cb(RETRO_LOG_INFO, "Rumble interface supported!\n");
 }
 
 void input_set_env( retro_environment_t _environ_cb )
@@ -462,245 +461,242 @@ void input_set_env( retro_environment_t _environ_cb )
 
 void input_init()
 {
-	// Initialise to default and bind input buffers to PS1 emulation.
-	for ( unsigned i = 0; i < MAX_CONTROLLERS; ++i )
-	{
-		input_type[ i ] = RETRO_DEVICE_JOYPAD;
+   // Initialise to default and bind input buffers to PS1 emulation.
+   for ( unsigned i = 0; i < MAX_CONTROLLERS; ++i )
+   {
+      input_type[ i ] = RETRO_DEVICE_JOYPAD;
 
-		SetInput( i, "gamepad", (uint8*)&input_data[ i ] );
-	}
+      SetInput( i, "gamepad", (uint8*)&input_data[ i ] );
+   }
 }
 
 void input_set_fio( FrontIO* fio )
 {
-	FIO = fio;
+   FIO = fio;
 }
 
 void input_init_calibration()
 {
-	for ( unsigned i = 0; i < MAX_CONTROLLERS; i++ )
-	{
-		analog_calibration[ i ].left = 0.7f;
-		analog_calibration[ i ].right = 0.7f;
-		analog_calibration[ i ].twist = 0.7f;
-	}
+   for ( unsigned i = 0; i < MAX_CONTROLLERS; i++ )
+   {
+      analog_calibration[ i ].left = 0.7f;
+      analog_calibration[ i ].right = 0.7f;
+      analog_calibration[ i ].twist = 0.7f;
+   }
 }
 
 void input_enable_calibration( bool enable )
 {
-	enable_analog_calibration = enable;
+   enable_analog_calibration = enable;
 }
 
 void input_set_player_count( unsigned _players )
 {
-	players = _players;
-	
-	input_set_env( environ_cb );
+   players = _players;
+   input_set_env( environ_cb );
 }
 
 void input_set_mouse_sensitivity( int percent )
 {
-	if ( percent > 0 && percent <= 200 )
-		mouse_sensitivity = (float)percent / 100.0f;
+   if ( percent > 0 && percent <= 200 )
+      mouse_sensitivity = (float)percent / 100.0f;
 }
 
 void input_set_gun_cursor( int cursor )
 {
-	gun_cursor = cursor;
-	if ( FIO )
+   gun_cursor = cursor;
+   if ( FIO )
    {
-		// todo -- support multiple guns.
-		for ( int port = 0; port < 8; ++port )
-			FIO->SetCrosshairsCursor( port, gun_cursor );
-	}
+      // todo -- support multiple guns.
+      for ( int port = 0; port < 8; ++port )
+         FIO->SetCrosshairsCursor( port, gun_cursor );
+   }
 }
 
 void input_set_negcon_deadzone( int deadzone )
 {
-	negcon_deadzone = deadzone;
+   negcon_deadzone = deadzone;
 }
 
 void input_set_negcon_linearity( int linearity )
 {
-	negcon_linearity = linearity;
+   negcon_linearity = linearity;
 }
 
 unsigned input_get_player_count()
 {
-	return players;
+   return players;
 }
 
 void input_handle_lightgun_touchscreen( INPUT_DATA *p_input, int iplayer, retro_input_state_t input_state_cb )
 {
-	int gun_x_raw = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X);
-	int gun_y_raw = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y);
+   int gun_x_raw = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X);
+   int gun_y_raw = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y);
 
-	// .. scale into screen space:
-	// NOTE: the scaling here is semi-guesswork, need to re-write.
-	// TODO: Test with PAL games.
+   // .. scale into screen space:
+   // NOTE: the scaling here is semi-guesswork, need to re-write.
+   // TODO: Test with PAL games.
 
-	const int scale_x = 2800;
-	const int scale_y = 240;
+   const int scale_x = 2800;
+   const int scale_y = 240;
 
-	int gun_x = ( ( gun_x_raw + 0x7fff ) * scale_x ) / (0x7fff << 1);
-	int gun_y = ( ( gun_y_raw + 0x7fff ) * scale_y ) / (0x7fff << 1);
+   int gun_x = ( ( gun_x_raw + 0x7fff ) * scale_x ) / (0x7fff << 1);
+   int gun_y = ( ( gun_y_raw + 0x7fff ) * scale_y ) / (0x7fff << 1);
 
 #if 0
-	int is_offscreen = 0;
+   int is_offscreen = 0;
 #endif
 
-	// Handle offscreen by checking corrected x and y values
-	if ( gun_x == 0 || gun_y == 0 )
-	{
-#if 0
-		is_offscreen = 1;
-#endif
-
-		gun_x = -16384; // magic position to disable cross-hair drawing.
-		gun_y = -16384;
-	}
-
-	// Touch sensitivity: Keep the gun position held for a fixed number of cycles after touch is released
-	// because a very light touch can result in a misfire
-	if ( pointer_cycles_after_released > 0 && pointer_cycles_after_released < POINTER_PRESSED_CYCLES )
+   // Handle offscreen by checking corrected x and y values
+   if ( gun_x == 0 || gun_y == 0 )
    {
-		pointer_cycles_after_released++;
-		p_input->gun_pos[ 0 ] = pointer_pressed_last_x;
-		p_input->gun_pos[ 1 ] = pointer_pressed_last_y;
-		return;
-	}
+#if 0
+      is_offscreen = 1;
+#endif
 
-	// trigger
-	if ( input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED ) )
-	{
-		pointer_pressed = 1;
-		pointer_cycles_after_released = 0;
-		pointer_pressed_last_x = gun_x;
-		pointer_pressed_last_y = gun_y;
-	} else if ( pointer_pressed ) {
-		pointer_cycles_after_released++;
-		pointer_pressed = 0;
-		p_input->gun_pos[ 0 ] = pointer_pressed_last_x;
-		p_input->gun_pos[ 1 ] = pointer_pressed_last_y;
-		p_input->u8[4] &= ~0x1;
-		return;
-	}
+      gun_x = -16384; // magic position to disable cross-hair drawing.
+      gun_y = -16384;
+   }
 
-	// position
-	p_input->gun_pos[ 0 ] = gun_x;
-	p_input->gun_pos[ 1 ] = gun_y;
+   // Touch sensitivity: Keep the gun position held for a fixed number of cycles after touch is released
+   // because a very light touch can result in a misfire
+   if ( pointer_cycles_after_released > 0 && pointer_cycles_after_released < POINTER_PRESSED_CYCLES )
+   {
+      pointer_cycles_after_released++;
+      p_input->gun_pos[ 0 ] = pointer_pressed_last_x;
+      p_input->gun_pos[ 1 ] = pointer_pressed_last_y;
+      return;
+   }
 
-	// buttons
-	p_input->u8[ 4 ] = 0;
+   // trigger
+   if ( input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED ) )
+   {
+      pointer_pressed = 1;
+      pointer_cycles_after_released = 0;
+      pointer_pressed_last_x = gun_x;
+      pointer_pressed_last_y = gun_y;
+   } else if ( pointer_pressed ) {
+      pointer_cycles_after_released++;
+      pointer_pressed = 0;
+      p_input->gun_pos[ 0 ] = pointer_pressed_last_x;
+      p_input->gun_pos[ 1 ] = pointer_pressed_last_y;
+      p_input->u8[4] &= ~0x1;
+      return;
+   }
 
-	// use multi-touch to support different button inputs:
-	// 3-finger touch: START button
-	// 2-finger touch: Reload
-	// offscreen touch: Reload
-	int touch_count = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_COUNT );
-	if ( touch_count == 1 )
-		p_input->u8[ 4 ] |= 0x1;
+   // position
+   p_input->gun_pos[ 0 ] = gun_x;
+   p_input->gun_pos[ 1 ] = gun_y;
 
-	if ( input_type[ iplayer ] == RETRO_DEVICE_PS_JUSTIFIER )
-	{
-		// Justifier 'Aux'
-		if ( touch_count == 2 )
-			p_input->u8[ 4 ] |= 0x2;
+   // buttons
+   p_input->u8[ 4 ] = 0;
 
-		// Justifier 'Start'
-		if ( touch_count == 3 )
-			p_input->u8[ 4 ] |= 0x4;
-	}
-	else
-	{
-		// Guncon 'A'
-		if ( touch_count == 2 )
-			p_input->u8[ 4 ] |= 0x2;
+   // use multi-touch to support different button inputs:
+   // 3-finger touch: START button
+   // 2-finger touch: Reload
+   // offscreen touch: Reload
+   int touch_count = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_COUNT );
+   if ( touch_count == 1 )
+      p_input->u8[ 4 ] |= 0x1;
 
-		// Guncon 'B'
-		if ( touch_count == 3 )
-			p_input->u8[ 4 ] |= 0x4;
+   if ( input_type[ iplayer ] == RETRO_DEVICE_PS_JUSTIFIER )
+   {
+      // Justifier 'Aux'
+      if ( touch_count == 2 )
+         p_input->u8[ 4 ] |= 0x2;
 
-		// Guncon 'A' + 'B'
-		if ( touch_count == 4 )
+      // Justifier 'Start'
+      if ( touch_count == 3 )
+         p_input->u8[ 4 ] |= 0x4;
+   }
+   else
+   {
+      // Guncon 'A'
+      if ( touch_count == 2 )
+         p_input->u8[ 4 ] |= 0x2;
+
+      // Guncon 'B'
+      if ( touch_count == 3 )
+         p_input->u8[ 4 ] |= 0x4;
+
+      // Guncon 'A' + 'B'
+      if ( touch_count == 4 )
       {
-			p_input->u8[ 4 ] |= 0x2;
-			p_input->u8[ 4 ] |= 0x4;
-		}
-	}
-
+         p_input->u8[ 4 ] |= 0x2;
+         p_input->u8[ 4 ] |= 0x4;
+      }
+   }
 }
 
 void input_handle_lightgun( INPUT_DATA *p_input, int iplayer, retro_input_state_t input_state_cb )
 {
-	uint8_t shot_type;
-	int gun_x, gun_y;
-	int forced_reload = input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD );
+   uint8_t shot_type;
+   int gun_x, gun_y;
+   int forced_reload = input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD );
 
-	// off-screen?
-	if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN ) || forced_reload )
-	{
-		shot_type = 0x8; // off-screen shot
+   // off-screen?
+   if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN ) || forced_reload )
+   {
+      shot_type = 0x8; // off-screen shot
 
-		gun_x = -16384; // magic position to disable cross-hair drawing.
-		gun_y = -16384;
-	}
-	else
-	{
-		shot_type = 0x1; // on-screen shot
+      gun_x = -16384; // magic position to disable cross-hair drawing.
+      gun_y = -16384;
+   }
+   else
+   {
+      shot_type = 0x1; // on-screen shot
 
-		int gun_x_raw = input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X );
-		int gun_y_raw = input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y );
+      int gun_x_raw = input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X );
+      int gun_y_raw = input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y );
 
-		// .. scale into screen space:
-		// NOTE: the scaling here is semi-guesswork, need to re-write.
-		// TODO: Test with PAL games.
+      // .. scale into screen space:
+      // NOTE: the scaling here is semi-guesswork, need to re-write.
+      // TODO: Test with PAL games.
 
-		const int scale_x = 2800;
-		const int scale_y = 240;
+      const int scale_x = 2800;
+      const int scale_y = 240;
 
-		gun_x = ( ( gun_x_raw + 0x7fff ) * scale_x ) / (0x7fff << 1);
-		gun_y = ( ( gun_y_raw + 0x7fff ) * scale_y ) / (0x7fff << 1);
-	}
+      gun_x = ( ( gun_x_raw + 0x7fff ) * scale_x ) / (0x7fff << 1);
+      gun_y = ( ( gun_y_raw + 0x7fff ) * scale_y ) / (0x7fff << 1);
+   }
 
-	// position
-	p_input->gun_pos[ 0 ] = gun_x;
-	p_input->gun_pos[ 1 ] = gun_y;
+   // position
+   p_input->gun_pos[ 0 ] = gun_x;
+   p_input->gun_pos[ 1 ] = gun_y;
 
-	// buttons
-	p_input->u8[ 4 ] = 0;
+   // buttons
+   p_input->u8[ 4 ] = 0;
 
-	// trigger
-	if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER ) || forced_reload )
-		p_input->u8[ 4 ] |= shot_type;
+   // trigger
+   if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_TRIGGER ) || forced_reload )
+      p_input->u8[ 4 ] |= shot_type;
 
-	if ( input_type[ iplayer ] == RETRO_DEVICE_PS_JUSTIFIER )
-	{
-		// Justifier 'Aux'
-		if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_AUX_A ) )
-			p_input->u8[ 4 ] |= 0x2;
+   if ( input_type[ iplayer ] == RETRO_DEVICE_PS_JUSTIFIER )
+   {
+      // Justifier 'Aux'
+      if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_AUX_A ) )
+         p_input->u8[ 4 ] |= 0x2;
 
-		// Justifier 'Start'
-		if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_START ) )
-			p_input->u8[ 4 ] |= 0x4;
-	}
-	else
-	{
-		// Guncon 'A'
-		if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_AUX_A ) )
-			p_input->u8[ 4 ] |= 0x2;
+      // Justifier 'Start'
+      if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_START ) )
+         p_input->u8[ 4 ] |= 0x4;
+   }
+   else
+   {
+      // Guncon 'A'
+      if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_AUX_A ) )
+         p_input->u8[ 4 ] |= 0x2;
 
-		// Guncon 'B'
-		if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_AUX_B ) )
-			p_input->u8[ 4 ] |= 0x4;
-	}
-
+      // Guncon 'B'
+      if ( input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_AUX_B ) )
+         p_input->u8[ 4 ] |= 0x4;
+   }
 }
 
 void input_update(bool libretro_supports_bitmasks, retro_input_state_t input_state_cb )
 {
-	// For each player (logical controller)
-	for ( unsigned iplayer = 0; iplayer < players; ++iplayer )
+   // For each player (logical controller)
+   for ( unsigned iplayer = 0; iplayer < players; ++iplayer )
    {
       INPUT_DATA* p_input = &(input_data[ iplayer ]);
 
@@ -1056,12 +1052,12 @@ void input_update(bool libretro_supports_bitmasks, retro_input_state_t input_sta
 
 void retro_set_controller_port_device( unsigned in_port, unsigned device )
 {
-	if ( in_port < MAX_CONTROLLERS )
-	{
-		// Store input type
-		input_type[ in_port ] = device;
+   if ( in_port < MAX_CONTROLLERS )
+   {
+      // Store input type
+      input_type[ in_port ] = device;
 
-		switch ( device )
+      switch ( device )
       {
 
          case RETRO_DEVICE_NONE:
@@ -1121,15 +1117,15 @@ void retro_set_controller_port_device( unsigned in_port, unsigned device )
 
       } // switch ( device )
 
-		// Clear rumble.
-		if ( rumble.set_rumble_state )
-		{
-			rumble.set_rumble_state(in_port, RETRO_RUMBLE_STRONG, 0);
-			rumble.set_rumble_state(in_port, RETRO_RUMBLE_WEAK, 0);
-		}
-		input_data[ in_port ].u32[ 9 ] = 0;
+      // Clear rumble.
+      if ( rumble.set_rumble_state )
+      {
+         rumble.set_rumble_state(in_port, RETRO_RUMBLE_STRONG, 0);
+         rumble.set_rumble_state(in_port, RETRO_RUMBLE_WEAK, 0);
+      }
+      input_data[ in_port ].u32[ 9 ] = 0;
 
-	} // valid port?
+   } // valid port?
 }
 
 //==============================================================================

--- a/input.h
+++ b/input.h
@@ -33,8 +33,8 @@ void input_update(bool supports_bitmasks, retro_input_state_t input_state_cb );
 
 enum
 {
-	SETTING_GUN_INPUT_LIGHTGUN,
-	SETTING_GUN_INPUT_POINTER,
+   SETTING_GUN_INPUT_LIGHTGUN,
+   SETTING_GUN_INPUT_POINTER,
 };
 extern int gun_input_mode;
 

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -2936,11 +2936,11 @@ static void check_variables(void)
 
 	if ( environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value )
 	{
-		if ( !strcmp(var.value, "Off") ) {
+		if ( !strcmp(var.value, "off") ) {
 			input_set_gun_cursor( FrontIO::SETTING_GUN_CROSSHAIR_OFF );
-		} else if ( !strcmp(var.value, "Cross") ) {
+		} else if ( !strcmp(var.value, "cross") ) {
 			input_set_gun_cursor( FrontIO::SETTING_GUN_CROSSHAIR_CROSS );
-		} else if ( !strcmp(var.value, "Dot") ) {
+		} else if ( !strcmp(var.value, "dot") ) {
 			input_set_gun_cursor( FrontIO::SETTING_GUN_CROSSHAIR_DOT );
 		}
 	}
@@ -2950,12 +2950,14 @@ static void check_variables(void)
 
    if ( environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value )
    {
-      if ( !strcmp(var.value, "Touchscreen" ) ) {
-         gun_input_mode = SETTING_GUN_INPUT_POINTER;
-      } else {
+      if ( !strcmp(var.value, "lightgun" ) ) {
          gun_input_mode = SETTING_GUN_INPUT_LIGHTGUN;
       }
-   }
+      else if ( !strcmp(var.value, "touchscreen" ) ) {
+         gun_input_mode = SETTING_GUN_INPUT_POINTER;
+      }
+   } else
+      gun_input_mode = SETTING_GUN_INPUT_LIGHTGUN;
 
 	var.key = BEETLE_OPT(negcon_deadzone);
 	var.value = NULL;
@@ -3054,22 +3056,8 @@ static void check_variables(void)
    {
       if (strcmp(var.value, "disabled") == 0)
          image_offset = 0;
-      else if (strcmp(var.value, "1 px") == 0)
-         image_offset = -1;
-      else if (strcmp(var.value, "-1 px") == 0)
-         image_offset = 1;
-      else if (strcmp(var.value, "2 px") == 0)
-         image_offset = -2;
-      else if (strcmp(var.value, "-2 px") == 0)
-         image_offset = 2;
-      else if (strcmp(var.value, "3 px") == 0)
-         image_offset = -3;
-      else if (strcmp(var.value, "-3 px") == 0)
-         image_offset = 3;
-      else if (strcmp(var.value, "4 px") == 0)
-         image_offset = -4;
-      else if (strcmp(var.value, "-4 px") == 0)
-         image_offset = 4;
+      else
+         image_offset = atoi(var.value);
    }
 
    var.key = BEETLE_OPT(image_crop);
@@ -3078,22 +3066,8 @@ static void check_variables(void)
    {
       if (strcmp(var.value, "disabled") == 0)
          image_crop = 0;
-      else if (strcmp(var.value, "1 px") == 0)
-         image_crop = 1;
-      else if (strcmp(var.value, "2 px") == 0)
-         image_crop = 2;
-      else if (strcmp(var.value, "3 px") == 0)
-         image_crop = 3;
-      else if (strcmp(var.value, "4 px") == 0)
-         image_crop = 4;
-      else if (strcmp(var.value, "5 px") == 0)
-         image_crop = 5;
-      else if (strcmp(var.value, "6 px") == 0)
-         image_crop = 6;
-      else if (strcmp(var.value, "7 px") == 0)
-         image_crop = 7;
-      else if (strcmp(var.value, "8 px") == 0)
-         image_crop = 8;
+      else
+         image_crop = atoi(var.value);
    }
 
    var.key = BEETLE_OPT(cd_fastload);

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3017,9 +3017,8 @@ static void check_variables(void)
       if (!strcmp(var.value, "enabled"))
       {
          bool can_dupe = false;
-
          if (environ_cb(RETRO_ENVIRONMENT_GET_CAN_DUPE, &can_dupe))
-            allow_frame_duping = true;
+            allow_frame_duping = can_dupe;
       }
       else if (!strcmp(var.value, "disabled"))
          allow_frame_duping = false;
@@ -3479,6 +3478,9 @@ bool retro_load_game(const struct retro_game_info *info)
          option_display.key = BEETLE_OPT(image_crop);
          environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 
+         option_display.key = BEETLE_OPT(frame_duping);
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+
          break;
       }
       case RSX_VULKAN:
@@ -3496,6 +3498,9 @@ bool retro_load_game(const struct retro_game_info *info)
          option_display.key = BEETLE_OPT(image_offset);
          environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
          option_display.key = BEETLE_OPT(image_crop);
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+
+         option_display.key = BEETLE_OPT(frame_duping);
          environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 
          break;

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -2669,7 +2669,6 @@ static void check_variables(void)
 
 #ifndef EMSCRIPTEN
    var.key = BEETLE_OPT(cd_access_method);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "sync") == 0)
@@ -2691,16 +2690,14 @@ static void check_variables(void)
 #endif
 
    var.key = BEETLE_OPT(cpu_freq_scale);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       int scale_percent = atoi(var.value);
 
-      if (scale_percent == 100) {
+      if (scale_percent == 100)
          psx_overclock_factor = 0;
-      } else {
+      else
          psx_overclock_factor = ((scale_percent << OVERCLOCK_SHIFT) + 50) / 100;
-      }
    }
    else
       psx_overclock_factor = 0;
@@ -2709,7 +2706,6 @@ static void check_variables(void)
    GPU_RecalcClockRatio();
 
    var.key = BEETLE_OPT(gte_overclock);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "enabled") == 0)
@@ -2721,7 +2717,6 @@ static void check_variables(void)
       psx_gte_overclock = false;
 
    var.key = BEETLE_OPT(gpu_overclock);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       unsigned val = atoi(var.value);
@@ -2742,7 +2737,6 @@ static void check_variables(void)
       psx_gpu_overclock_shift = 0;
 
    var.key = BEETLE_OPT(skip_bios);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "enabled") == 0)
@@ -2752,7 +2746,6 @@ static void check_variables(void)
    }
 
    var.key = BEETLE_OPT(widescreen_hack);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "enabled") == 0)
@@ -2770,7 +2763,6 @@ static void check_variables(void)
       widescreen_hack = false;
 
    var.key = BEETLE_OPT(enable_memcard1);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "enabled") == 0)
@@ -2782,21 +2774,19 @@ static void check_variables(void)
       enable_memcard1 = false;
 
    var.key = BEETLE_OPT(analog_calibration);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "enabled") == 0)
-         input_enable_calibration( true );
+         input_enable_calibration(true);
       else if (strcmp(var.value, "disabled") == 0)
-         input_enable_calibration( false );
+         input_enable_calibration(false);
    }
    else
-      input_enable_calibration( false );
+      input_enable_calibration(false);
 
    rsx_intf_refresh_variables();
 
    var.key = BEETLE_OPT(dither_mode);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "1x(native)") == 0)
@@ -2811,7 +2801,6 @@ static void check_variables(void)
 
    // iCB: PGXP settings
    var.key = BEETLE_OPT(pgxp_mode);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "disabled") == 0)
@@ -2825,7 +2814,6 @@ static void check_variables(void)
       psx_pgxp_mode = PGXP_MODE_NONE;
 
    var.key = BEETLE_OPT(pgxp_vertex);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "disabled") == 0)
@@ -2837,7 +2825,6 @@ static void check_variables(void)
       psx_pgxp_vertex_caching = PGXP_MODE_NONE;
 
    var.key = BEETLE_OPT(pgxp_texture);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "disabled") == 0)
@@ -2850,33 +2837,31 @@ static void check_variables(void)
    // \iCB
 
    var.key = BEETLE_OPT(lineRender);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "disabled"))
+      if (strcmp(var.value, "disabled") == 0)
          lineRenderMode = 0;
-      else if (!strcmp(var.value, "default"))
+      else if (strcmp(var.value, "default") == 0)
          lineRenderMode = 1;
-      else if (!strcmp(var.value, "aggressive"))
+      else if (strcmp(var.value, "aggressive") == 0)
          lineRenderMode = 2;
    }
 
    var.key = BEETLE_OPT(filter);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       int old_filter_mode = filter_mode;
-      if (!strcmp(var.value, "nearest"))
+      if (strcmp(var.value, "nearest") == 0)
          filter_mode = 0;
-      else if (!strcmp(var.value, "xBR"))
+      else if (strcmp(var.value, "xBR") == 0)
          filter_mode = 1;
-      else if (!strcmp(var.value, "SABR"))
+      else if (strcmp(var.value, "SABR") == 0)
          filter_mode = 2;
-      else if (!strcmp(var.value, "bilinear"))
+      else if (strcmp(var.value, "bilinear") == 0)
          filter_mode = 3;
-      else if (!strcmp(var.value, "3-point"))
+      else if (strcmp(var.value, "3-point") == 0)
          filter_mode = 4;
-      else if (!strcmp(var.value, "JINC2"))
+      else if (strcmp(var.value, "JINC2") == 0)
          filter_mode = 5;
 
       if(filter_mode != old_filter_mode)
@@ -2888,7 +2873,6 @@ static void check_variables(void)
    }
 
    var.key = BEETLE_OPT(analog_toggle);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if ((strcmp(var.value, "enabled") == 0)
@@ -2906,7 +2890,6 @@ static void check_variables(void)
    }
 
    var.key = BEETLE_OPT(enable_multitap_port1);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "enabled") == 0)
@@ -2916,7 +2899,6 @@ static void check_variables(void)
    }
 
    var.key = BEETLE_OPT(enable_multitap_port2);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "enabled") == 0)
@@ -2926,132 +2908,115 @@ static void check_variables(void)
    }
 
    var.key = BEETLE_OPT(mouse_sensitivity);
-	var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      input_set_mouse_sensitivity(atoi(var.value));
 
-	if ( environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value )
-		input_set_mouse_sensitivity( atoi( var.value ) );
-
-	var.key = BEETLE_OPT(gun_cursor);
-	var.value = NULL;
-
-	if ( environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value )
-	{
-		if ( !strcmp(var.value, "off") ) {
-			input_set_gun_cursor( FrontIO::SETTING_GUN_CROSSHAIR_OFF );
-		} else if ( !strcmp(var.value, "cross") ) {
-			input_set_gun_cursor( FrontIO::SETTING_GUN_CROSSHAIR_CROSS );
-		} else if ( !strcmp(var.value, "dot") ) {
-			input_set_gun_cursor( FrontIO::SETTING_GUN_CROSSHAIR_DOT );
-		}
-	}
+   var.key = BEETLE_OPT(gun_cursor);
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "off") == 0)
+         input_set_gun_cursor(FrontIO::SETTING_GUN_CROSSHAIR_OFF);
+      else if (strcmp(var.value, "cross") == 0)
+         input_set_gun_cursor(FrontIO::SETTING_GUN_CROSSHAIR_CROSS);
+      else if (strcmp(var.value, "dot") == 0)
+         input_set_gun_cursor(FrontIO::SETTING_GUN_CROSSHAIR_DOT);
+   }
 
    var.key = BEETLE_OPT(gun_input_mode);
-   var.value = NULL;
-
-   if ( environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value )
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if ( !strcmp(var.value, "lightgun" ) ) {
+      if (strcmp(var.value, "lightgun") == 0)
          gun_input_mode = SETTING_GUN_INPUT_LIGHTGUN;
-      }
-      else if ( !strcmp(var.value, "touchscreen" ) ) {
+      else if (strcmp(var.value, "touchscreen") == 0)
          gun_input_mode = SETTING_GUN_INPUT_POINTER;
-      }
-   } else
+   }
+   else
       gun_input_mode = SETTING_GUN_INPUT_LIGHTGUN;
 
-	var.key = BEETLE_OPT(negcon_deadzone);
-	var.value = NULL;
-	input_set_negcon_deadzone(0);
-	if ( environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value ) {
-		input_set_negcon_deadzone( (int)(atoi(var.value) * 0.01f * NEGCON_RANGE) );
-	}
+   var.key = BEETLE_OPT(negcon_deadzone);
+   input_set_negcon_deadzone(0);
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      input_set_negcon_deadzone((int)(atoi(var.value) * 0.01f * NEGCON_RANGE));
+   }
 
-	var.key = BEETLE_OPT(negcon_response);
-	var.value = NULL;
-	input_set_negcon_linearity(1);
-	if ( environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value ) {
-		if (strcmp(var.value, "quadratic") == 0) {
-        input_set_negcon_linearity(2);
-      } else if (strcmp(var.value, "cubic") == 0) {
+   var.key = BEETLE_OPT(negcon_response);
+   input_set_negcon_linearity(1);
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "quadratic") == 0)
+         input_set_negcon_linearity(2);
+      else if (strcmp(var.value, "cubic") == 0)
          input_set_negcon_linearity(3);
-      }
-	}
+   }
 
-        var.key = BEETLE_OPT(initial_scanline);
-
+   var.key = BEETLE_OPT(initial_scanline);
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       setting_initial_scanline = atoi(var.value);
    }
 
    var.key = BEETLE_OPT(last_scanline);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       setting_last_scanline = atoi(var.value);
    }
 
    var.key = BEETLE_OPT(initial_scanline_pal);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       setting_initial_scanline_pal = atoi(var.value);
    }
 
    var.key = BEETLE_OPT(last_scanline_pal);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       setting_last_scanline_pal = atoi(var.value);
    }
 
    if(setting_psx_multitap_port_1 && setting_psx_multitap_port_2)
-      input_set_player_count( 8 );
+      input_set_player_count(8);
    else if (setting_psx_multitap_port_1 || setting_psx_multitap_port_2)
-      input_set_player_count( 5 );
+      input_set_player_count(5);
    else
-      input_set_player_count( 2 );
+      input_set_player_count(2);
 
    var.key = BEETLE_OPT(frame_duping);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "enabled"))
+      if (strcmp(var.value, "enabled") == 0)
       {
          bool can_dupe = false;
          if (environ_cb(RETRO_ENVIRONMENT_GET_CAN_DUPE, &can_dupe))
             allow_frame_duping = can_dupe;
       }
-      else if (!strcmp(var.value, "disabled"))
+      else if (strcmp(var.value, "disabled") == 0)
          allow_frame_duping = false;
    }
    else
       allow_frame_duping = false;
 
    var.key = BEETLE_OPT(display_internal_fps);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-     {
-       if (strcmp(var.value, "enabled") == 0)
+   {
+      if (strcmp(var.value, "enabled") == 0)
          display_internal_framerate = true;
-       else if (strcmp(var.value, "disabled") == 0)
+      else if (strcmp(var.value, "disabled") == 0)
          display_internal_framerate = false;
-     }
+   }
    else
-     display_internal_framerate = false;
+      display_internal_framerate = false;
 
    var.key = BEETLE_OPT(crop_overscan);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-     {
-       if (strcmp(var.value, "enabled") == 0)
+   {
+      if (strcmp(var.value, "enabled") == 0)
          crop_overscan = true;
-       else if (strcmp(var.value, "disabled") == 0)
+      else if (strcmp(var.value, "disabled") == 0)
          crop_overscan = false;
-     }
+   }
 
    var.key = BEETLE_OPT(image_offset);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "disabled") == 0)
@@ -3061,7 +3026,6 @@ static void check_variables(void)
    }
 
    var.key = BEETLE_OPT(image_crop);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "disabled") == 0)
@@ -3071,21 +3035,17 @@ static void check_variables(void)
    }
 
    var.key = BEETLE_OPT(cd_fastload);
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      uint8_t val = var.value[0] - '0';
+      if (var.value[1] != 'x')
       {
-         uint8_t val = var.value[0] - '0';
-
-         if (var.value[1] != 'x')
-            {
-               val  = (var.value[0] - '0') * 10;
-               val += var.value[1] - '0';
-            }
-
-         // Value is a multiplier from the native 2x, so we divide by
-         // two
-         cd_2x_speedup = val / 2;
+         val  = (var.value[0] - '0') * 10;
+         val += var.value[1] - '0';
       }
+      // Value is a multiplier from the native 2x, so we divide by two
+      cd_2x_speedup = val / 2;
+   }
    else
       cd_2x_speedup = 1;
 }
@@ -3320,7 +3280,7 @@ bool retro_load_game(const struct retro_game_info *info)
    if (failed_init)
       return false;
 
-	input_init_env( environ_cb );
+   input_init_env(environ_cb);
 
    enum retro_pixel_format fmt = RETRO_PIXEL_FORMAT_XRGB8888;
    if (!environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &fmt))

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -75,6 +75,62 @@ struct retro_core_option_definition option_defs_us[] = {
       "enabled"
    },
 #endif
+   {
+      BEETLE_OPT(internal_resolution),
+      "Internal GPU Resolution",
+      "Select internal resolution multiplier. Resolutions higher than '1x (Native)' improve the fidelity of 3D models at the expense of increased performance requirements. 2D elements are generally unaffected by this setting.",
+      {
+         { "1x(native)", "1x (Native)" },
+         { "2x",         NULL },
+         { "4x",         NULL },
+         { "8x",         NULL },
+         { "16x",        NULL },
+         { NULL, NULL },
+      },
+      "1x(native)"
+   },
+#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
+   {
+      BEETLE_OPT(depth),
+      "Internal Color Depth",
+      "The PSX has a limited color depth of 16 bits per pixel (bpp). This leads to 'banding' effects (uneven color gradients) which are 'smoothed out' by original hardware through the use of a dithering pattern. The 'Dithered 16bpp (Native)' setting emulates this behaviour. Selecting '32 bpp' increases the color depth such that smooth gradients can be achieved without dithering, allowing for a 'cleaner' output image. Only the OpenGL renderer supports this choice (the Software renderer forces 16 bpp, while the Vulkan renderer forces 32 bpp). Note: the 'Dithering Pattern' option should be disabled when using increased color depth.",
+      {
+         { "16bpp(native)", "16 bpp (Native)" },
+         { "32bpp",         "32 bpp" },
+         { NULL, NULL },
+      },
+      "16bpp(native)"
+   },
+#endif
+   {
+      BEETLE_OPT(dither_mode),
+      "Dithering Pattern",
+      "Configures emulation of the dithering pattern used by original hardware to 'smooth out' color banding artefacts caused by the PSX's limited color depth. '1x (Native)' is authentic, but when running at increased internal GPU resolution the 'Internal Resolution' setting produces cleaner results. Note: This option should be disabled when 'Internal Color Depth' is set to '32 bpp', or when using the Vulkan renderer.",
+      {
+         { "1x(native)",          "1x (Native)" },
+         { "internal resolution", "Internal Resolution" },
+         { "disabled",            NULL },
+         { NULL, NULL },
+      },
+      "1x(native)"
+   },
+#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_VULKAN)
+   {
+      BEETLE_OPT(filter),
+      "Texture Filtering",
+      "Enables the use of a filter to modify/enhance the appearance of polygon textures and 2D artwork. 'Nearest' emulates original hardware. 'Bilinear' and '3-Point' are smoothing filters, which reduce pixelation via blurring. 'SABR', 'xBR' and 'JINC2' are upscaling filters, which improve texture fidelity/sharpness at the expense of increased performance requirements. Only supported by the 'Hardware' renderers.",
+      {
+         { "nearest",  "Nearest" },
+         { "SABR",     NULL },
+         { "xBR",      NULL },
+         { "bilinear", "Bilinear" },
+         { "3-point",  "3-Point" },
+         { "JINC2",    NULL },
+         { NULL, NULL },
+      },
+      "nearest"
+   },
+#endif
 #ifdef HAVE_VULKAN
    {
       BEETLE_OPT(adaptive_smoothing),
@@ -124,32 +180,7 @@ struct retro_core_option_definition option_defs_us[] = {
       "disabled"
    },
 #endif
-   {
-      BEETLE_OPT(internal_resolution),
-      "Internal GPU Resolution",
-      "Select internal resolution multiplier. Resolutions higher than '1x (Native)' improve the fidelity of 3D models at the expense of increased performance requirements. 2D elements are generally unaffected by this setting.",
-      {
-         { "1x(native)", "1x (Native)" },
-         { "2x",         NULL },
-         { "4x",         NULL },
-         { "8x",         NULL },
-         { "16x",        NULL },
-         { NULL, NULL },
-      },
-      "1x(native)"
-   },
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
-   {
-      BEETLE_OPT(depth),
-      "Internal Color Depth",
-      "The PSX has a limited color depth of 16 bits per pixel (bpp). This leads to 'banding' effects (uneven color gradients) which are 'smoothed out' by original hardware through the use of a dithering pattern. The 'Dithered 16bpp (Native)' setting emulates this behaviour. Selecting '32 bpp' increases the color depth such that smooth gradients can be achieved without dithering, allowing for a 'cleaner' output image. Only the OpenGL renderer supports this choice (the Software renderer forces 16 bpp, while the Vulkan renderer forces 32 bpp). Note: the 'Dithering Pattern' option should be disabled when using increased color depth.",
-      {
-         { "16bpp(native)", "16 bpp (Native)" },
-         { "32bpp",         "32 bpp" },
-         { NULL, NULL },
-      },
-      "16bpp(native)"
-   },
    {
       BEETLE_OPT(wireframe),
       "Wireframe Mode",
@@ -171,23 +202,6 @@ struct retro_core_option_definition option_defs_us[] = {
          { NULL, NULL },
       },
       "disabled"
-   },
-#endif
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_VULKAN)
-   {
-      BEETLE_OPT(filter),
-      "Texture Filtering",
-      "Enables the use of a filter to modify/enhance the appearance of polygon textures and 2D artwork. 'Nearest' emulates original hardware. 'Bilinear' and '3-Point' are smoothing filters, which reduce pixelation via blurring. 'SABR', 'xBR' and 'JINC2' are upscaling filters, which improve texture fidelity/sharpness at the expense of increased performance requirements. Only supported by the 'Hardware' renderers.",
-      {
-         { "nearest",  "Nearest" },
-         { "SABR",     NULL },
-         { "xBR",      NULL },
-         { "bilinear", "Bilinear" },
-         { "3-point",  "3-Point" },
-         { "JINC2",    NULL },
-         { NULL, NULL },
-      },
-      "nearest"
    },
 #endif
    {
@@ -227,6 +241,17 @@ struct retro_core_option_definition option_defs_us[] = {
    },
 #endif
    {
+      BEETLE_OPT(display_internal_fps),
+      "Display Internal FPS",
+      "When enabled, shows the frame rate at which the emulated PSX is rendering content. Note: This requires 'Onscreen Notifications' to be enabled in the RetroArch 'Onscreen Display' settings menu.",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
       BEETLE_OPT(lineRender),
       "Line-to-Quad Hack",
       "Certain games employ a special technique for drawing horizontal lines, which involves stretching single-pixel-high triangles across the screen in a manner that causes the PSX hardware to rasterise them as a row of pixels. Examples include Doom/Hexen, and the water effects in Soul Blade. When running such games with a 'Hardware' renderer and/or with an internal GPU resolution higher than native, these triangles no longer resolve as a line, causing gaps to appear in the output image. Setting 'Line-to-Quad Hack' to 'Default' solves this issue by detecting small triangles and converting them as required. The 'Aggressive' option will likely introduce visual glitches due to false positives, but is needed for correct rendering of some 'difficult' titles (e.g. Dark Forces, Duke Nukem).",
@@ -237,17 +262,6 @@ struct retro_core_option_definition option_defs_us[] = {
          { NULL, NULL },
       },
       "default"
-   },
-   {
-      BEETLE_OPT(widescreen_hack),
-      "Widescreen Mode Hack",
-      "When enabled, forces content to be rendered with an aspect ratio of 16:9. Produces best results with fully 3D games. 2D artwork will be stretched horizontally.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "disabled"
    },
    {
       BEETLE_OPT(frame_duping),
@@ -353,21 +367,9 @@ struct retro_core_option_definition option_defs_us[] = {
       "disabled"
    },
    {
-      BEETLE_OPT(dither_mode),
-      "Dithering Pattern",
-      "Configures emulation of the dithering pattern used by original hardware to 'smooth out' color banding artefacts caused by the PSX's limited color depth. '1x (Native)' is authentic, but when running at increased internal GPU resolution the 'Internal Resolution' setting produces cleaner results. Note: This option should be disabled when 'Internal Color Depth' is set to '32 bpp', or when using the Vulkan renderer.",
-      {
-         { "1x(native)",          "1x (Native)" },
-         { "internal resolution", "Internal Resolution" },
-         { "disabled",            NULL },
-         { NULL, NULL },
-      },
-      "1x(native)"
-   },
-   {
-      BEETLE_OPT(display_internal_fps),
-      "Display Internal FPS",
-      "When enabled, shows the frame rate at which the emulated PSX is rendering content. Note: This requires 'Onscreen Notifications' to be enabled in the RetroArch 'Onscreen Display' settings menu.",
+      BEETLE_OPT(widescreen_hack),
+      "Widescreen Mode Hack",
+      "When enabled, forces content to be rendered with an aspect ratio of 16:9. Produces best results with fully 3D games. 2D artwork will be stretched horizontally.",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -482,213 +484,6 @@ struct retro_core_option_definition option_defs_us[] = {
       "0"
    },
 #endif
-   {
-      BEETLE_OPT(analog_calibration),
-      "Analog Self-Calibration",
-      "When enabled, and when the input device type is set to 'DualShock', 'Analog Controller', 'Analog Joystick' or 'neGcon', allows dynamic calibration of analog inputs. Maximum registered input values are monitored in real time, and used to scale analog coordinates passed to the emulator. This is generally not required when using high quality controllers, but it can improve accuracy/response when using gamepads with 'flawed' analog sticks (i.e. that have range/symmetry issues). For best results, the left and right analog sticks should be rotated at full extent to 'tune' the calibration algorithm before playing (this must be done each time content is launched).",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
-      BEETLE_OPT(analog_toggle),
-      "DualShock Analog Button Toggle",
-      "When the input device type is 'DualShock', sets the state of the 'ANALOG' button found on original controller hardware. If disabled, the left and right analog sticks are always active. If enabled, the analog sticks are inactive by default, but may be toggled on by pressing and holding START+SELECT+L1+L2+R1+R2.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
-      BEETLE_OPT(enable_multitap_port1),
-      "Port 1: Multitap Enable",
-      "Enables/Disables multitap functionality on port 1.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
-      BEETLE_OPT(enable_multitap_port2),
-      "Port 2: Multitap Enable",
-      "Enables/Disables multitap functionality on port 2.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
-      BEETLE_OPT(gun_cursor),
-      "Gun Cursor",
-      "Select the gun cursor to be displayed on screen while using the the 'Guncon / G-Con 45' and 'Justifier' input device types. When disabled, cross hairs are always hidden.",
-      {
-         { "cross", "Cross" },
-         { "dot",   "Dot" },
-         { "off",   "disabled" },
-         { NULL, NULL },
-      },
-      "cross"
-   },
-   {
-      BEETLE_OPT(gun_input_mode),
-      "Gun Input Mode",
-      "When device type is set to 'Guncon / G-Con 45' or 'Justifier', specify whether to use a mouse-controlled 'Light Gun' or 'Touchscreen' input.",
-      {
-         { "lightgun",    "Light Gun" },
-         { "touchscreen", "Touchscreen" },
-         { NULL, NULL },
-      },
-      "lightgun"
-   },
-   {
-      BEETLE_OPT(mouse_sensitivity),
-      "Mouse Sensitivity",
-      "Configure the response of the 'Mouse' input device type.",
-      {
-         { "5%",   NULL },
-         { "10%",  NULL },
-         { "15%",  NULL },
-         { "20%",  NULL },
-         { "25%",  NULL },
-         { "30%",  NULL },
-         { "35%",  NULL },
-         { "40%",  NULL },
-         { "45%",  NULL },
-         { "50%",  NULL },
-         { "55%",  NULL },
-         { "60%",  NULL },
-         { "65%",  NULL },
-         { "70%",  NULL },
-         { "75%",  NULL },
-         { "80%",  NULL },
-         { "85%",  NULL },
-         { "90%",  NULL },
-         { "95%",  NULL },
-         { "100%", NULL },
-         { "105%", NULL },
-         { "110%", NULL },
-         { "115%", NULL },
-         { "120%", NULL },
-         { "125%", NULL },
-         { "130%", NULL },
-         { "135%", NULL },
-         { "140%", NULL },
-         { "145%", NULL },
-         { "150%", NULL },
-         { "155%", NULL },
-         { "160%", NULL },
-         { "165%", NULL },
-         { "170%", NULL },
-         { "175%", NULL },
-         { "180%", NULL },
-         { "185%", NULL },
-         { "190%", NULL },
-         { "195%", NULL },
-         { "200%", NULL },
-         { NULL, NULL },
-      },
-      "100%"
-   },
-   {
-      BEETLE_OPT(negcon_deadzone),
-      "NegCon Twist Deadzone",
-      "Sets the deadzone of the RetroPad left analog stick when simulating the 'twist' action of emulated 'neGcon' input devices. Used to eliminate controller drift. Note: Most negCon-compatible titles provide in-game options for setting a 'twist' deadzone value. To avoid loss of precision, the in-game deadzone should *always* be set to zero. Any required adjustments should *only* be applied via this core option. This is particularly important when 'NegCon Twist Response' is set to 'Quadratic' or 'Cubic'.",
-      {
-         { "0%",  NULL },
-         { "5%",  NULL },
-         { "10%", NULL },
-         { "15%", NULL },
-         { "20%", NULL },
-         { "25%", NULL },
-         { "30%", NULL },
-         { NULL, NULL },
-      },
-      "0%"
-   },
-   {
-      BEETLE_OPT(negcon_response),
-      "NegCon Twist Response",
-      "Specifies the response of the RetroPad left analog stick when simulating the 'twist' action of emulated 'neGcon' input devices. Analog stick displacement may be mapped to negCon rotation angle either linearly, quadratically or cubically. 'Quadratic' allows for greater precision than 'Linear' when making small movements. 'Cubic' further increases small movement precision, but 'exaggerates' larger movements. Note: 'Linear' is only recommended when using racing wheel peripherals. Conventional gamepads implement analog input in a manner fundamentally different from the neGcon 'twist' mechanism, such that linear mapping over-amplifies small movements, impairing fine control. In most cases, 'Quadratic' provides the closest approximation of real hardware.",
-      {
-         { "linear",    "Linear" },
-         { "quadratic", "Quadratic" },
-         { "cubic",     "Cubic" },
-         { NULL, NULL },
-      },
-      "linear"
-   },
-#ifndef EMSCRIPTEN
-   {
-      BEETLE_OPT(cd_access_method),
-      "CD Access Method (Restart)",
-      "Select method used to read data from content disk images. 'Synchronous' mimics original hardware. 'Asynchronous' can reduce stuttering on devices with slow storage. 'Pre-Cache' loads the entire disk image into memory when launching content; this provides the best performance and may improve in-game loading times, at the expense of increased RAM usage and an initial delay at startup.",
-      {
-         { "sync",     "Synchronous" },
-         { "async",    "Asynchronous" },
-         { "precache", "Pre-Cache" },
-         { NULL, NULL },
-      },
-      "sync"
-   },
-#endif
-   {
-      BEETLE_OPT(use_mednafen_memcard0_method),
-      "Memory Card 0 Method (Restart)",
-      "Choose the save data format used for memory card 0. 'Libretro' is recommended. 'Mednafen' may be used for compatibility with the stand-alone version of Mednafen.",
-      {
-         { "libretro", "Libretro" },
-         { "mednafen", "Mednafen" },
-         { NULL, NULL },
-      },
-      "libretro"
-   },
-   {
-      BEETLE_OPT(enable_memcard1),
-      "Enable Memory Card 1",
-      "Select whether to emulate a second memory card in slot 1. When disabled, games can only access the memory card in slot 0. Note: Some games require this option to be enabled for correct operation (e.g. Codename Tenka).",
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL },
-      },
-      "enabled"
-   },
-   {
-      BEETLE_OPT(shared_memory_cards),
-      "Shared Memcards (Restart)",
-      "When enabled, all games will save to and load from the same memory card data files. When disabled, separate memory card files will be generated for each item of loaded content. Note: If shared memory cards are enabled, the 'Memory Card 0 Method' option *must* be set to 'Mednafen' for correct operation.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
-      BEETLE_OPT(cd_fastload),
-      "Increase CD Loading Speed",
-      "Select disk access speed multiplier. Setting this higher than '2x (Native)' can greatly reduce in-game loading times, but may introduce errors/timing glitches. Some games break entirely if the loading speed is increased above a certain value.",
-      {
-         { "2x(native)", "2x (Native)" },
-         { "4x",          NULL },
-         { "6x",          NULL },
-         { "8x",          NULL },
-         { "10x",         NULL },
-         { "12x",         NULL },
-         { "14x",         NULL },
-         { NULL, NULL },
-      },
-      "2x(native)"
-   },
    {
       BEETLE_OPT(initial_scanline),
       "Initial Scanline - NTSC (Restart)",
@@ -894,6 +689,213 @@ struct retro_core_option_definition option_defs_us[] = {
          { NULL, NULL },
       },
       "287"
+   },
+#ifndef EMSCRIPTEN
+   {
+      BEETLE_OPT(cd_access_method),
+      "CD Access Method (Restart)",
+      "Select method used to read data from content disk images. 'Synchronous' mimics original hardware. 'Asynchronous' can reduce stuttering on devices with slow storage. 'Pre-Cache' loads the entire disk image into memory when launching content; this provides the best performance and may improve in-game loading times, at the expense of increased RAM usage and an initial delay at startup.",
+      {
+         { "sync",     "Synchronous" },
+         { "async",    "Asynchronous" },
+         { "precache", "Pre-Cache" },
+         { NULL, NULL },
+      },
+      "sync"
+   },
+#endif
+   {
+      BEETLE_OPT(cd_fastload),
+      "Increase CD Loading Speed",
+      "Select disk access speed multiplier. Setting this higher than '2x (Native)' can greatly reduce in-game loading times, but may introduce errors/timing glitches. Some games break entirely if the loading speed is increased above a certain value.",
+      {
+         { "2x(native)", "2x (Native)" },
+         { "4x",          NULL },
+         { "6x",          NULL },
+         { "8x",          NULL },
+         { "10x",         NULL },
+         { "12x",         NULL },
+         { "14x",         NULL },
+         { NULL, NULL },
+      },
+      "2x(native)"
+   },
+   {
+      BEETLE_OPT(use_mednafen_memcard0_method),
+      "Memory Card 0 Method (Restart)",
+      "Choose the save data format used for memory card 0. 'Libretro' is recommended. 'Mednafen' may be used for compatibility with the stand-alone version of Mednafen.",
+      {
+         { "libretro", "Libretro" },
+         { "mednafen", "Mednafen" },
+         { NULL, NULL },
+      },
+      "libretro"
+   },
+   {
+      BEETLE_OPT(enable_memcard1),
+      "Enable Memory Card 1",
+      "Select whether to emulate a second memory card in slot 1. When disabled, games can only access the memory card in slot 0. Note: Some games require this option to be enabled for correct operation (e.g. Codename Tenka).",
+      {
+         { "enabled",  NULL },
+         { "disabled", NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      BEETLE_OPT(shared_memory_cards),
+      "Shared Memcards (Restart)",
+      "When enabled, all games will save to and load from the same memory card data files. When disabled, separate memory card files will be generated for each item of loaded content. Note: If shared memory cards are enabled, the 'Memory Card 0 Method' option *must* be set to 'Mednafen' for correct operation.",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      BEETLE_OPT(analog_calibration),
+      "Analog Self-Calibration",
+      "When enabled, and when the input device type is set to 'DualShock', 'Analog Controller', 'Analog Joystick' or 'neGcon', allows dynamic calibration of analog inputs. Maximum registered input values are monitored in real time, and used to scale analog coordinates passed to the emulator. This is generally not required when using high quality controllers, but it can improve accuracy/response when using gamepads with 'flawed' analog sticks (i.e. that have range/symmetry issues). For best results, the left and right analog sticks should be rotated at full extent to 'tune' the calibration algorithm before playing (this must be done each time content is launched).",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      BEETLE_OPT(analog_toggle),
+      "DualShock Analog Button Toggle",
+      "When the input device type is 'DualShock', sets the state of the 'ANALOG' button found on original controller hardware. If disabled, the left and right analog sticks are always active. If enabled, the analog sticks are inactive by default, but may be toggled on by pressing and holding START+SELECT+L1+L2+R1+R2.",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      BEETLE_OPT(enable_multitap_port1),
+      "Port 1: Multitap Enable",
+      "Enables/Disables multitap functionality on port 1.",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      BEETLE_OPT(enable_multitap_port2),
+      "Port 2: Multitap Enable",
+      "Enables/Disables multitap functionality on port 2.",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      BEETLE_OPT(gun_input_mode),
+      "Gun Input Mode",
+      "When device type is set to 'Guncon / G-Con 45' or 'Justifier', specify whether to use a mouse-controlled 'Light Gun' or 'Touchscreen' input.",
+      {
+         { "lightgun",    "Light Gun" },
+         { "touchscreen", "Touchscreen" },
+         { NULL, NULL },
+      },
+      "lightgun"
+   },
+   {
+      BEETLE_OPT(gun_cursor),
+      "Gun Cursor",
+      "Select the gun cursor to be displayed on screen while using the the 'Guncon / G-Con 45' and 'Justifier' input device types. When disabled, cross hairs are always hidden.",
+      {
+         { "cross", "Cross" },
+         { "dot",   "Dot" },
+         { "off",   "disabled" },
+         { NULL, NULL },
+      },
+      "cross"
+   },
+   {
+      BEETLE_OPT(mouse_sensitivity),
+      "Mouse Sensitivity",
+      "Configure the response of the 'Mouse' input device type.",
+      {
+         { "5%",   NULL },
+         { "10%",  NULL },
+         { "15%",  NULL },
+         { "20%",  NULL },
+         { "25%",  NULL },
+         { "30%",  NULL },
+         { "35%",  NULL },
+         { "40%",  NULL },
+         { "45%",  NULL },
+         { "50%",  NULL },
+         { "55%",  NULL },
+         { "60%",  NULL },
+         { "65%",  NULL },
+         { "70%",  NULL },
+         { "75%",  NULL },
+         { "80%",  NULL },
+         { "85%",  NULL },
+         { "90%",  NULL },
+         { "95%",  NULL },
+         { "100%", NULL },
+         { "105%", NULL },
+         { "110%", NULL },
+         { "115%", NULL },
+         { "120%", NULL },
+         { "125%", NULL },
+         { "130%", NULL },
+         { "135%", NULL },
+         { "140%", NULL },
+         { "145%", NULL },
+         { "150%", NULL },
+         { "155%", NULL },
+         { "160%", NULL },
+         { "165%", NULL },
+         { "170%", NULL },
+         { "175%", NULL },
+         { "180%", NULL },
+         { "185%", NULL },
+         { "190%", NULL },
+         { "195%", NULL },
+         { "200%", NULL },
+         { NULL, NULL },
+      },
+      "100%"
+   },
+   {
+      BEETLE_OPT(negcon_response),
+      "NegCon Twist Response",
+      "Specifies the response of the RetroPad left analog stick when simulating the 'twist' action of emulated 'neGcon' input devices. Analog stick displacement may be mapped to negCon rotation angle either linearly, quadratically or cubically. 'Quadratic' allows for greater precision than 'Linear' when making small movements. 'Cubic' further increases small movement precision, but 'exaggerates' larger movements. Note: 'Linear' is only recommended when using racing wheel peripherals. Conventional gamepads implement analog input in a manner fundamentally different from the neGcon 'twist' mechanism, such that linear mapping over-amplifies small movements, impairing fine control. In most cases, 'Quadratic' provides the closest approximation of real hardware.",
+      {
+         { "linear",    "Linear" },
+         { "quadratic", "Quadratic" },
+         { "cubic",     "Cubic" },
+         { NULL, NULL },
+      },
+      "linear"
+   },
+   {
+      BEETLE_OPT(negcon_deadzone),
+      "NegCon Twist Deadzone",
+      "Sets the deadzone of the RetroPad left analog stick when simulating the 'twist' action of emulated 'neGcon' input devices. Used to eliminate controller drift. Note: Most negCon-compatible titles provide in-game options for setting a 'twist' deadzone value. To avoid loss of precision, the in-game deadzone should *always* be set to zero. Any required adjustments should *only* be applied via this core option. This is particularly important when 'NegCon Twist Response' is set to 'Quadratic' or 'Cubic'.",
+      {
+         { "0%",  NULL },
+         { "5%",  NULL },
+         { "10%", NULL },
+         { "15%", NULL },
+         { "20%", NULL },
+         { "25%", NULL },
+         { "30%", NULL },
+         { NULL, NULL },
+      },
+      "0%"
    },
    { NULL, NULL, NULL, {{0}}, NULL },
 };

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -189,6 +189,7 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "nearest"
    },
+#endif
    {
       BEETLE_OPT(pgxp_mode),
       "PGXP Operation Mode",
@@ -201,6 +202,7 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "disabled"
    },
+#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_VULKAN)
    {
       BEETLE_OPT(pgxp_vertex),
       "PGXP Vertex Cache",

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -103,7 +103,7 @@ struct retro_core_option_definition option_defs_us[] = {
       "Multi-Sampled Anti Aliasing",
       "Apply multi-sample anti-aliasing (MSAA) to rendered content. This is a type of spatial anti-aliasing similar to supersampling, but of somewhat lower quality and with (correspondingly) lower performance requirements. Improves the appearance of 3D objects. Only supported by the Vulkan renderer.",
       {
-         { "1x",  NULL },
+         { "1x",  "1x (Default)" },
          { "2x",  NULL },
          { "4x",  NULL },
          { "8x",  NULL },
@@ -144,11 +144,11 @@ struct retro_core_option_definition option_defs_us[] = {
       "Internal Color Depth",
       "The PSX has a limited color depth of 16 bits per pixel (bpp). This leads to 'banding' effects (uneven color gradients) which are 'smoothed out' by original hardware through the use of a dithering pattern. The 'Dithered 16bpp (Native)' setting emulates this behaviour. Selecting '32 bpp' increases the color depth such that smooth gradients can be achieved without dithering, allowing for a 'cleaner' output image. Only the OpenGL renderer supports this choice (the Software renderer forces 16 bpp, while the Vulkan renderer forces 32 bpp). Note: the 'Dithering Pattern' option should be disabled when using increased color depth.",
       {
-         { "dithered 16bpp (native)", "Dithered 16 bpp (Native)" },
-         { "32bpp",                   "32 bpp" },
+         { "16bpp(native)", "16 bpp (Native)" },
+         { "32bpp",         "32 bpp" },
          { NULL, NULL },
       },
-      "dithered 16bpp (native)"
+      "16bpp(native)"
    },
    {
       BEETLE_OPT(wireframe),
@@ -270,7 +270,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "70%",           NULL },
          { "80%",           NULL },
          { "90%",           NULL },
-         { "100% (native)", "100% (Native)" },
+         { "100%(native)", "100% (Native)" },
          { "110%",          NULL },
          { "120%",          NULL },
          { "130%",          NULL },
@@ -313,7 +313,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "500%",          NULL },
          { NULL, NULL },
       },
-      "100% (native)"
+      "100%(native)"
    },
    {
       BEETLE_OPT(gte_overclock),
@@ -392,14 +392,14 @@ struct retro_core_option_definition option_defs_us[] = {
       "When 'Crop Overscan' is enabled, this option further reduces the width of the cropped image by the specified number of pixels. Note: This can have unintended consequences. While the absolute width is reduced, the resultant video is still scaled to the currently set aspect ratio. Enabling 'Additional Cropping' may therefore cause horizontal stretching. As with 'Crop Overscan', currently only supported by the software renderer.",
       {
          { "disabled", NULL },
-         { "1 px",     NULL },
-         { "2 px",     NULL },
-         { "3 px",     NULL },
-         { "4 px",     NULL },
-         { "5 px",     NULL },
-         { "6 px",     NULL },
-         { "7 px",     NULL },
-         { "8 px",     NULL },
+         { "1px",     NULL },
+         { "2px",     NULL },
+         { "3px",     NULL },
+         { "4px",     NULL },
+         { "5px",     NULL },
+         { "6px",     NULL },
+         { "7px",     NULL },
+         { "8px",     NULL },
          { NULL, NULL },
       },
       "disabled"
@@ -410,14 +410,14 @@ struct retro_core_option_definition option_defs_us[] = {
       "When 'Crop Overscan' is enabled, allows the resultant cropped image to be offset horizontally to the right (positive) or left (negative) by the specified number of pixels. May be used to correct alignment issues. As with 'Crop Overscan', currently only supported by the software renderer.",
       {
          { "disabled", NULL },
-         { "-4 px",    NULL },
-         { "-3 px",    NULL },
-         { "-2 px",    NULL },
-         { "-1 px",    NULL },
-         { "1 px",     NULL },
-         { "2 px",     NULL },
-         { "3 px",     NULL },
-         { "4 px",     NULL },
+         { "-4px",    NULL },
+         { "-3px",    NULL },
+         { "-2px",    NULL },
+         { "-1px",    NULL },
+         { "+1px",     NULL },
+         { "+2px",     NULL },
+         { "+3px",     NULL },
+         { "+4px",     NULL },
          { NULL, NULL },
       },
       "disabled"
@@ -531,23 +531,23 @@ struct retro_core_option_definition option_defs_us[] = {
       "Gun Cursor",
       "Select the gun cursor to be displayed on screen while using the the 'Guncon / G-Con 45' and 'Justifier' input device types. When disabled, cross hairs are always hidden.",
       {
-         { "Cross", NULL },
-         { "Dot",   NULL },
-         { "Off",   "disabled" },
+         { "cross", "Cross" },
+         { "dot",   "Dot" },
+         { "off",   "disabled" },
          { NULL, NULL },
       },
-      "Cross"
+      "cross"
    },
    {
       BEETLE_OPT(gun_input_mode),
       "Gun Input Mode",
       "When device type is set to 'Guncon / G-Con 45' or 'Justifier', specify whether to use a mouse-controlled 'Light Gun' or 'Touchscreen' input.",
       {
-         { "Lightgun",    "Light Gun" },
-         { "Touchscreen", NULL },
+         { "lightgun",    "Light Gun" },
+         { "touchscreen", "Touchscreen" },
          { NULL, NULL },
       },
-      "Lightgun"
+      "lightgun"
    },
    {
       BEETLE_OPT(mouse_sensitivity),
@@ -600,19 +600,19 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       BEETLE_OPT(negcon_deadzone),
-      "NegCon Twist Deadzone (Percent)",
+      "NegCon Twist Deadzone",
       "Sets the deadzone of the RetroPad left analog stick when simulating the 'twist' action of emulated 'neGcon' input devices. Used to eliminate controller drift. Note: Most negCon-compatible titles provide in-game options for setting a 'twist' deadzone value. To avoid loss of precision, the in-game deadzone should *always* be set to zero. Any required adjustments should *only* be applied via this core option. This is particularly important when 'NegCon Twist Response' is set to 'Quadratic' or 'Cubic'.",
       {
-         { "0",  NULL },
-         { "5",  NULL },
-         { "10", NULL },
-         { "15", NULL },
-         { "20", NULL },
-         { "25", NULL },
-         { "30", NULL },
+         { "0%",  NULL },
+         { "5%",  NULL },
+         { "10%", NULL },
+         { "15%", NULL },
+         { "20%", NULL },
+         { "25%", NULL },
+         { "30%", NULL },
          { NULL, NULL },
       },
-      "0"
+      "0%"
    },
    {
       BEETLE_OPT(negcon_response),
@@ -678,7 +678,7 @@ struct retro_core_option_definition option_defs_us[] = {
       "Increase CD Loading Speed",
       "Select disk access speed multiplier. Setting this higher than '2x (Native)' can greatly reduce in-game loading times, but may introduce errors/timing glitches. Some games break entirely if the loading speed is increased above a certain value.",
       {
-         { "2x (native)", "2x (Native)" },
+         { "2x(native)", "2x (Native)" },
          { "4x",          NULL },
          { "6x",          NULL },
          { "8x",          NULL },
@@ -687,7 +687,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "14x",         NULL },
          { NULL, NULL },
       },
-      "2x (native)"
+      "2x(native)"
    },
    {
       BEETLE_OPT(initial_scanline),

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -379,8 +379,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       BEETLE_OPT(crop_overscan),
-      "Crop Overscan",
-      "By default, the software renderer adds horizontal padding (black bars or 'pillarboxes' on either side of the screen) to emulate the same black bars generated in analog video output by real PSX hardware. Enabling 'Crop Overscan' will remove horizontal padding and stretch the remaining output to the full window width. This option does not affect vertical overscan. Currently only supported by the software renderer, as the hardware renderers will always output without pillarboxing.",
+      "Crop Horizontal Overscan",
+      "By default, the renderers add horizontal padding (black bars or 'pillarboxes' on either side of the screen) to emulate the same black bars generated in analog video output by real PSX hardware. Enabling 'Crop Overscan' removes this horizontal padding.",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
@@ -486,8 +486,8 @@ struct retro_core_option_definition option_defs_us[] = {
 #endif
    {
       BEETLE_OPT(initial_scanline),
-      "Initial Scanline - NTSC (Restart)",
-      "Select the first displayed scanline when running NTSC content. Setting a value greater than zero will reduce the height of output images by cropping pixels from the topmost edge. May be used to counteract letterboxing. Note: This can have unintended consequences. While the absolute height is reduced, the resultant video is still scaled to the currently set aspect ratio. Non-zero values may therefore cause vertical stretching.",
+      "Initial Scanline - NTSC",
+      "Select the first displayed scanline when running NTSC content. Setting a value greater than zero will reduce the height of output images by cropping pixels from the topmost edge. May be used to counteract letterboxing. Requires restart for software renderer.",
       {
          { "0",  NULL },
          { "1",  NULL },
@@ -536,8 +536,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       BEETLE_OPT(last_scanline),
-      "Last Scanline - NTSC (Restart)",
-      "Select the last displayed scanline when running NTSC content. Setting a value less than 239 will reduce the height of output images by cropping pixels from the bottommost edge. May be used to counteract letterboxing. Note: This can have unintended consequences. While the absolute height is reduced, the resultant video is still scaled to the currently set aspect ratio. Values less than 239 may therefore cause vertical stretching.",
+      "Last Scanline - NTSC",
+      "Select the last displayed scanline when running NTSC content. Setting a value less than 239 will reduce the height of output images by cropping pixels from the bottommost edge. May be used to counteract letterboxing. Requires restart for software renderer.",
       {
          { "210", NULL },
          { "211", NULL },
@@ -575,8 +575,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       BEETLE_OPT(initial_scanline_pal),
-      "Initial Scanline - PAL (Restart)",
-      "Select the first displayed scanline when running PAL content. Setting a value greater than zero will reduce the height of output images by cropping pixels from the topmost edge. May be used to counteract letterboxing. Note: This can have unintended consequences. While the absolute height is reduced, the resultant video is still scaled to the currently set aspect ratio. Non-zero values may therefore cause vertical stretching.",
+      "Initial Scanline - PAL",
+      "Select the first displayed scanline when running PAL content. Setting a value greater than zero will reduce the height of output images by cropping pixels from the topmost edge. May be used to counteract letterboxing. Requires restart for software renderer.",
       {
          { "0",  NULL },
          { "1",  NULL },
@@ -625,8 +625,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       BEETLE_OPT(last_scanline_pal),
-      "Last Scanline - PAL (Restart)",
-      "Select the last displayed scanline when running PAL content. Setting a value less than 287 will reduce the height of output images by cropping pixels from the bottommost edge. May be used to counteract letterboxing. Note: This can have unintended consequences. While the absolute height is reduced, the resultant video is still scaled to the currently set aspect ratio. Values less than 287 may therefore cause vertical stretching.",
+      "Last Scanline - PAL",
+      "Select the last displayed scanline when running PAL content. Setting a value less than 287 will reduce the height of output images by cropping pixels from the bottommost edge. May be used to counteract letterboxing. Requires restart for software renderer.",
       {
          { "230", NULL },
          { "231", NULL },

--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -1184,7 +1184,6 @@ static void get_variables(uint8_t *upscaling, bool *display_vram)
    struct retro_variable var = {0};
 
    var.key = BEETLE_OPT(internal_resolution);
-
    if (upscaling)
    {
       if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
@@ -1242,9 +1241,9 @@ static bool GlRenderer_new(GlRenderer *renderer, DrawConfig config)
    bool crop_overscan = true;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (strcmp(var.value, "enabled") == 0)
+      if (!strcmp(var.value, "enabled"))
          crop_overscan = true;
-      else if (strcmp(var.value, "disabled") == 0)
+      else if (!strcmp(var.value, "disabled"))
          crop_overscan = false;
    }
 
@@ -1710,9 +1709,9 @@ static bool retro_refresh_variables(GlRenderer *renderer)
    bool crop_overscan = true;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (strcmp(var.value, "enabled") == 0)
+      if (!strcmp(var.value, "enabled"))
          crop_overscan = true;
-      else if (strcmp(var.value, "disabled") == 0)
+      else if (!strcmp(var.value, "disabled"))
          crop_overscan = false;
    }
 
@@ -1770,7 +1769,6 @@ static bool retro_refresh_variables(GlRenderer *renderer)
 
    var.key = BEETLE_OPT(depth);
    uint8_t depth = 16;
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (!strcmp(var.value, "32bpp"))
@@ -3214,8 +3212,8 @@ static bool rsx_vulkan_open(bool is_pal)
 static void rsx_vulkan_refresh_variables(void)
 {
    struct retro_variable var = {0};
-   var.key = BEETLE_OPT(renderer_software_fb);
 
+   var.key = BEETLE_OPT(renderer_software_fb);
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (!strcmp(var.value, "enabled"))


### PR DESCRIPTION
PR has a number of small fixes with some code cleanup that I merged in from rz5's other PR into some other cleanup/reorganizing. Changes have been grouped into distinct commits so they're easy to follow. 

The cleanup merging isn't quite done yet but there's a pretty big change I made with core options reordering so it's probably fair to open up to review for now.

**Core options reordering**

Some notes on options
* Internal Color Depth: SW locks to 16, VK autos based on dithering setting. Color depth and dithering should be put together because they are settings that are toggled in relation to one another (at least for GL).
* Texture Filtering: Possible minor optimization? This option is checked by all renderers in `check_variables` but the variables that are set by it in `libretro_cbs.h` seem to only be used by the VK renderer.
* PGXP Operation Mode: Some commit last month unhid this for toggling in SW mode but didn't actually allow it to be built for the SW-only core. A commit in this PR exposes it to be built for the SW-only core.
* Initial/Last Scanline: Not yet implemented for Vulkan, unfortunately. I'll get around to it sometime.

Rules for reordering
* Options should be grouped by similarity, e.g. windowing and display area options like overscan cropping and initial/last scanline should be grouped together, etc.
* General image enhancement functionality such as Internal GPU Resolution and Depth/Dithering should be placed ahead of renderer-exclusive image enhancements.

Other notes
* I have no personal preference on relative ordering of categories, e.g. if windowing should come before or after speedups, so I just went with what seemed sane.
* This reorganization makes the case for greatly reducing the sublabels. Some of them have way too much unnecessary information. Still working on this slowly alongside the multitude of other things that need to be done.
* Also would be nice to have options categories in libretro (if this doesn't already exist) since we have so many, but that's more QOL than absolutely necessary.

**Current Order**

Checkmarks denote if the option has any effect (not whether they are included in a build) and indicate option visibility to the end user.

| Option Name | Option Key | Software | OpenGL | Vulkan |
| --- | --- | --- | --- | --- |
| Renderer | `renderer` | ✔ | ✔ | ✔ |
| Software Framebuffer | `renderer_software_fb` | ✖ | ✔ | ✔ |
| Adaptive Smoothing | `adaptive_smoothing` | ✖ | ✖ | ✔ |
| Supersampling | `super_sampling` | ✖ | ✖ | ✔ |
| Multi-Sampled Anti Aliasing | `msaa` | ✖ | ✖ | ✔ |
| MDEC YUV Chroma Filter | `mdec_yuv` | ✖ | ✖ | ✔ |
| Internal GPU Resolution |`internal_resolution` | ✔ | ✔ | ✔ |
| Internal Color Depth | `depth` | ✖ | ✔ | ✖ |
| Wireframe Mode | `wireframe` | ✖ | ✔ | ✖ |
| Display Full VRAM | `display_vram` | ✖ | ✔ | ✖ |
| Texture Filtering | `filter` | ✖ | ✔ | ✔ |
| PGXP Operation Mode | `pgxp_mode` | ✔ | ✔ | ✔ |
| PGXP Vertex Cache | `pgxp_vertex` | ✖ | ✔ | ✔ |
| PGXP Perspective Correct Texturing | `pgxp_texture` | ✖ | ✔ | ✔ |
| Line-to-Quad Hack | `lineRender` | ✔ | ✔ | ✔ |
| Widescreen Mode Hack | `widescreen_hack` | ✔ | ✔ | ✔ |
| Frame Duping (Speedup) | `frame_duping` | ✔ | ✖ | ✖ |
| CPU Frequency Scaling (Overclock) | `cpu_freq_scale` | ✔ | ✔ | ✔ |
| GTE Overclock | `gte_overclock` | ✔ | ✔ | ✔ |
| GPU Rasterizer Overclock | `gpu_overclock` | ✔ | ✔ | ✔ |
| Skip BIOS | `skip_bios` | ✔ | ✔ | ✔ |
| Dithering Pattern | `dither_mode` | ✔ | ✔ | ✔ |
| Display Internal FPS | `display_internal_fps` | ✔ | ✔ | ✔ |
| Crop Overscan | `crop_overscan` | ✔ | ✔ | ✔ |
| Additional Cropping | `image_crop` | ✔ | ✖ | ✖ |
| Offset Cropped Image | `image_offset` | ✔ | ✖ | ✖ |
| Analog Self-Calibration | `analog_calibration` | ✔ | ✔ | ✔ |
| DualShock Analog Button Toggle | `analog_toggle` | ✔ | ✔ | ✔ |
| Port 1: Multitap Enable | `enable_multitap_port1` | ✔ | ✔ | ✔ |
| Port 2: Multitap Enable | `enable_multitap_port2` | ✔ | ✔ | ✔ |
| Gun Cursor | `gun_cursor` | ✔ | ✔ | ✔ |
| Gun Input Mode | `gun_input_mode` | ✔ | ✔ | ✔ |
| Mouse Sensitivity | `mouse_sensitivity` | ✔ | ✔ | ✔ |
| NegCon Twist Deadzone | `negcon_deadzone` | ✔ | ✔ | ✔ |
| NegCon Twist Response | `negcon_response` | ✔ | ✔ | ✔ |
| CD Access Method | `cd_access_method` | ✔ | ✔ | ✔ |
| Memory Card 0 Method | `use_mednafen_memcard0_method` | ✔ | ✔ | ✔ |
| Enable Memory Card 1 | `enable_memcard1` | ✔ | ✔ | ✔ |
| Shared Memcards | `shared_memory_cards` | ✔ | ✔ | ✔ |
| Increase CD Loading Speed | `cd_fastload` | ✔ | ✔ | ✔ |
| Initial Scanline - NTSC | `initial_scanline` | ✔ | ✔ | ✖ |
| Last Scanline - NTSC | `last_scanline` | ✔ | ✔ | ✖ |
| Initial Scanline - PAL | `initial_scanline_pal` | ✔ | ✔ | ✖ |
| Last Scanline - PAL | `last_scanline_pal` | ✔ | ✔ | ✖ |

**New Order**

| Option Name | Option Key | Software | OpenGL | Vulkan |
| --- | --- | --- | --- | --- |
| Renderer | `renderer` | ✔ | ✔ | ✔ |
| Software Framebuffer | `renderer_software_fb` | ✖ | ✔ | ✔ |
| Internal GPU Resolution |`internal_resolution` | ✔ | ✔ | ✔ |
| Internal Color Depth | `depth` | ✖ | ✔ | ✖ |
| Dithering Pattern | `dither_mode` | ✔ | ✔ | ✔ |
| Texture Filtering | `filter` | ✖ | ✔ | ✔ |
| Adaptive Smoothing | `adaptive_smoothing` | ✖ | ✖ | ✔ |
| Supersampling | `super_sampling` | ✖ | ✖ | ✔ |
| Multi-Sampled Anti Aliasing | `msaa` | ✖ | ✖ | ✔ |
| MDEC YUV Chroma Filter | `mdec_yuv` | ✖ | ✖ | ✔ |
| Wireframe Mode | `wireframe` | ✖ | ✔ | ✖ |
| Display Full VRAM | `display_vram` | ✖ | ✔ | ✖ |
| PGXP Operation Mode | `pgxp_mode` | ✔ | ✔ | ✔ |
| PGXP Vertex Cache | `pgxp_vertex` | ✖ | ✔ | ✔ |
| PGXP Perspective Correct Texturing | `pgxp_texture` | ✖ | ✔ | ✔ |
| Display Internal FPS | `display_internal_fps` | ✔ | ✔ | ✔ |
| Line-to-Quad Hack | `lineRender` | ✔ | ✔ | ✔ |
| Frame Duping (Speedup) | `frame_duping` | ✔ | ✖ | ✖ |
| CPU Frequency Scaling (Overclock) | `cpu_freq_scale` | ✔ | ✔ | ✔ |
| GTE Overclock | `gte_overclock` | ✔ | ✔ | ✔ |
| GPU Rasterizer Overclock | `gpu_overclock` | ✔ | ✔ | ✔ |
| Skip BIOS | `skip_bios` | ✔ | ✔ | ✔ |
| Widescreen Mode Hack | `widescreen_hack` | ✔ | ✔ | ✔ |
| Crop Overscan | `crop_overscan` | ✔ | ✔ | ✔ |
| Additional Cropping | `image_crop` | ✔ | ✖ | ✖ |
| Offset Cropped Image | `image_offset` | ✔ | ✖ | ✖ |
| Initial Scanline - NTSC | `initial_scanline` | ✔ | ✔ | ✖ |
| Last Scanline - NTSC | `last_scanline` | ✔ | ✔ | ✖ |
| Initial Scanline - PAL | `initial_scanline_pal` | ✔ | ✔ | ✖ |
| Last Scanline - PAL | `last_scanline_pal` | ✔ | ✔ | ✖ |
| CD Access Method | `cd_access_method` | ✔ | ✔ | ✔ |
| Increase CD Loading Speed | `cd_fastload` | ✔ | ✔ | ✔ |
| Memory Card 0 Method | `use_mednafen_memcard0_method` | ✔ | ✔ | ✔ |
| Enable Memory Card 1 | `enable_memcard1` | ✔ | ✔ | ✔ |
| Shared Memcards | `shared_memory_cards` | ✔ | ✔ | ✔ |
| Analog Self-Calibration | `analog_calibration` | ✔ | ✔ | ✔ |
| DualShock Analog Button Toggle | `analog_toggle` | ✔ | ✔ | ✔ |
| Port 1: Multitap Enable | `enable_multitap_port1` | ✔ | ✔ | ✔ |
| Port 2: Multitap Enable | `enable_multitap_port2` | ✔ | ✔ | ✔ |
| Gun Input Mode | `gun_input_mode` | ✔ | ✔ | ✔ |
| Gun Cursor | `gun_cursor` | ✔ | ✔ | ✔ |
| Mouse Sensitivity | `mouse_sensitivity` | ✔ | ✔ | ✔ |
| NegCon Twist Response | `negcon_response` | ✔ | ✔ | ✔ |
| NegCon Twist Deadzone | `negcon_deadzone` | ✔ | ✔ | ✔ |
