### PR TITLE
Add frame duping support to RSX Vulkan

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -4127,9 +4127,6 @@ bool retro_load_game(const struct retro_game_info *info)
          option_display.key = BEETLE_OPT(image_crop);
          environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 
-         option_display.key = BEETLE_OPT(frame_duping);
-         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
-
          break;
       }
    }

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -4250,7 +4250,7 @@ void retro_run(void)
       if (frame_count % INTERNAL_FPS_SAMPLE_PERIOD == 0)
       {
          char msg_buffer[64];
-         float fps = is_pal ? FPS_PAL : FPS_NTSC;
+         float fps = content_is_pal ? FPS_PAL_NONINTERLACED : FPS_NTSC_NONINTERLACED;
          float internal_fps = (internal_frame_count * fps) / INTERNAL_FPS_SAMPLE_PERIOD;
 
          snprintf(msg_buffer, sizeof(msg_buffer), _("Internal FPS: %.2f"), internal_fps);

--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -76,7 +76,7 @@ void rsx_intf_get_system_av_info(struct retro_system_av_info *info)
    {
       case RSX_SOFTWARE:
          memset(info, 0, sizeof(*info));
-         info->timing.fps            = content_is_pal ? FPS_PAL : FPS_NTSC;
+         info->timing.fps            = content_is_pal ? FPS_PAL_NONINTERLACED : FPS_NTSC_NONINTERLACED;
          info->timing.sample_rate    = SOUND_FREQUENCY;
          info->geometry.base_width   = MEDNAFEN_CORE_GEOMETRY_BASE_W;
          info->geometry.base_height  = MEDNAFEN_CORE_GEOMETRY_BASE_H;

--- a/rsx/rsx_intf.h
+++ b/rsx/rsx_intf.h
@@ -4,8 +4,17 @@
 #include "libretro.h"
 
 #define SOUND_FREQUENCY 44100
-#define FPS_NTSC 59.941
-#define FPS_PAL 49.76
+
+/* NTSC content on NTSC clock, PAL content on PAL clock.
+ * Note: Core currently only reports non-interlaced timings
+ * to avoid possible frontend driver reinits. Core option
+ * for allowing automatic reporting of timing switches is
+ * to-be-implemented.
+ */
+#define FPS_NTSC_INTERLACED    59.940
+#define FPS_NTSC_NONINTERLACED 59.826
+#define FPS_PAL_INTERLACED     50.000
+#define FPS_PAL_NONINTERLACED  49.761
 
 enum rsx_renderer_type
 {

--- a/rsx/rsx_lib_gl.cpp
+++ b/rsx/rsx_lib_gl.cpp
@@ -2257,10 +2257,10 @@ static struct retro_system_av_info get_av_info(VideoClock std)
    switch (std)
    {
       case VideoClock_Ntsc:
-         info.timing.fps = FPS_NTSC;
+         info.timing.fps = FPS_NTSC_NONINTERLACED;
          break;
       case VideoClock_Pal:
-         info.timing.fps = FPS_PAL;
+         info.timing.fps = FPS_PAL_NONINTERLACED;
          break;
    }
 

--- a/rsx/rsx_lib_gl.cpp
+++ b/rsx/rsx_lib_gl.cpp
@@ -2412,13 +2412,7 @@ void rsx_gl_finalize_frame(const void *fb, unsigned width,
    glClearColor(0.0, 0.0, 0.0, 0.0);
    glClear(GL_COLOR_BUFFER_BIT);
 
-   /* If the display is off, just clear the screen */
-   if (renderer->config.display_off && !renderer->display_vram)
-   {
-      glClearColor(0.0, 0.0, 0.0, 0.0);
-      glClear(GL_COLOR_BUFFER_BIT);
-   }
-   else
+   if (!renderer->config.display_off || renderer->display_vram)
    {
       /* Bind 'fb_out' to texture unit 1 */
       glActiveTexture(GL_TEXTURE1);

--- a/rsx/rsx_lib_vulkan.cpp
+++ b/rsx/rsx_lib_vulkan.cpp
@@ -207,9 +207,9 @@ void rsx_vulkan_get_system_av_info(struct retro_system_av_info *info)
 
    info->geometry.aspect_ratio = !widescreen_hack ? MEDNAFEN_CORE_GEOMETRY_ASPECT_RATIO : 16.0 / 9.0;
    if (content_is_pal)
-      info->timing.fps = FPS_PAL;
+      info->timing.fps = FPS_PAL_NONINTERLACED;
    else
-      info->timing.fps = FPS_NTSC;
+      info->timing.fps = FPS_NTSC_NONINTERLACED;
 }
 
 void rsx_vulkan_refresh_variables(void)


### PR DESCRIPTION
Provides some minor performance increase for titles that don't swap PSX VRAM framebuffers at a full ~50 or ~60 Hz refresh rate.

A consequence of enabling this option is that some FMV and BIOS video bugs (occasional garbled 24-bit/15-bit conversion issue very first frame of FMVs, PS BIOS logo teleporting into the bottom right corner at the end of playing the BIOS) are alleviated, but I think this option really only addresses the symptoms and not the cause, so those issues can't be closed on the tracker yet.

I tried implementing this in the GL renderer as well but was tripping over graphical issues left and right, so any help there would be greatly appreciated.