### PR TITLE
Minor updates

### DIFF
--- a/mednafen/psx/gpu_polygon.cpp
+++ b/mednafen/psx/gpu_polygon.cpp
@@ -1026,7 +1026,6 @@ static void Command_DrawPolygon(PS_GPU *gpu, const uint32_t *cb)
 	do
 	{
 
-#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_VULKAN)
 		enum blending_modes blend_mode = BLEND_MODE_AVERAGE;
 
 		if (textured)
@@ -1160,7 +1159,6 @@ static void Command_DrawPolygon(PS_GPU *gpu, const uint32_t *cb)
 				gpu->killQuadPart = 0;
 			}
 		}
-#endif
 
       if (rsx_intf_is_type() == RSX_SOFTWARE)
       {

--- a/rsx/README.md
+++ b/rsx/README.md
@@ -1,0 +1,17 @@
+# RSX API and RSX OpenGL Renderer
+
+The RSX API is the means by which components of the Beetle PSX libretro core interface with the hardware renderers. The RSX API offers two general classes of functions for the core. The first class consists of various functions used to perform libretro-specific actions such as reading core options or preparing/finalizing the current emulation loop frame. The second class of functions consists of RSX interface functions that the emulated PSX GPU uses to issue commands to the hardware renderer. Not every emulated PSX GPU command has a corresponding RSX interface function, but the set of available functions can be extended or modified as necessary when bugs are discovered and higher accuracy is required.
+
+Each unique hardware renderer will implement RSX interface functions as another layer of function calls, typically but not necessarily one per RSX interface function. The RSX interface should then select the correct function to call based on the currently running hardware renderer.
+
+The RSX API also includes support for dumping RSX API calls to file, which can be utilized for debugging purposes by any renderers that implement RSX playback.
+
+The RSX OpenGL renderer is currently implemented alongside the RSX API in `rsx_intf.cpp`. OpenGL renderer functions are prefixed with `rsx_gl`.
+
+## Building
+
+The RSX API and RSX OpenGL renderer are components of the Beetle PSX libretro core. To build with OpenGL support, run `make HAVE_OPENGL=1` in the repository's top level directory. To build with all possible hardware renderers, instead run `make HAVE_HW=1`. To build with dump support, additionally pass `RSX_DUMP=1`.
+
+## Coding Style
+
+The preferred coding style for the rsx subdirectory is the libretro coding style. See: https://docs.libretro.com/development/coding-standards/


### PR DESCRIPTION
Just some minor stuff. Going to merge this in later if there aren't any concerns.

As discussed with r5 and hizzle a while back, we should allow the line render hack for the non-HW build. This is going to cause a slight performance hit for that build, but if we're allowing internal resolution upscaling we should allow this option as well since they're related.

Lot of core option sublabels rewritten to be less wordy or to rework information that was wrong. Still isn't 100% complete yet, but most of it is finished. There's just some lingering details and the NegCon sections remaining. I'd prefer to pare the information even further and leave most of it in the libretro docs, but that's personal taste. It would mostly be useful for menus like RetroArch's XMB that take a long time to scroll through if the sublabels are too long.