### PR TITLE
When HAVE_SHM, include <sys/stat.h> for S_IRUSR and S_IWUSR

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -39,6 +39,7 @@
 #endif
 
 #if defined(HAVE_SHM) || defined(HAVE_ASHMEM)
+#include <sys/stat.h>
 #include <fcntl.h>
 #endif
 


### PR DESCRIPTION
~~~
libretro.cpp: In function 'int lightrec_init_mmap()':
libretro.cpp:1683:4: error: 'S_IRUSR' was not declared in this scope
    S_IRUSR | S_IWUSR);
    ^~~~~~~
libretro.cpp:1683:14: error: 'S_IWUSR' was not declared in this scope
    S_IRUSR | S_IWUSR);
~~~

Defined here: https://pubs.opengroup.org/onlinepubs/009695399/basedefs/sys/stat.h.html