### PR TITLE
Don't call PGXP functions in gpu when PGXP is disabled

### DIFF
--- a/mednafen/psx/gpu.cpp
+++ b/mednafen/psx/gpu.cpp
@@ -1059,7 +1059,8 @@ static void ProcessFIFO(uint32_t in_count)
 
    for (i = 0; i < command_len; i++)
    {
-      PGXP_WriteCB(PGXP_ReadFIFO(GPU_BlitterFIFO.read_pos), i);
+      if(PGXP_enabled())
+         PGXP_WriteCB(PGXP_ReadFIFO(GPU_BlitterFIFO.read_pos), i);
       CB[i] = GPU_BlitterFIFO.Read();
    }
 
@@ -1100,7 +1101,8 @@ static INLINE void GPU_WriteCB(uint32_t InData, uint32_t addr)
       return;
    }
 
-   PGXP_WriteFIFO(ReadMem(addr), GPU_BlitterFIFO.write_pos);
+   if(PGXP_enabled())
+      PGXP_WriteFIFO(ReadMem(addr), GPU_BlitterFIFO.write_pos);
    GPU_BlitterFIFO.Write(InData);
 
    if(GPU_BlitterFIFO.in_count && GPU.InCmd != INCMD_FBREAD)


### PR DESCRIPTION
This increases performance slightly. 

When I tested with dynarec and hardware renderer with software framebuffer disabled, I measured an increase from ~300 fps to ~309 fps in soul blade.

PGXP seems to still work fine when changing the mode at run-time.