### PR TITLE
Added "fast PAL" hack to allow PAL games to play at NTSC framerates

### DIFF
--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -477,6 +477,16 @@ struct retro_core_option_definition option_defs_us[] = {
       "disabled"
    },
    {
+      BEETLE_OPT(pal_video_override),
+      "PAL (European) video timing override",
+      "Due to different standards PAL games often appear slowed down compared to the American or Japanese NTSC releases. This option can be used to override the timings in order to attempt to run these games with the NTSC framerate.",
+      {
+         { "no_override", "Standard PAL timings" },
+         { "fast_pal",  "PAL resolution, NTSC framerate" },
+      },
+      "no_override"
+   },
+   {
       BEETLE_OPT(crop_overscan),
       "Crop Horizontal Overscan",
       "By default, the renderers add horizontal padding (pillarboxes on either side of the image) to emulate the same black bars generated in analog video output by real PSX hardware. Enabling this option removes horizontal padding.",

--- a/mednafen/psx/gpu.cpp
+++ b/mednafen/psx/gpu.cpp
@@ -56,6 +56,8 @@
 
 */
 
+extern bool fast_pal;
+
 /*
    November 29, 2012 notes:
 
@@ -1457,7 +1459,11 @@ int32_t GPU_Update(const int32_t sys_timestamp)
          if(GPU.LinePhase)
          {
             TIMER_SetHRetrace(true);
-            GPU.LineClockCounter = 200;
+            if(GPU.DisplayMode & DISP_PAL && fast_pal) {
+               GPU.LineClockCounter = (200 * 25) / 30;
+            } else {
+               GPU.LineClockCounter = 200;
+            }
             TIMER_ClockHRetrace();
          }
          else
@@ -1470,7 +1476,11 @@ int32_t GPU_Update(const int32_t sys_timestamp)
             TIMER_SetHRetrace(false);
 
             if(GPU.DisplayMode & DISP_PAL)
-               GPU.LineClockCounter = 3405 - 200;
+               if (fast_pal) {
+                  GPU.LineClockCounter = ((3405 - 200) * 25) / 30;
+               } else {
+                  GPU.LineClockCounter = 3405 - 200;
+               }
             else
                GPU.LineClockCounter = 3412 + GPU.PhaseChange - 200;
 

--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -28,6 +28,8 @@
 #include "rsx_lib_vulkan.h"
 #endif
 
+extern bool fast_pal;
+
 static enum rsx_renderer_type rsx_type          = RSX_SOFTWARE;
 
 static bool gl_initialized                      = false;
@@ -840,14 +842,16 @@ void rsx_intf_toggle_display(bool status)
 
 double rsx_common_get_timing_fps(void)
 {
+   bool pal_timings = content_is_pal && !fast_pal;
+
    if (core_timing_fps_mode == FORCE_PROGRESSIVE_TIMING)
-      return (content_is_pal ? FPS_PAL_NONINTERLACED : FPS_NTSC_NONINTERLACED);
+      return (pal_timings ? FPS_PAL_NONINTERLACED : FPS_NTSC_NONINTERLACED);
 
    else if (core_timing_fps_mode == FORCE_INTERLACED_TIMING)
-      return (content_is_pal ? FPS_PAL_INTERLACED : FPS_NTSC_INTERLACED);
+      return (pal_timings ? FPS_PAL_INTERLACED : FPS_NTSC_INTERLACED);
 
    //else AUTO_TOGGLE_TIMING
-   return (content_is_pal ?
+   return (pal_timings ?
                (currently_interlaced ? FPS_PAL_INTERLACED : FPS_PAL_NONINTERLACED) :
                (currently_interlaced ? FPS_NTSC_INTERLACED : FPS_NTSC_NONINTERLACED));
 }


### PR DESCRIPTION
This is an implementation of the feature request #67 

It adds a core option "pal_video_override" that can be used to hack the video timing of PAL games in order to make them run at 60fps instead of 50. The resolution remains the same. NTSC games will ignore that setting entirely so it shouldn't have any impact for them.

As discussed in the issue many (but not all) PAL ports of NTSC games also have black bars at the top and bottom of the screen. This patch will not remove them. An other patch will be necessary to optionally crop the video output to remove those bars.