### PR TITLE
Implement aspect ratio core option (psx.correct_aspect equivalent)

### DIFF
--- a/beetle_psx_globals.c
+++ b/beetle_psx_globals.c
@@ -14,3 +14,6 @@ bool crop_overscan = false;
 int core_timing_fps_mode = FORCE_PROGRESSIVE_TIMING;
 bool currently_interlaced = false;
 bool interlace_setting_dirty = false;
+
+int aspect_ratio_setting = 0;
+bool aspect_ratio_dirty = false;

--- a/beetle_psx_globals.h
+++ b/beetle_psx_globals.h
@@ -34,6 +34,9 @@ extern int core_timing_fps_mode;
 extern bool currently_interlaced;
 extern bool interlace_setting_dirty;
 
+extern int aspect_ratio_setting;
+extern bool aspect_ratio_dirty;
+
 #ifdef __cplusplus
 }
 #endif

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -455,6 +455,17 @@ struct retro_core_option_definition option_defs_us[] = {
       "force_progressive"
    },
    {
+      BEETLE_OPT(aspect_ratio),
+      "Core Aspect Ratio",
+      "Set core provided aspect ratio. This setting is ignored when the Widescreen Mode Hack or Display Full VRAM options are enabled.",
+      {
+         { "corrected", "Corrected" },
+         { "uncorrected", "Uncorrected" },
+         { "4:3",  "Force 4:3" },
+      },
+      "corrected"
+   },
+   {
       BEETLE_OPT(widescreen_hack),
       "Widescreen Mode Hack",
       "When enabled, renders 3D content anamorphically and outputs the emulated framebuffer at a widescreen aspect ratio. Produces best results with fully 3D games. 2D elements will be horizontally stretched and may be misaligned.",

--- a/rsx/rsx_intf.h
+++ b/rsx/rsx_intf.h
@@ -48,6 +48,12 @@ enum width_modes
    WIDTH_MODE_368
 };
 
+enum height_modes
+{
+   HEIGHT_MODE_240 = 0,
+   HEIGHT_MODE_480
+};
+
 void rsx_intf_set_environment(retro_environment_t cb);
 void rsx_intf_set_video_refresh(retro_video_refresh_t cb);
 void rsx_intf_get_system_av_info(struct retro_system_av_info *info);
@@ -155,5 +161,9 @@ void rsx_intf_toggle_display(bool status);
 bool rsx_intf_has_software_renderer(void);
 
 double rsx_common_get_timing_fps(void);
+
+float rsx_common_get_aspect_ratio(bool pal_content, bool crop_overscan,
+                                  int first_visible_scanline, int last_visible_scanline,
+                                  int aspect_ratio_setting, bool vram_override, bool widescreen_override);
 
 #endif /*__RSX_H__*/


### PR DESCRIPTION
Beetle PSX has traditionally gotten aspect ratio scaling wrong (see [link](https://forum.fobby.net/index.php?t=msg&&th=1117&goto=3777#msg_3777)). This patch brings proper aspect ratio correction for all the renderers and additionally implements a functional equivalent of mednafen 1.24.0-UNSTABLE's `psx.correct_aspect` option. The upstream mednafen code isn't quite suitable for our purposes, so this implementation uses the rsx interface as a more general solution that covers the hardware renderers as well.

`Corrected` gives the proper aspect ratio scaling while `Uncorrected` is the effective "1:1 PAR" mode.

Some users may not be happy with this new behavior that is more accurate and matches upstream more closely and may prefer the old behavior, so `Force 4:3` is left as a legacy option for those users. Those users may alternatively choose to force 4:3 stretching through their frontend.
