### PR TITLE
Lightgun Fixes

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -170,7 +170,8 @@ ifneq ($(HAVE_GRIFFIN), 1)
       SOURCES_CXX += $(CORE_EMU_DIR)/decomp.cpp
    endif
 
-   SOURCES_C += $(CORE_DIR)/libretro_cbs.c
+   SOURCES_C += $(CORE_DIR)/libretro_cbs.c \
+                $(CORE_DIR)/beetle_psx_globals.c
 
    ifeq ($(NEED_TREMOR), 1)
       SOURCES_C += $(sort $(wildcard $(MEDNAFEN_DIR)/tremor/*.c))

--- a/beetle_psx_globals.c
+++ b/beetle_psx_globals.c
@@ -8,3 +8,4 @@ int line_render_mode;
 int filter_mode;
 bool opaque_check;
 bool semitrans_check;
+bool crop_overscan = false;

--- a/beetle_psx_globals.c
+++ b/beetle_psx_globals.c
@@ -1,0 +1,10 @@
+#include <boolean.h>
+#include <stdint.h>
+
+bool content_is_pal = false;
+uint8_t widescreen_hack;
+uint8_t psx_gpu_upscale_shift;
+int line_render_mode;
+int filter_mode;
+bool opaque_check;
+bool semitrans_check;

--- a/beetle_psx_globals.h
+++ b/beetle_psx_globals.h
@@ -21,6 +21,7 @@ extern int line_render_mode;
 extern int filter_mode;
 extern bool opaque_check;
 extern bool semitrans_check;
+extern bool crop_overscan;
 
 #ifdef __cplusplus
 }

--- a/beetle_psx_globals.h
+++ b/beetle_psx_globals.h
@@ -1,0 +1,29 @@
+#ifndef BEETLE_PSX_GLOBALS_H__
+#define BEETLE_PSX_GLOBALS_H__
+
+#include <boolean.h>
+#include <stdint.h>
+
+/* Global state variables used by the Beetle PSX Core.
+ * These are typically set by core options and are used
+ * by methods in the Mednafen PSX module that have been
+ * modified for Beetle PSX.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern bool content_is_pal;
+extern uint8_t widescreen_hack;
+extern uint8_t psx_gpu_upscale_shift;
+extern int line_render_mode;
+extern int filter_mode;
+extern bool opaque_check;
+extern bool semitrans_check;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/input.cpp
+++ b/input.cpp
@@ -6,6 +6,7 @@
 #include "mednafen/git.h"
 #include "mednafen/psx/frontio.h"
 #include "input.h"
+#include "beetle_psx_globals.h"
 
 //------------------------------------------------------------------------------
 // Locals
@@ -533,15 +534,17 @@ void input_handle_lightgun_touchscreen( INPUT_DATA *p_input, int iplayer, retro_
    int gun_x_raw = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X);
    int gun_y_raw = input_state_cb( iplayer, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y);
 
+   // Comments by hiddenasbestos
    // .. scale into screen space:
    // NOTE: the scaling here is semi-guesswork, need to re-write.
    // TODO: Test with PAL games.
+   // Can also implement scaling with initial/last scanline
 
-   const int scale_x = 2800;
-   const int scale_y = 240;
+   const int scale_x = (crop_overscan ? 2560 : 2800);
+   const int scale_y = (content_is_pal ? 288 : 240);
 
-   int gun_x = ( ( gun_x_raw + 0x7fff ) * scale_x ) / (0x7fff << 1);
-   int gun_y = ( ( gun_y_raw + 0x7fff ) * scale_y ) / (0x7fff << 1);
+   int gun_x = (( ( gun_x_raw + 0x7fff ) * scale_x ) / (0x7fff << 1)) + (crop_overscan ? 120 : 0);
+   int gun_y = ( ( gun_y_raw + 0x7fff ) * scale_y ) / (0x7fff << 1) + (content_is_pal ? 4 : 0);
 
 #if 0
    int is_offscreen = 0;
@@ -649,15 +652,17 @@ void input_handle_lightgun( INPUT_DATA *p_input, int iplayer, retro_input_state_
       int gun_x_raw = input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X );
       int gun_y_raw = input_state_cb( iplayer, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y );
 
+      // Comments by hiddenasbestos
       // .. scale into screen space:
       // NOTE: the scaling here is semi-guesswork, need to re-write.
       // TODO: Test with PAL games.
+      // Can also implement scaling with initial/last scanline
 
-      const int scale_x = 2800;
-      const int scale_y = 240;
+      const int scale_x = (crop_overscan ? 2560 : 2800);
+      const int scale_y = (content_is_pal ? 288 : 240);
 
-      gun_x = ( ( gun_x_raw + 0x7fff ) * scale_x ) / (0x7fff << 1);
-      gun_y = ( ( gun_y_raw + 0x7fff ) * scale_y ) / (0x7fff << 1);
+      gun_x = (( ( gun_x_raw + 0x7fff ) * scale_x ) / (0x7fff << 1)) + (crop_overscan ? 120 : 0);
+      gun_y = ( ( gun_y_raw + 0x7fff ) * scale_y ) / (0x7fff << 1) + (content_is_pal ? 4 : 0);
    }
 
    // position

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1178,9 +1178,9 @@ void PSX_MemPoke32(uint32 A, uint32 V)
    MemPoke<uint32, false>(0, A, V);
 }
 
-void PSX_GPULineHook(const int32_t timestamp, const int32_t line_timestamp, bool vsync, uint32_t *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider)
+void PSX_GPULineHook(const int32_t timestamp, const int32_t line_timestamp, bool vsync, uint32_t *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider, const unsigned surf_pitchinpix, const unsigned upscale_factor)
 {
-   PSX_FIO->GPULineHook(timestamp, line_timestamp, vsync, pixels, format, width, pix_clock_offset, pix_clock, pix_clock_divider);
+   PSX_FIO->GPULineHook(timestamp, line_timestamp, vsync, pixels, format, width, pix_clock_offset, pix_clock, pix_clock_divider, surf_pitchinpix, upscale_factor);
 }
 
 static bool TestMagic(const char *name, RFILE *fp, int64_t size)

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -49,7 +49,6 @@ static bool allow_frame_duping = false;
 static bool failed_init = false;
 static unsigned image_offset = 0;
 static unsigned image_crop = 0;
-static bool crop_overscan = false;
 static bool enable_memcard1 = false;
 static bool enable_variable_serialization_size = false;
 static int frame_width = 0;

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -16,6 +16,7 @@
 #include "ugui_tools.h"
 #include "rsx/rsx_intf.h"
 #include "libretro_cbs.h"
+#include "beetle_psx_globals.h"
 #include "libretro_options.h"
 #include "input.h"
 
@@ -2911,11 +2912,11 @@ static void check_variables(bool startup)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "disabled") == 0)
-         lineRenderMode = 0;
+         line_render_mode = 0;
       else if (strcmp(var.value, "default") == 0)
-         lineRenderMode = 1;
+         line_render_mode = 1;
       else if (strcmp(var.value, "aggressive") == 0)
-         lineRenderMode = 2;
+         line_render_mode = 2;
    }
 
    var.key = BEETLE_OPT(filter);

--- a/libretro_cbs.c
+++ b/libretro_cbs.c
@@ -1,12 +1,4 @@
-#include <boolean.h>
 #include "libretro.h"
 
-bool content_is_pal = false;
 retro_video_refresh_t video_cb;
 retro_environment_t environ_cb;
-uint8_t widescreen_hack;
-uint8_t psx_gpu_upscale_shift;
-int lineRenderMode;
-int filter_mode;
-bool opaque_check;
-bool semitrans_check;

--- a/libretro_cbs.h
+++ b/libretro_cbs.h
@@ -1,21 +1,14 @@
 #ifndef __LIBRETRO_CBS_H
 #define __LIBRETRO_CBS_H
 
-#include <boolean.h>
+#include "libretro.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern bool content_is_pal;
 extern retro_video_refresh_t video_cb;
 extern retro_environment_t environ_cb;
-extern uint8_t widescreen_hack;
-extern uint8_t psx_gpu_upscale_shift;
-extern int lineRenderMode;
-extern int filter_mode;
-extern bool opaque_check;
-extern bool semitrans_check;
 
 #ifdef __cplusplus
 }

--- a/mednafen/psx/frontio.cpp
+++ b/mednafen/psx/frontio.cpp
@@ -260,7 +260,7 @@ bool InputDevice::RequireNoFrameskip(void)
  return false;
 }
 
-int32_t InputDevice::GPULineHook(const int32_t timestamp, bool vsync, uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider)
+int32_t InputDevice::GPULineHook(const int32_t timestamp, bool vsync, uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider, const unsigned surf_pitchinpix, const unsigned upscale_factor)
 {
  return(PSX_EVENT_MAXTS);
 }
@@ -1028,7 +1028,7 @@ void FrontIO::GPULineHook(const int32_t timestamp, const int32_t line_timestamp,
 
    for(unsigned i = 0; i < 8; i++)
    {
-      int32_t plts = Devices[i]->GPULineHook(line_timestamp, vsync, pixels, format, width, pix_clock_offset, pix_clock, pix_clock_divider);
+      int32_t plts = Devices[i]->GPULineHook(line_timestamp, vsync, pixels, format, width, pix_clock_offset, pix_clock, pix_clock_divider, surf_pitchinpix, upscale_factor);
 
       if(i < 2)
       {

--- a/mednafen/psx/frontio.cpp
+++ b/mednafen/psx/frontio.cpp
@@ -126,7 +126,7 @@ static void crosshair_plot( uint32 *pixels,
 	pixels[x] = MAKECOLOR(nr, ng, nb, a);
 }
 
-INLINE void InputDevice::DrawCrosshairs(uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock)
+INLINE void InputDevice::DrawCrosshairs(uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock, const unsigned surf_pitchinpix, const unsigned upscale_factor)
 {
 	switch ( chair_cursor )
 	{
@@ -147,12 +147,15 @@ INLINE void InputDevice::DrawCrosshairs(uint32 *pixels, const MDFN_PixelFormat* 
 				ic = 0;
 			}
 
-			x_start = std::max<int32>(0, chair_x - ic);
-			x_bound = std::min<int32>(width, chair_x + ic + 1);
+			x_start = std::max<int32>(0, (chair_x - ic) * upscale_factor);
+			x_bound = std::min<int32>(width * upscale_factor, (chair_x + ic + 1) * upscale_factor);
 
 			for ( int32 x = x_start; x < x_bound; x++ )
 			{
-				crosshair_plot( pixels, x, format, chair_r, chair_g, chair_b );
+            for (int row = 0; row < upscale_factor; row++)
+            {
+               crosshair_plot( pixels, x + (row * surf_pitchinpix), format, chair_r, chair_g, chair_b );
+            }
 			}
 		}
 
@@ -167,12 +170,15 @@ INLINE void InputDevice::DrawCrosshairs(uint32 *pixels, const MDFN_PixelFormat* 
 
 			ic = pix_clock / ( 762925 * 6 );
 
-			x_start = std::max<int32>(0, chair_x - ic);
-			x_bound = std::min<int32>(width, chair_x + ic);
+			x_start = std::max<int32>(0, (chair_x - ic) * upscale_factor);
+			x_bound = std::min<int32>(width * upscale_factor, (chair_x + ic) * upscale_factor);
 
 			for ( int32 x = x_start; x < x_bound; x++ )
 			{
-				crosshair_plot( pixels, x, format, chair_r, chair_g, chair_b );
+            for (int row = 0; row < upscale_factor; row++)
+            {
+               crosshair_plot( pixels, x + (row * surf_pitchinpix), format, chair_r, chair_g, chair_b );
+            }
 			}
 		}
 
@@ -1016,7 +1022,7 @@ bool FrontIO::RequireNoFrameskip(void)
    return(false);
 }
 
-void FrontIO::GPULineHook(const int32_t timestamp, const int32_t line_timestamp, bool vsync, uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider)
+void FrontIO::GPULineHook(const int32_t timestamp, const int32_t line_timestamp, bool vsync, uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider, const unsigned surf_pitchinpix, const unsigned upscale_factor)
 {
    Update(timestamp);
 
@@ -1044,7 +1050,7 @@ void FrontIO::GPULineHook(const int32_t timestamp, const int32_t line_timestamp,
    {
       for(unsigned i = 0; i < 8; i++)
       {
-         Devices[i]->DrawCrosshairs(pixels, format, width, pix_clock);
+         Devices[i]->DrawCrosshairs(pixels, format, width, pix_clock, surf_pitchinpix, upscale_factor);
       }
    }
 

--- a/mednafen/psx/frontio.h
+++ b/mednafen/psx/frontio.h
@@ -18,7 +18,8 @@ class InputDevice
 
       virtual bool RequireNoFrameskip(void);
       // Divide mouse X coordinate by pix_clock_divider in the lightgun code to get the coordinate in pixel(clocks).
-      virtual int32_t GPULineHook(const int32_t line_timestamp, bool vsync, uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider);
+      // GPULineHook modified to take upscale_factor for color detection (surf_pitchinpix unused)
+      virtual int32_t GPULineHook(const int32_t line_timestamp, bool vsync, uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider, const unsigned surf_pitchinpix, const unsigned upscale_factor);
 
       virtual void Update(const int32_t timestamp);	// Partially-implemented, don't rely on for timing any more fine-grained than a video frame for now.
       virtual void ResetTS(void);

--- a/mednafen/psx/frontio.h
+++ b/mednafen/psx/frontio.h
@@ -23,7 +23,8 @@ class InputDevice
       virtual void Update(const int32_t timestamp);	// Partially-implemented, don't rely on for timing any more fine-grained than a video frame for now.
       virtual void ResetTS(void);
 
-      void DrawCrosshairs(uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock);
+      // DrawCrosshairs modified to take surface pitch (in pixels) and upscale factor for software renderer internal upscaling
+      void DrawCrosshairs(uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock, const unsigned surf_pitchinpix, const unsigned upscale_factor);
 
       virtual void SetAMCT(bool enabled);
       virtual void SetCrosshairsCursor(int cursor);
@@ -74,7 +75,9 @@ class FrontIO
       void ResetTS(void);
 
       bool RequireNoFrameskip(void);
-      void GPULineHook(const int32_t timestamp, const int32_t line_timestamp, bool vsync, uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider);
+
+      // GPULineHook modified to take surface pitch (in pixels) and upscale factor for software renderer internal upscaling
+      void GPULineHook(const int32_t timestamp, const int32_t line_timestamp, bool vsync, uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider, const unsigned surf_pitchinpix, const unsigned upscale_factor);
 
       void UpdateInput(void);
       void SetInput(unsigned int port, const char *type, void *ptr);

--- a/mednafen/psx/gpu_polygon.cpp
+++ b/mednafen/psx/gpu_polygon.cpp
@@ -1,6 +1,6 @@
 #include <math.h>
 #include <algorithm>
-#include "libretro_cbs.h"
+#include "beetle_psx_globals.h"
 
 #define COORD_FBS 12
 #define COORD_MF_INT(n) ((n) << COORD_FBS)
@@ -1037,11 +1037,11 @@ static void Command_DrawPolygon(PS_GPU *gpu, const uint32_t *cb)
 		}
 
 		// Line Renderer: Detect triangles that would resolve as lines at x1 scale and create second triangle to make quad
-		if ((lineRenderMode != 0) && (!lineFound) && (numvertices == 3) && (textured))
+		if ((line_render_mode != 0) && (!lineFound) && (numvertices == 3) && (textured))
 		{
-			if(lineRenderMode == 1)
+			if(line_render_mode == 1)
 				lineFound = Hack_FindLine(gpu, vertices, lineVertices);		// Default enabled
-			else if (lineRenderMode == 2)
+			else if (line_render_mode == 2)
 				lineFound = Hack_ForceLine(gpu, vertices, lineVertices);	// Aggressive mode enabled (causes more artifacts)
 			else
 				lineFound = false;

--- a/mednafen/psx/input/guncon.cpp
+++ b/mednafen/psx/input/guncon.cpp
@@ -32,7 +32,8 @@ class InputDevice_GunCon : public InputDevice
       virtual int StateAction(StateMem* sm, int load, int data_only, const char* section_name);
       virtual void UpdateInput(const void *data);
       virtual bool RequireNoFrameskip(void);
-      virtual int32_t GPULineHook(const int32_t line_timestamp, bool vsync, uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider);
+      // GPULineHook modified to take upscale_factor for color detection (surf_pitchinpix unused)
+      virtual int32_t GPULineHook(const int32_t line_timestamp, bool vsync, uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider, const unsigned surf_pitchinpix, const unsigned upscale_factor);
 
       //
       //
@@ -187,7 +188,7 @@ bool InputDevice_GunCon::RequireNoFrameskip(void)
 }
 
 int32_t InputDevice_GunCon::GPULineHook(const int32_t line_timestamp, bool vsync, uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width,
-      const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider)
+      const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider, const unsigned surf_pitchinpix, const unsigned upscale_factor)
 {
    if(vsync && !prev_vsync)
       line_counter = 0;
@@ -207,7 +208,7 @@ int32_t InputDevice_GunCon::GPULineHook(const int32_t line_timestamp, bool vsync
          {
             int r, g, b, a;
 
-            format->DecodeColor(pixels[ix], r, g, b, a);
+            format->DecodeColor(pixels[ix * upscale_factor], r, g, b, a);
 
             if((r + g + b) >= 0x40)	// Wrong, but not COMPLETELY ABSOLUTELY wrong, at least. ;)
             {

--- a/mednafen/psx/input/justifier.cpp
+++ b/mednafen/psx/input/justifier.cpp
@@ -32,7 +32,8 @@ class InputDevice_Justifier : public InputDevice
       virtual int StateAction(StateMem* sm, int load, int data_only, const char* section_name);
       virtual void UpdateInput(const void *data);
       virtual bool RequireNoFrameskip(void);
-      virtual int32_t GPULineHook(const int32_t timestamp, bool vsync, uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider);
+      // GPULineHook modified to take upscale_factor for color detection (surf_pitchinpix unused)
+      virtual int32_t GPULineHook(const int32_t timestamp, bool vsync, uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider, const unsigned surf_pitchinpix, const unsigned upscale_factor);
 
       //
       //
@@ -186,7 +187,7 @@ bool InputDevice_Justifier::RequireNoFrameskip(void)
    return(true);
 }
 
-int32_t InputDevice_Justifier::GPULineHook(const int32_t timestamp, bool vsync, uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider)
+int32_t InputDevice_Justifier::GPULineHook(const int32_t timestamp, bool vsync, uint32 *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider, const unsigned surf_pitchinpix, const unsigned upscale_factor)
 {
    int32_t ret = PSX_EVENT_MAXTS;
 
@@ -210,7 +211,7 @@ int32_t InputDevice_Justifier::GPULineHook(const int32_t timestamp, bool vsync, 
       {
          int r, g, b, a;
 
-         format->DecodeColor(pixels[gxa], r, g, b, a);
+         format->DecodeColor(pixels[gxa * upscale_factor], r, g, b, a);
 
          if((r + g + b) >= 0x40)	// Wrong, but not COMPLETELY ABSOLUTELY wrong, at least. ;)
          {

--- a/mednafen/psx/psx.h
+++ b/mednafen/psx/psx.h
@@ -83,7 +83,8 @@ void PSX_SetEventNT(const int type, const int32_t next_timestamp);
 
 void PSX_SetDMACycleSteal(unsigned stealage);
 
-void PSX_GPULineHook(const int32_t timestamp, const int32_t line_timestamp, bool vsync, uint32_t *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divide);
+// PSX_GPULineHook modified to take surface pitch (in pixels) and upscale factor for software renderer internal upscaling
+void PSX_GPULineHook(const int32_t timestamp, const int32_t line_timestamp, bool vsync, uint32_t *pixels, const MDFN_PixelFormat* const format, const unsigned width, const unsigned pix_clock_offset, const unsigned pix_clock, const unsigned pix_clock_divider, const unsigned surf_pitchinpix, const unsigned upscale_factor);
 
 uint32_t PSX_GetRandU32(uint32_t mina, uint32_t maxa);
 

--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -3084,7 +3084,7 @@ static unsigned msaa = 1;
 static bool mdec_yuv;
 static vector<function<void ()>> defer;
 static dither_mode dither_mode = DITHER_NATIVE;
-static bool crop_overscan;
+static bool crop_overscan_vk;
 static int image_offset_cycles;
 static int initial_scanline;
 static int last_scanline;
@@ -3294,9 +3294,9 @@ static void rsx_vulkan_refresh_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (!strcmp(var.value, "enabled"))
-         crop_overscan = true;
+         crop_overscan_vk = true;
       else
-         crop_overscan = false;
+         crop_overscan_vk = false;
    }
 
    var.key = BEETLE_OPT(image_offset_cycles);
@@ -3357,7 +3357,7 @@ static void rsx_vulkan_finalize_frame(const void *fb, unsigned width,
 {
    renderer->set_adaptive_smoothing(adaptive_smoothing);
    renderer->set_dither_native_resolution(dither_mode == DITHER_NATIVE);
-   renderer->set_horizontal_overscan_cropping(crop_overscan);
+   renderer->set_horizontal_overscan_cropping(crop_overscan_vk);
    renderer->set_horizontal_offset_cycles(image_offset_cycles);
    renderer->set_visible_scanlines(initial_scanline, last_scanline, initial_scanline_pal, last_scanline_pal);
 

--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -19,6 +19,7 @@
 #include "rsx_intf.h"
 #include "rsx.h"
 #include "../libretro_cbs.h"
+#include "../beetle_psx_globals.h"
 
 
 #ifdef RSX_DUMP


### PR DESCRIPTION
An attempt to solve #471 and #501.

**2x IR scaling before** (note the halved width on cursor, cursor only displaying every other line, improper horizontal positioning)
![](https://user-images.githubusercontent.com/45282415/70472723-72aa7380-1a84-11ea-97c8-0fb1e715d3be.png)

**2x IR scaling after**
![](https://user-images.githubusercontent.com/45282415/70472720-70e0b000-1a84-11ea-94d6-9332b41bb023.png)

**Crop Overscan before** (improper horizontal positioning)
![](https://user-images.githubusercontent.com/45282415/70472853-b43b1e80-1a84-11ea-9457-499ea600d710.png)

**Crop Overscan after**
![](https://user-images.githubusercontent.com/45282415/70472860-b7360f00-1a84-11ea-9fac-5b85e407a574.png)

**PAL before** (improper vertical positioning)
![](https://user-images.githubusercontent.com/45282415/70472896-ccab3900-1a84-11ea-9d3c-449483336606.png)

**PAL after**
![capture-pal-fix](https://user-images.githubusercontent.com/45282415/70472899-cddc6600-1a84-11ea-9850-d35967378ee1.png)



### Remaining Issues
1. Drawing cursor is still yet to be implemented for hardware renderers. I think lightgun games are only really going to work for the hardware renderers if Software Framebuffer is enabled unless we hook in some hard GPU readbacks like what maister was doing a while ago. Getting the lightgun to work with the hardware renderers in the first place is going to require some re-architecting of how we track global state in the core.
2. Scaling formula not modified for initial/last scanline core options. I don't really plan on implementing that until we have a better scaling formula.
3. Haven't tested the Justifier color scaling fix but it should work properly.