### PR TITLE
Add support for forcing hw rendering backend

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3344,7 +3344,7 @@ static void check_variables(bool startup)
       bool hw_renderer = false;
       if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       {
-         if (strcmp(var.value, "hardware") == 0)
+         if (!strcmp(var.value, "hardware") || !strcmp(var.value, "hardware_gl") || !strcmp(var.value, "hardware_vk"))
          {
             hw_renderer = true;
          }
@@ -4022,7 +4022,7 @@ bool retro_load_game(const struct retro_game_info *info)
    deint.ClearState();
 #endif
 
-	input_init();
+   input_init();
 
    boot = false;
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -55,10 +55,12 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       BEETLE_OPT(renderer),
       "Renderer (Restart)",
-      "Choose video renderer. The software renderer is the most accurate but has steep performance requirements when running at increased internal GPU resolutions. The hardware renderers, while less accurate, improve performance over the software renderer at increased internal resolutions and enable various graphical enhancements. 'Hardware' automatically selects the Vulkan or OpenGL renderer depending upon the current libretro frontend video driver. If the provided video driver is not Vulkan or OpenGL 3.3-compatible then the core will fall back to the software renderer.",
+      "Choose video renderer. The software renderer is the most accurate but has steep performance requirements when running at increased internal GPU resolutions. The hardware renderers, while less accurate, improve performance over the software renderer at increased internal resolutions and enable various graphical enhancements. 'Hardware (Auto)' automatically selects the Vulkan or OpenGL renderer depending upon the current libretro frontend video driver. If the provided video driver is not Vulkan or OpenGL 3.3-compatible then the core will fall back to the software renderer.",
       {
-         { "hardware", "Hardware" },
-         { "software", "Software" },
+         { "hardware",    "Hardware (Auto)" },
+         { "hardware_gl", "Hardware (OpenGL)" },
+         { "hardware_vk", "Hardware (Vulkan)" },
+         { "software",    "Software" },
          { NULL, NULL },
       },
       "hardware"

--- a/rsx/rsx_intf.h
+++ b/rsx/rsx_intf.h
@@ -23,6 +23,13 @@ enum rsx_renderer_type
    RSX_VULKAN
 };
 
+enum force_renderer_type
+{
+   AUTO = 0,
+   FORCE_OPENGL,
+   FORCE_VULKAN
+};
+
 enum blending_modes
 {
    BLEND_MODE_OPAQUE     = -1,


### PR DESCRIPTION
Feature discussed back in #573 that's also been requested by users many times on various channels.

The logic still works the same way as before for the `Hardware` option value, which is renamed `Hardware (Auto)`. If the frontend's preferred driver doesn't have a corresponding hardware renderer, we fall back to the software renderer and notify the user, and if the frontend doesn't have a preferred driver, we go down the list trying to initialize a hardware renderer instance until we get one.

The two new option values, `Hardware (Vulkan)` and `Hardware (OpenGL)` work with pretty much the same logic as the frontend having a preferred driver. We try to open the user's selected hardware renderer, and if we're unable to do so we simply notify the user and fall back to the software renderer. These two new values take precedence over the frontend's preferred driver and will cause that preferred driver setting to be ignored.

@hizzlekizzle @rz5 Would be appreciated if you guys have time to test this in case I missed something.