### PR TITLE
"Clamp" pgxp coordinates if lacking w components

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -126,7 +126,7 @@ enum dither_mode psx_gpu_dither_mode;
 
 //iCB: PGXP options
 unsigned int psx_pgxp_mode;
-unsigned int psx_pgxp_2d_tol;
+int psx_pgxp_2d_tol;
 unsigned int psx_pgxp_vertex_caching;
 unsigned int psx_pgxp_texture_correction;
 // \iCB

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -126,6 +126,7 @@ enum dither_mode psx_gpu_dither_mode;
 
 //iCB: PGXP options
 unsigned int psx_pgxp_mode;
+unsigned int psx_pgxp_2d_tol;
 unsigned int psx_pgxp_vertex_caching;
 unsigned int psx_pgxp_texture_correction;
 // \iCB
@@ -3461,6 +3462,17 @@ static void check_variables(bool startup)
    }
    else
       psx_pgxp_mode = PGXP_MODE_NONE;
+
+   var.key = BEETLE_OPT(pgxp_2d_tol);
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "disabled") == 0)
+         psx_pgxp_2d_tol = -1;
+      else
+         psx_pgxp_2d_tol = atoi(var.value);
+   }
+   else
+      psx_pgxp_2d_tol = -1;
 
    var.key = BEETLE_OPT(pgxp_vertex);
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -260,6 +260,25 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "disabled"
    },
+   {
+      BEETLE_OPT(pgxp_2d_tol),
+      "PGXP 2D Geometry Tolerance",
+      "Hide more glaring errors in PGXP operations: the value specifies the tolerance in which PGXP values will be kept in case of geometries without proper depth information.",
+      {
+         { "disabled", NULL },
+         { "0px", NULL },
+         { "1px", NULL },
+         { "2px", NULL },
+         { "3px", NULL },
+         { "4px", NULL },
+         { "5px", NULL },
+         { "6px", NULL },
+         { "7px", NULL },
+         { "8px", NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_VULKAN)
    {
       BEETLE_OPT(pgxp_vertex),

--- a/libretro_core_options_intl.h
+++ b/libretro_core_options_intl.h
@@ -215,6 +215,25 @@ struct retro_core_option_definition option_defs_it[] = {
       },
       "disabled"
    },
+   {
+      BEETLE_OPT(pgxp_2d_tol),
+      "Tolerancia de geometría PGXP 2D",
+      "Ocultar errores más evidentes en las operaciones de PGXP: el valor especifica la tolerancia en la que se mantendrán los valores de PGXP en caso de geometrías sin la información de profundidad adecuada",
+      {
+         { "disabled", NULL },
+         { "0px", NULL },
+         { "1px", NULL },
+         { "2px", NULL },
+         { "3px", NULL },
+         { "4px", NULL },
+         { "5px", NULL },
+         { "6px", NULL },
+         { "7px", NULL },
+         { "8px", NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_VULKAN)
    {
       BEETLE_OPT(pgxp_vertex),

--- a/mednafen/psx/gpu_polygon.cpp
+++ b/mednafen/psx/gpu_polygon.cpp
@@ -499,6 +499,8 @@ void Finalise_UVLimits(PS_GPU *gpu);
 bool Hack_FindLine(PS_GPU *gpu, tri_vertex* vertices, tri_vertex* outVertices);
 bool Hack_ForceLine(PS_GPU *gpu, tri_vertex* vertices, tri_vertex* outVertices);
 
+extern unsigned int psx_pgxp_2d_tol;
+
 template<int numvertices, bool goraud, bool textured, int BlendMode, bool TexMult, uint32_t TexMode_TA, bool MaskEval_TA, bool pgxp>
 static void Command_DrawPolygon(PS_GPU *gpu, const uint32_t *cb)
 {
@@ -636,11 +638,12 @@ static void Command_DrawPolygon(PS_GPU *gpu, const uint32_t *cb)
       {
          // lacking w component tends to mean degenerate coordinates
          // set to non-pgxp value if difference is too great
-         //
-         // TODO the difference could be a configurable option
-         if (
-            abs(vertices[v].precise[0] - vertices[v].x) > 4.0 * UPSCALE(gpu) ||
-            abs(vertices[v].precise[1] - vertices[v].y) > 4.0 * UPSCALE(gpu)
+         int tol = psx_pgxp_2d_tol * UPSCALE(gpu);
+         if (psx_pgxp_2d_tol >= 0 &&
+            (
+               abs(vertices[v].precise[0] - vertices[v].x) > tol ||
+               abs(vertices[v].precise[1] - vertices[v].y) > tol
+            )
          )
          {
             vertices[v].precise[0] = vertices[v].x;

--- a/mednafen/psx/gpu_polygon.cpp
+++ b/mednafen/psx/gpu_polygon.cpp
@@ -499,7 +499,7 @@ void Finalise_UVLimits(PS_GPU *gpu);
 bool Hack_FindLine(PS_GPU *gpu, tri_vertex* vertices, tri_vertex* outVertices);
 bool Hack_ForceLine(PS_GPU *gpu, tri_vertex* vertices, tri_vertex* outVertices);
 
-extern unsigned int psx_pgxp_2d_tol;
+extern int psx_pgxp_2d_tol;
 
 template<int numvertices, bool goraud, bool textured, int BlendMode, bool TexMult, uint32_t TexMode_TA, bool MaskEval_TA, bool pgxp>
 static void Command_DrawPolygon(PS_GPU *gpu, const uint32_t *cb)

--- a/mednafen/psx/gpu_polygon.cpp
+++ b/mednafen/psx/gpu_polygon.cpp
@@ -607,15 +607,11 @@ static void Command_DrawPolygon(PS_GPU *gpu, const uint32_t *cb)
          vertices[v].precise[1] = ((vert.y + (float)gpu->OffsY) * UPSCALE(gpu));
          vertices[v].precise[2] = vert.w;
 
-         if (!vert.valid_w)
+         if (!vert.valid_w || vert.w <= 0.0)
             invalidW = true;
       }
       else
-      {
-         vertices[v].precise[0] = vertices[v].x;
-         vertices[v].precise[1] = vertices[v].y;
          invalidW = true;
-      }
 
       cb++;
 
@@ -637,7 +633,21 @@ static void Command_DrawPolygon(PS_GPU *gpu, const uint32_t *cb)
    // iCB: If any vertices lack w components then set all to 1
    if (invalidW)
       for (unsigned v = 0; v < 3; v++)
+      {
+         // lacking w component tends to mean degenerate coordinates
+         // set to non-pgxp value if difference is too great
+         //
+         // TODO the difference could be a configurable option
+         if (
+            abs(vertices[v].precise[0] - vertices[v].x) > 4.0 * UPSCALE(gpu) ||
+            abs(vertices[v].precise[1] - vertices[v].y) > 4.0 * UPSCALE(gpu)
+         )
+         {
+            vertices[v].precise[0] = vertices[v].x;
+            vertices[v].precise[1] = vertices[v].y;
+         }
          vertices[v].precise[2] = 1.f;
+      }
 
    // Copy before Calc_UVOffsets which modifies vertices
    if(numvertices == 4 && gpu->InCmd != INCMD_QUAD)


### PR DESCRIPTION
I don't really know how to make PGXP less glitchy. This however adds a failsafe if a pgxp coordinate is lacking w component:

If the difference between pgxp x and y components and non-pgxp x and y components are too great, the non-pgxp values are used.

This in effect "hides" some more glaring glitches..