### PR TITLE
Removed library path /usr/local/lib.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ ifneq (,$(findstring unix,$(platform)))
          GLES = 1
          GL_LIB := -lGLESv2
       else
-         GL_LIB := -L/usr/local/lib -lGL
+         GL_LIB := -lGL
       endif
    endif
 


### PR DESCRIPTION
Recovered PR #624 that was closed by a force-push.
Old message below:

-----------

I'm getting QA problems in my sandbox cross-compilation environment that /usr/local/lib is pointing to host libraries.

ERROR: beetle-psx-libretro-1.0+gitrAUTOINC+7210cff299-r100 do_package_qa: QA Issue: beetle-psx-libretro: The compile log indicates that host include and/or library paths were used.
Please check the log '/home/dev/embedded/retro-build-enviroment/build/tmp/work/core2-32-poky-linux/beetle-psx-libretro/1.0+gitrAUTOINC+7210cff299-r100/temp/log.do_compile' for more information. [compile-host-path]