### PR TITLE
Add support for frontend message interface v1

### DIFF
--- a/mednafen/cdrom/cdromif.cpp
+++ b/mednafen/cdrom/cdromif.cpp
@@ -317,7 +317,6 @@ int CDIF_MT::ReadThreadStart()
       CDIF_Message msg;
 
       // Only do a blocking-wait for a message if we don't have any sectors to read-ahead.
-      // MDFN_DispMessage("%d %d %d\n", last_read_lba, ra_lba, ra_count);
       if(ReadThreadQueue.Read(&msg, ra_count ? false : true))
       {
          switch(msg.message)

--- a/mednafen/mednafen-driver.h
+++ b/mednafen/mednafen-driver.h
@@ -1,6 +1,8 @@
 #ifndef __MDFN_MEDNAFEN_DRIVER_H
 #define __MDFN_MEDNAFEN_DRIVER_H
 
+#include <libretro.h>
+
 #include <stdio.h>
 #include <vector>
 #include <string>
@@ -19,8 +21,15 @@ void MDFNI_SetBaseDirectory(const char *dir);
 /* Closes currently loaded game */
 void MDFNI_CloseGame(void);
 
-void MDFN_DispMessage(const char *format, ...);
-#define MDFNI_DispMessage MDFN_DispMessage
+void MDFND_DispMessage(
+      unsigned priority, enum retro_log_level level,
+      enum retro_message_target target, enum retro_message_type type,
+      const char *msg);
+
+void MDFN_DispMessage(
+      unsigned priority, enum retro_log_level level,
+      enum retro_message_target target, enum retro_message_type type,
+      const char *format, ...);
 
 uint32 MDFNI_CRC32(uint32 crc, uint8 *buf, uint32 len);
 

--- a/mednafen/mednafen.h
+++ b/mednafen/mednafen.h
@@ -1,6 +1,8 @@
 #ifndef _MEDNAFEN_H
 #define _MEDNAFEN_H
 
+#include <libretro.h>
+
 #include "mednafen-types.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -30,7 +32,15 @@ extern MDFNGI *MDFNGameInfo;
 
 #include "settings.h"
 
-void MDFN_DispMessage(const char *format, ...);
+void MDFND_DispMessage(
+      unsigned priority, enum retro_log_level level,
+      enum retro_message_target target, enum retro_message_type type,
+      const char *msg);
+
+void MDFN_DispMessage(
+      unsigned priority, enum retro_log_level level,
+      enum retro_message_target target, enum retro_message_type type,
+      const char *format, ...);
 
 void MDFN_LoadGameCheats(void *override);
 void MDFN_FlushGameCheats(int nosave);

--- a/mednafen/psx/cdc.cpp
+++ b/mednafen/psx/cdc.cpp
@@ -926,9 +926,14 @@ void PS_CDC::HandlePlayRead(void)
    else if (!Cur_CDIF->ReadRawSector(read_buf, CurSector, cd_slow_timeout))
    {
       if (cd_async)
-         MDFN_DispMessage("*Really* slow CD image read detected -- consider using precache CD Access Method");
+         MDFND_DispMessage(3, RETRO_LOG_WARN,
+               RETRO_MESSAGE_TARGET_ALL, RETRO_MESSAGE_TYPE_NOTIFICATION,
+               "*Really* slow CD image read detected: consider using precache CD Access Method");
       else
-         MDFN_DispMessage("Slow CD image read detected -- consider using async or precache CD Access Method");
+         MDFND_DispMessage(3, RETRO_LOG_WARN,
+               RETRO_MESSAGE_TARGET_ALL, RETRO_MESSAGE_TYPE_NOTIFICATION,
+               "Slow CD image read detected: consider using async or precache CD Access Method");
+
       cd_warned_slow = true;
       Cur_CDIF->ReadRawSector(read_buf, CurSector, -1);
    }
@@ -1039,7 +1044,9 @@ void PS_CDC::HandlePlayRead(void)
                {
                   if(!edc_lec_check_and_correct(buf, true))
                   {
-                     MDFN_DispMessage("Bad sector? - %d", CurSector);
+                     MDFN_DispMessage(3, RETRO_LOG_ERROR,
+                           RETRO_MESSAGE_TARGET_ALL, RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
+                           "Bad sector? - %d", CurSector);
                   }
                }
 
@@ -1151,8 +1158,6 @@ int32_t PS_CDC::Update(const int32_t timestamp)
          if(DiscStartupDelay <= 0)
             DriveStatus = DS_PAUSED;	// or is it supposed to be DS_STANDBY?
       }
-
-      //MDFN_DispMessage("%02x %d -- %d %d -- %02x", IRQBuffer, CDCReadyReceiveCounter, PSRCounter, PendingCommandCounter, PendingCommand);
 
       if(!(IRQBuffer & 0xF))
       {

--- a/mednafen/psx/dma.cpp
+++ b/mednafen/psx/dma.cpp
@@ -415,7 +415,6 @@ static INLINE void RunChannel(int32_t timestamp, int32_t clocks, int ch)
          else if(CRModeCache & 0x100) // BLARGH BLARGH FISHWHALE
          {
             //printf("LoadWC: %u(oldWC=%u)\n", DMACH[ch].BlockControl & 0xFFFF, DMACH[ch].WordCounter);
-            //MDFN_DispMessage("SPOOOON\n");
             DMACH[ch].CurAddr = DMACH[ch].BaseAddr;
             DMACH[ch].WordCounter = DMACH[ch].BlockControl & 0xFFFF;
          }
@@ -611,7 +610,9 @@ void DMA_Write(const int32_t timestamp, uint32_t A, uint32_t V)
                RunChannel(timestamp, 1, ch);
                DMACH[ch].ClockCounter = 0;
                PSX_WARNING("[DMA] Forced stop for channel %d -- scanline=%d", ch, GPU_GetScanlineNum());
-               //MDFN_DispMessage("[DMA] Forced stop for channel %d", ch);
+               MDFND_DispMessage(3, RETRO_LOG_ERROR,
+                     RETRO_MESSAGE_TARGET_ALL, RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
+                     "[DMA] Forced stop for channel %d", ch);
 #endif
             }
 

--- a/mednafen/psx/frontio.cpp
+++ b/mednafen/psx/frontio.cpp
@@ -642,7 +642,6 @@ void FrontIO::Write(int32_t timestamp, uint32_t A, uint32_t V)
       case 0xe:
          Baudrate = V;
          //printf("%02x\n", V);
-         //MDFN_DispMessage("%02x\n", V);
          break;
    }
 

--- a/mednafen/psx/input/dualshock.cpp
+++ b/mednafen/psx/input/dualshock.cpp
@@ -156,7 +156,10 @@ void InputDevice_DualShock::SetAMCT(bool enabled)
    else
       analog_mode = true;
 
-   MDFN_DispMessage("%s: Analog button toggle is %s, sticks are %s", gp_name.c_str(), amct_enabled ? "ENABLED" : "DISABLED", analog_mode ? "ON" : "OFF");  
+   MDFN_DispMessage(2, RETRO_LOG_INFO,
+         RETRO_MESSAGE_TARGET_OSD, RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
+         "%s: Analog toggle is %s, sticks are %s",
+         gp_name.c_str(), amct_enabled ? "ENABLED" : "DISABLED", analog_mode ? "ON" : "OFF");
 }
 
 //
@@ -195,10 +198,10 @@ void InputDevice_DualShock::CheckManualAnaModeChange(void)
       if(need_mode_toggle)
       {
          if(analog_mode_locked)
-         {
-            //MDFN_DispMessage("%s: Analog mode is  %s.", gp_name.c_str(), analog_mode ? "on" : "off");
-            MDFN_DispMessage("%s: 2 Analog toggle is DISABLED, sticks are %s", gp_name.c_str(), analog_mode ? "ON" : "OFF");         
-         }
+            MDFN_DispMessage(2, RETRO_LOG_INFO,
+                  RETRO_MESSAGE_TARGET_OSD, RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
+                  "%s: 2 Analog toggle is DISABLED, sticks are %s",
+                  gp_name.c_str(), analog_mode ? "ON" : "OFF");
          else
             analog_mode = !analog_mode;
       }
@@ -353,10 +356,11 @@ void InputDevice_DualShock::UpdateInput(const void *data)
    CheckManualAnaModeChange();
 
    if(am_prev_info != analog_mode || aml_prev_info != analog_mode_locked)
-   {
-      //MDFN_DispMessage("%s: Analog mode is %s(%s).", gp_name.c_str(), analog_mode ? "on" : "off", analog_mode_locked ? "locked" : "unlocked");
-      MDFN_DispMessage("%s: Analog toggle is %s, sticks are %s", gp_name.c_str(), amct_enabled ? "ENABLED" : "DISABLED", analog_mode ? "ON" : "OFF");  
-   }
+      MDFN_DispMessage(2, RETRO_LOG_INFO,
+            RETRO_MESSAGE_TARGET_OSD, RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
+            "%s: Analog toggle is %s, sticks are %s",
+            gp_name.c_str(), amct_enabled ? "ENABLED" : "DISABLED", analog_mode ? "ON" : "OFF");
+
    aml_prev_info = analog_mode_locked;
    am_prev_info = analog_mode;
 }

--- a/mednafen/psx/input/guncon.cpp
+++ b/mednafen/psx/input/guncon.cpp
@@ -178,8 +178,6 @@ void InputDevice_GunCon::UpdateInput(const void *data)
    if((d8[4] & 0x8) && !prev_oss && os_shot_counter == 0)
       os_shot_counter = 4;
    prev_oss = d8[4] & 0x8;
-
-   //MDFN_DispMessage("%08x %08x", nom_x, nom_y);
 }
 
 bool InputDevice_GunCon::RequireNoFrameskip(void)

--- a/mednafen/psx/input/memcard.cpp
+++ b/mednafen/psx/input/memcard.cpp
@@ -437,7 +437,6 @@ bool InputDevice_Memcard::Clock(bool TxD, int32 &dsr_pulse_delay)
                break;
 
             case (2048 + 130):	// End flag
-               //MDFN_DispMessage("%02x %02x", calced_xor, write_xor);
                //printf("[MCR] Write End.  Actual_XOR=0x%02x, CW_XOR=0x%02x\n", calced_xor, write_xor);
 
                if(calced_xor != write_xor)

--- a/mednafen/psx/input/mouse.cpp
+++ b/mednafen/psx/input/mouse.cpp
@@ -158,8 +158,6 @@ void InputDevice_Mouse::UpdateInput(const void *data)
    button |= *((uint8 *)data + 8);
    button_post_mask = *((uint8 *)data + 8);
 
-   //if(button)
-   // MDFN_DispMessage("Button\n");
    //printf("%d %d\n", accum_xdelta, accum_ydelta);
 }
 

--- a/mednafen/psx/irq.cpp
+++ b/mednafen/psx/irq.cpp
@@ -59,8 +59,12 @@ void IRQ_Assert(int which, bool status)
    uint32_t old_Asserted = Asserted;
    //PSX_WARNING("[IRQ] Assert: %d %d", which, status);
 
-   //if(which == IRQ_SPU && status && (Asserted & (1 << which)))
-   // MDFN_DispMessage("SPU IRQ glitch??");
+/*
+   if(which == IRQ_SPU && status && (Asserted & (1 << which)))
+      MDFND_DispMessage(3, RETRO_LOG_ERROR,
+            RETRO_MESSAGE_TARGET_ALL, RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
+            "SPU IRQ glitch??");
+*/
 
    Asserted &= ~(1 << which);
 

--- a/mednafen/psx/mdec.cpp
+++ b/mednafen/psx/mdec.cpp
@@ -524,8 +524,6 @@ void MDEC_Run(int32 clocks)
 {
    static const unsigned MDRPhaseBias = 0 + 1;
 
-   //MDFN_DispMessage("%u", OutFIFO.in_count);
-
    ClockCounter += clocks;
 
    if(ClockCounter > 128)

--- a/mednafen/video.h
+++ b/mednafen/video.h
@@ -1,8 +1,18 @@
 #ifndef __MDFN_VIDEO_H
 #define __MDFN_VIDEO_H
 
+#include <libretro.h>
+
 #include "video/surface.h"
 
-void MDFN_DispMessage(const char *format, ...);
+void MDFND_DispMessage(
+      unsigned priority, enum retro_log_level level,
+      enum retro_message_target target, enum retro_message_type type,
+      const char *msg);
+
+void MDFN_DispMessage(
+      unsigned priority, enum retro_log_level level,
+      enum retro_message_target target, enum retro_message_type type,
+      const char *format, ...);
 
 #endif

--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -165,11 +165,17 @@ bool rsx_intf_open(bool is_pal, bool force_software)
          }
          else
          {
-            MDFN_DispMessage("Could not force Vulkan renderer. Falling back to software renderer.");
+            MDFND_DispMessage(3, RETRO_LOG_ERROR,
+                  RETRO_MESSAGE_TARGET_ALL, RETRO_MESSAGE_TYPE_NOTIFICATION,
+                  "Could not force Vulkan renderer. Falling back to software renderer.");
+
             goto soft;
          }
 #else
-         MDFN_DispMessage("Attempted to force Vulkan renderer, but core was built without it. Falling back to software renderer.");
+         MDFND_DispMessage(3, RETRO_LOG_ERROR,
+               RETRO_MESSAGE_TARGET_ALL, RETRO_MESSAGE_TYPE_NOTIFICATION,
+               "Attempted to force Vulkan renderer, but core was built without it. Falling back to software renderer.");
+
          goto soft;
 #endif
       }
@@ -185,11 +191,17 @@ bool rsx_intf_open(bool is_pal, bool force_software)
          }
          else
          {
-            MDFN_DispMessage("Could not force OpenGL renderer. Falling back to software renderer.");
+            MDFND_DispMessage(3, RETRO_LOG_ERROR,
+                  RETRO_MESSAGE_TARGET_ALL, RETRO_MESSAGE_TYPE_NOTIFICATION,
+                  "Could not force OpenGL renderer. Falling back to software renderer.");
+
             goto soft;
          }
 #else
-         MDFN_DispMessage("Attempted to force OpenGL renderer, but core was built without it. Falling back to software renderer.");
+         MDFND_DispMessage(3, RETRO_LOG_ERROR,
+               RETRO_MESSAGE_TARGET_ALL, RETRO_MESSAGE_TYPE_NOTIFICATION,
+               "Attempted to force OpenGL renderer, but core was built without it. Falling back to software renderer.");
+
          goto soft;
 #endif
       }
@@ -229,9 +241,13 @@ bool rsx_intf_open(bool is_pal, bool force_software)
 #endif
 
       if (preferred == RETRO_HW_CONTEXT_DUMMY)
-         MDFN_DispMessage("No hardware renderers could be opened. Falling back to software renderer.");
+         MDFND_DispMessage(3, RETRO_LOG_ERROR,
+               RETRO_MESSAGE_TARGET_ALL, RETRO_MESSAGE_TYPE_NOTIFICATION,
+               "No hardware renderers could be opened. Falling back to software renderer.");
       else
-         MDFN_DispMessage("Unable to find or open hardware renderer for frontend preferred hardware context. Falling back to software renderer.");
+         MDFND_DispMessage(3, RETRO_LOG_ERROR,
+               RETRO_MESSAGE_TARGET_ALL, RETRO_MESSAGE_TYPE_NOTIFICATION,
+               "Unable to find or open hardware renderer for frontend preferred hardware context. Falling back to software renderer.");
    }
 
 soft:


### PR DESCRIPTION
This PR adds support for v1 of the core->frontend message interface implemented here: https://github.com/libretro/RetroArch/pull/10679

The main benefits are:

- Reduced log spam. Only important messages are recorded via the logging interface - the rest are just output via the OSD.

- Certain warnings/errors are now reported via regular notifications (pop-up widgets), making them more obvious to the user.

- Internal FPS text is now displayed via the status widget:

![Screenshot_2020-05-29_14-26-14](https://user-images.githubusercontent.com/38211560/83266955-73160280-a1bb-11ea-9ea1-642c89e9f356.png)
