### PR TITLE
Maintain Solaris compat + restore IllumOS build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ ifneq (,$(findstring unix,$(platform)))
    fpic   := -fPIC
    ifneq ($(findstring SunOS,$(shell uname -a)),)
       GREP = ggrep
-      SHARED := -shared -z defs -z gnu-version-script-compat
+      SHARED := -shared -z defs
    else
       GREP = grep
       SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T


### PR DESCRIPTION
Following the conversation in #659 I will be removing this option from various Makefiles to allow IllumOS builds again while maintaining Solaris compatibility