### PR TITLE
Android: Fix hw compilation

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -70,5 +70,5 @@ LOCAL_CFLAGS       := $(COREFLAGS)
 LOCAL_CXXFLAGS     := $(COREFLAGS) -std=c++11
 LOCAL_LDFLAGS      := -Wl,-version-script=$(CORE_DIR)/link.T -ldl
 LOCAL_LDLIBS       := -llog
-LOCAL_CPP_FEATURES := exceptions
+LOCAL_CPP_FEATURES := exceptions rtti
 include $(BUILD_SHARED_LIBRARY)

--- a/parallel-psx/custom-textures/texture_tracker.hpp
+++ b/parallel-psx/custom-textures/texture_tracker.hpp
@@ -8,6 +8,7 @@
 #include "../vulkan/device.hpp"
 #include <fstream>
 #include "config_parser.h"
+#include "libretro.h"
 
 extern retro_log_printf_t log_cb;
 


### PR DESCRIPTION
A missing header, which makes me wonder how this compiled on any platform, even though it obviously did. And something in the new code requires rtti.