### PR TITLE
Prevent buffer over-read when saving states

### DIFF
--- a/mednafen/state.cpp
+++ b/mednafen/state.cpp
@@ -230,11 +230,13 @@ static int WriteStateChunk(StateMem *st, const char *sname, SFORMAT *sf)
 
    uint8_t sname_tmp[32];
 
+   size_t sname_len = strlen(sname);
+
    memset(sname_tmp, 0, sizeof(sname_tmp));
-   memcpy((char *)sname_tmp, sname, 32);
+   memcpy((char *)sname_tmp, sname, (sname_len < 32) ? sname_len : 32);
 
 #ifndef NDEBUG
-   if(strlen(sname) > 32)
+   if(sname_len > 32)
       printf("Warning: section name is too long: %s\n", sname);
 #endif
 


### PR DESCRIPTION
At present, the core performs out-of-bounds memory access when reading the chunk 'name' identifier every time a save state is made. This was causing a crash on my system.

This trivial PR fixes the issue.