### PR TITLE
allow using system libs

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -9,6 +9,68 @@ CORE_EMU_DIR := $(MEDNAFEN_DIR)/psx
 RSXGL_DIR    := $(CORE_DIR)/rustation-libretro/src
 CDROM_DIR    := $(MEDNAFEN_DIR)/cdrom
 
+LIBCHDR_INCFLAGS = -I$(DEPS_DIR)/crypto \
+                     -I$(DEPS_DIR)/flac-1.3.2/include \
+                     -I$(DEPS_DIR)/flac-1.3.2/src/libFLAC/include \
+                     -I$(DEPS_DIR)/lzma-16.04/C \
+                     -I$(DEPS_DIR)/libchdr
+LIBCHDR_SOURCES_C = $(DEPS_DIR)/crypto/md5.c \
+                     $(DEPS_DIR)/crypto/sha1.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/bitmath.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/bitreader.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/cpu.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/crc.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/fixed.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/fixed_intrin_sse2.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/fixed_intrin_ssse3.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/float.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/format.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/lpc.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/lpc_intrin_avx2.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/lpc_intrin_sse2.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/lpc_intrin_sse41.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/lpc_intrin_sse.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/md5.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/memory.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/metadata_iterators.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/metadata_object.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/stream_decoder.c \
+                     $(DEPS_DIR)/flac-1.3.2/src/libFLAC/window.c \
+                     $(DEPS_DIR)/lzma-16.04/C/Alloc.c \
+                     $(DEPS_DIR)/lzma-16.04/C/Bra86.c \
+                     $(DEPS_DIR)/lzma-16.04/C/Bra.c \
+                     $(DEPS_DIR)/lzma-16.04/C/BraIA64.c \
+                     $(DEPS_DIR)/lzma-16.04/C/CpuArch.c \
+                     $(DEPS_DIR)/lzma-16.04/C/Delta.c \
+                     $(DEPS_DIR)/lzma-16.04/C/LzFind.c \
+                     $(DEPS_DIR)/lzma-16.04/C/Lzma86Dec.c \
+                     $(DEPS_DIR)/lzma-16.04/C/Lzma86Enc.c \
+                     $(DEPS_DIR)/lzma-16.04/C/LzmaDec.c \
+                     $(DEPS_DIR)/lzma-16.04/C/LzmaEnc.c \
+                     $(DEPS_DIR)/lzma-16.04/C/LzmaLib.c \
+                     $(DEPS_DIR)/lzma-16.04/C/Sort.c \
+                     $(DEPS_DIR)/libchdr/bitstream.c \
+                     $(DEPS_DIR)/libchdr/cdrom.c \
+                     $(DEPS_DIR)/libchdr/chd.c \
+                     $(DEPS_DIR)/libchdr/flac.c \
+                     $(DEPS_DIR)/libchdr/huffman.c
+
+ZLIB_INCFLAGS = -I$(DEPS_DIR)/zlib
+ZLIB_SOURCES_C = $(DEPS_DIR)/zlib/adler32.c \
+               $(DEPS_DIR)/zlib/compress.c \
+               $(DEPS_DIR)/zlib/crc32.c \
+               $(DEPS_DIR)/zlib/deflate.c \
+               $(DEPS_DIR)/zlib/gzclose.c \
+               $(DEPS_DIR)/zlib/gzlib.c \
+               $(DEPS_DIR)/zlib/gzread.c \
+               $(DEPS_DIR)/zlib/gzwrite.c \
+               $(DEPS_DIR)/zlib/inffast.c \
+               $(DEPS_DIR)/zlib/inflate.c \
+               $(DEPS_DIR)/zlib/inftrees.c \
+               $(DEPS_DIR)/zlib/trees.c \
+               $(DEPS_DIR)/zlib/uncompr.c \
+               $(DEPS_DIR)/zlib/zutil.c
+
 ifeq ($(HAVE_OPENGL), 1)
    ifeq ($(GLES), 1)
       GLFLAGS  := -DHAVE_OPENGLES -DHAVE_OPENGLES2
@@ -37,29 +99,22 @@ INCFLAGS := -I$(CORE_DIR) \
             -I$(MEDNAFEN_DIR)/hw_cpu \
             -I$(MEDNAFEN_DIR)/hw_misc \
             -I$(LIBRETRO_DIR)/include \
-            -I$(DEPS_DIR)/zlib \
             -I$(DEPS_DIR)/ugui
 
 ifneq (,$(findstring msvc,$(platform)))
-INCFLAGS += -I$(CORE_DIR)/msvc
+   INCFLAGS += -I$(CORE_DIR)/msvc
 endif
 
-SOURCES_C +=   $(DEPS_DIR)/zlib/adler32.c \
-               $(DEPS_DIR)/zlib/compress.c \
-               $(DEPS_DIR)/zlib/crc32.c \
-               $(DEPS_DIR)/zlib/deflate.c \
-               $(DEPS_DIR)/zlib/gzclose.c \
-               $(DEPS_DIR)/zlib/gzlib.c \
-               $(DEPS_DIR)/zlib/gzread.c \
-               $(DEPS_DIR)/zlib/gzwrite.c \
-               $(DEPS_DIR)/zlib/inffast.c \
-               $(DEPS_DIR)/zlib/inflate.c \
-               $(DEPS_DIR)/zlib/inftrees.c \
-               $(DEPS_DIR)/zlib/trees.c \
-               $(DEPS_DIR)/zlib/uncompr.c \
-               $(DEPS_DIR)/zlib/zutil.c \
-               $(DEPS_DIR)/ugui/ugui.c \
+SOURCES_C += $(DEPS_DIR)/ugui/ugui.c \
                $(CORE_DIR)/ugui_tools.c
+
+ifeq ($(SYSTEM_ZLIB), 1)
+   CFLAGS += $(shell pkg-config --cflags zlib)
+   LIBS += $(shell pkg-config --libs zlib)
+else
+   INCFLAGS += $(ZLIB_INCFLAGS)
+   SOURCES_C += $(ZLIB_SOURCES_C)
+endif
 
 ifeq ($(HAVE_GRIFFIN),1)
    SOURCES_CXX += beetle_psx_griffin.cpp \
@@ -131,14 +186,19 @@ ifeq ($(HAVE_CHD), 1)
             -DHAVE_STDLIB_H \
             -DHAVE_SYS_PARAM_H
 
-   INCFLAGS += -I$(DEPS_DIR)/crypto \
-               -I$(DEPS_DIR)/flac-1.3.2/include \
-               -I$(DEPS_DIR)/flac-1.3.2/src/libFLAC/include \
-               -I$(DEPS_DIR)/lzma-16.04/C \
-               -I$(DEPS_DIR)/libchdr
-
    ifeq ($(platform), win)
-       FLAGS += -DHAVE_FSEEKO
+      FLAGS += -DHAVE_FSEEKO
+   endif
+
+   ifeq ($(SYSTEM_LIBCHDR), 1)
+      INCFLAGS += $(shell pkg-config --cflags libchdr)
+      LIBS += $(shell pkg-config --libs libchdr)
+   else
+      INCFLAGS += -I$(DEPS_DIR)/crypto \
+                  -I$(DEPS_DIR)/flac-1.3.2/include \
+                  -I$(DEPS_DIR)/flac-1.3.2/src/libFLAC/include \
+                  -I$(DEPS_DIR)/lzma-16.04/C \
+                  -I$(DEPS_DIR)/libchdr
    endif
 endif
 
@@ -317,49 +377,11 @@ SOURCES_C +=   $(CORE_DIR)/pgxp/pgxp_cpu.c \
                $(CORE_DIR)/pgxp/pgxp_value.c
 
 ifeq ($(HAVE_CHD), 1)
-   SOURCES_C +=   $(DEPS_DIR)/crypto/md5.c \
-                  $(DEPS_DIR)/crypto/sha1.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/bitmath.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/bitreader.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/cpu.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/crc.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/fixed.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/fixed_intrin_sse2.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/fixed_intrin_ssse3.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/float.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/format.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/lpc.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/lpc_intrin_avx2.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/lpc_intrin_sse2.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/lpc_intrin_sse41.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/lpc_intrin_sse.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/md5.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/memory.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/metadata_iterators.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/metadata_object.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/stream_decoder.c \
-                  $(DEPS_DIR)/flac-1.3.2/src/libFLAC/window.c \
-                  $(DEPS_DIR)/lzma-16.04/C/Alloc.c \
-                  $(DEPS_DIR)/lzma-16.04/C/Bra86.c \
-                  $(DEPS_DIR)/lzma-16.04/C/Bra.c \
-                  $(DEPS_DIR)/lzma-16.04/C/BraIA64.c \
-                  $(DEPS_DIR)/lzma-16.04/C/CpuArch.c \
-                  $(DEPS_DIR)/lzma-16.04/C/Delta.c \
-                  $(DEPS_DIR)/lzma-16.04/C/LzFind.c \
-                  $(DEPS_DIR)/lzma-16.04/C/Lzma86Dec.c \
-                  $(DEPS_DIR)/lzma-16.04/C/Lzma86Enc.c \
-                  $(DEPS_DIR)/lzma-16.04/C/LzmaDec.c \
-                  $(DEPS_DIR)/lzma-16.04/C/LzmaEnc.c \
-                  $(DEPS_DIR)/lzma-16.04/C/LzmaLib.c \
-                  $(DEPS_DIR)/lzma-16.04/C/Sort.c \
-                  $(DEPS_DIR)/libchdr/bitstream.c \
-                  $(DEPS_DIR)/libchdr/cdrom.c \
-                  $(DEPS_DIR)/libchdr/chd.c \
-                  $(DEPS_DIR)/libchdr/flac.c \
-                  $(DEPS_DIR)/libchdr/huffman.c 
-
-   ifneq (,$(findstring win,$(platform)))
-       SOURCES_C += $(DEPS_DIR)/flac-1.3.2/src/libFLAC/windows_unicode_filenames.c
+   ifneq ($(SYSTEM_LIBCHDR), 1)
+      SOURCES_C += $(LIBCHDR_SOURCES_C)
+      ifneq (,$(findstring win,$(platform)))
+         SOURCES_C += $(DEPS_DIR)/flac-1.3.2/src/libFLAC/windows_unicode_filenames.c
+      endif
    endif
 
    SOURCES_CXX += $(CDROM_DIR)/CDAccess_CHD.cpp


### PR DESCRIPTION
This allows building this core against system libchdr and zlib, similar to my PR to flycast.

I have backported and upstreamed your chd_precache work to libchdr, with this I'm successfully using the beetle-psx cores with vanilla libchdr and zlib.

It would be awesome if you could upstream your ongoing CHD parent-clone work when it's done, upstream is very open to it https://github.com/rtissera/libchdr/issues/17.