### PR TITLE
Cleanup warnings: snprintf truncation, strncpy->memcpy, memset

### DIFF
--- a/mednafen/cdrom/CDAccess_PBP.cpp
+++ b/mednafen/cdrom/CDAccess_PBP.cpp
@@ -745,7 +745,7 @@ void CDAccess_PBP::Eject(bool eject_status)
 int CDAccess_PBP::decrypt_pgd(unsigned char* pgd_data, int pgd_size)
 {
    int result;
-   PGD_HEADER PGD[sizeof(PGD_HEADER)];
+   PGD_HEADER PGD[1];
    MAC_KEY mkey;
    CIPHER_KEY ckey;
 

--- a/mednafen/mempatcher.cpp
+++ b/mednafen/mempatcher.cpp
@@ -185,9 +185,7 @@ void MDFNMP_RemoveReadPatches(void)
 /* This function doesn't allocate any memory for "name" */
 static int AddCheatEntry(char *name, char *conditions, uint32 addr, uint64 val, uint64 compare, int status, char type, unsigned int length, bool bigendian)
 {
- CHEATF temp;
-
- memset(&temp, 0, sizeof(CHEATF));
+ CHEATF temp = CHEATF();
 
  temp.name=name;
  temp.conditions = conditions;
@@ -597,7 +595,7 @@ int MDFNI_DecodePAR(const char *str, uint32 *a, uint8 *v, uint8 *c, char *type)
  int boo[4];
  if(strlen(str)!=8) return(0);
 
- sscanf(str,"%02p%02p%02p%02p",boo,boo+1,boo+2,boo+3);
+ sscanf(str,"%02x%02x%02x%02x",boo,boo+1,boo+2,boo+3);
 
  *c = 0;
 

--- a/mednafen/psx/cdc.cpp
+++ b/mednafen/psx/cdc.cpp
@@ -119,7 +119,7 @@ void PS_CDC::SetDisc(bool tray_open, CDIF *cdif, const char *disc_id)
 
       if(disc_id)
       {
-         strncpy((char *)DiscID, disc_id, 4);
+         memcpy((char *)DiscID, disc_id, 4);
          IsPSXDisc = true;
       }
    }

--- a/mednafen/settings.cpp
+++ b/mednafen/settings.cpp
@@ -128,14 +128,26 @@ std::string MDFN_GetSettingS(const char *name)
    if (!strcmp("filesys.fname_state", name))
    {
       char fullpath[4096];
-      snprintf(fullpath, sizeof(fullpath), "%s.sav", retro_cd_base_name);
-      return std::string(fullpath);
+      int r = snprintf(fullpath, sizeof(fullpath), "%s.sav", retro_cd_base_name);
+      if (r > 4095)
+      {
+         fprintf(stderr,"Path to .sav too long");
+         return 0;
+      }
+      else
+         return std::string(fullpath);
    }
    if (!strcmp("filesys.fname_sav", name))
    {
       char fullpath[4096];
-      snprintf(fullpath, sizeof(fullpath), "%s.bsv", retro_cd_base_name);
-      return std::string(fullpath);
+      int r = snprintf(fullpath, sizeof(fullpath), "%s.bsv", retro_cd_base_name);
+      if (r > 4095)
+      {
+         fprintf(stderr,"Path to .bsv too long");
+         return 0;
+      }
+      else
+         return std::string(fullpath);
    }
    fprintf(stderr, "unhandled setting S: %s\n", name);
    return 0;

--- a/mednafen/state.cpp
+++ b/mednafen/state.cpp
@@ -159,7 +159,10 @@ static bool SubWrite(StateMem *st, SFORMAT *sf, const char *name_prefix = NULL)
 
          if (slen >= 255)
          {
-            printf("Warning:  state variable name possibly too long: %s %s %s %d\n", sf->name, name_prefix, nameo, slen);
+            if(name_prefix != NULL)
+               printf("Warning:  state variable name possibly too long: %s %s %s %d\n", sf->name, name_prefix, nameo, slen);
+            else
+               printf("Warning:  state variable name possibly too long: %s %s %d\n", sf->name, nameo, slen);
             slen = 255;
          }
 
@@ -226,7 +229,7 @@ static int WriteStateChunk(StateMem *st, const char *sname, SFORMAT *sf)
    uint8_t sname_tmp[32];
 
    memset(sname_tmp, 0, sizeof(sname_tmp));
-   strncpy((char *)sname_tmp, sname, 32);
+   memcpy((char *)sname_tmp, sname, 32);
 
    if(strlen(sname) > 32)
       printf("Warning: section name is too long: %s\n", sname);

--- a/mednafen/video/surface.cpp
+++ b/mednafen/video/surface.cpp
@@ -42,7 +42,7 @@ MDFN_PixelFormat::MDFN_PixelFormat(const unsigned int p_colorspace, const uint8 
 
 MDFN_Surface::MDFN_Surface()
 {
-   memset(&format, 0, sizeof(format));
+   format = MDFN_PixelFormat();
 
    pixels = NULL;
    pitchinpix = 0;


### PR DESCRIPTION
Fix all build warnings other than those from libretro-common/ or deps/

Would like feedback on whether these changes make sense and don't break anything, as I just made the minimum changes to fix each warning and only build tested.