### PR TITLE
Add PGXP NCLIP on off switch

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -129,6 +129,7 @@ unsigned int psx_pgxp_mode;
 int psx_pgxp_2d_tol;
 unsigned int psx_pgxp_vertex_caching;
 unsigned int psx_pgxp_texture_correction;
+unsigned int psx_pgxp_nclip;
 // \iCB
 
 #define NEGCON_RANGE 0x7FFF
@@ -3390,6 +3391,17 @@ static void check_variables(bool startup)
       psx_pgxp_texture_correction = PGXP_MODE_NONE;
    // \iCB
 
+   var.key = BEETLE_OPT(pgxp_nclip);
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "disabled") == 0)
+         psx_pgxp_nclip = PGXP_MODE_NONE;
+      else if (strcmp(var.value, "enabled") == 0)
+         psx_pgxp_nclip = PGXP_NCLIP_IMPL;
+   }
+   else
+      psx_pgxp_nclip = PGXP_MODE_NONE;
+
    var.key = BEETLE_OPT(line_render);
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
@@ -4196,7 +4208,7 @@ void retro_run(void)
       GPU_set_visible_scanlines(MDFN_GetSettingI(content_is_pal ? "psx.slstartp" : "psx.slstart"),
                                 MDFN_GetSettingI(content_is_pal ? "psx.slendp" : "psx.slend"));
 
-      PGXP_SetModes(psx_pgxp_mode | psx_pgxp_vertex_caching | psx_pgxp_texture_correction);
+      PGXP_SetModes(psx_pgxp_mode | psx_pgxp_vertex_caching | psx_pgxp_texture_correction | psx_pgxp_nclip);
 
       // Reload memory cards if they were changed
       if (use_mednafen_memcard0_method &&

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -279,6 +279,17 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "disabled"
    },
+   {
+      BEETLE_OPT(pgxp_nclip),
+      "PGXP Primitive Culling",
+      "Use PGXP's NCLIP implementation. Improves appearance but causes many games to lock up.",
+      {
+         { "disabled", NULL },
+         { "enabled", NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_VULKAN)
    {
       BEETLE_OPT(pgxp_vertex),

--- a/libretro_core_options_intl.h
+++ b/libretro_core_options_intl.h
@@ -234,6 +234,17 @@ struct retro_core_option_definition option_defs_it[] = {
       },
       "disabled"
    },
+   {
+      BEETLE_OPT(pgxp_nclip),
+      "Eliminación primitiva de PGXP",
+      "Utilice la implementación NCLIP de PGXP. Mejora la apariencia pero hace que muchos juegos se bloqueen.",
+      {
+         { "disabled", NULL },
+         { "enabled", NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_VULKAN)
    {
       BEETLE_OPT(pgxp_vertex),

--- a/mednafen/psx/gte.cpp
+++ b/mednafen/psx/gte.cpp
@@ -1541,8 +1541,8 @@ static int32_t NCLIP(uint32_t instr)
    int64_t c      = x2 * (y0 - y1);
    int32_t sum    = a + b + c;
 
-   if (PGXP_enabled() &&
-       PGXP_NLCIP_valid(*((uint32*)&XY_FIFO[0]), *((uint32*)&XY_FIFO[1]), *((uint32*)&XY_FIFO[2]))) {
+   if ((PGXP_GetModes() & PGXP_NCLIP_IMPL) &&
+       PGXP_NCLIP_valid(*((uint32*)&XY_FIFO[0]), *((uint32*)&XY_FIFO[1]), *((uint32*)&XY_FIFO[2]))) {
       sum = PGXP_NCLIP();
    } else {
       sum = F( (int64_t)(XY_FIFO[0].X * (XY_FIFO[1].Y - XY_FIFO[2].Y)) + (XY_FIFO[1].X * (XY_FIFO[2].Y - XY_FIFO[0].Y)) + (XY_FIFO[2].X * (XY_FIFO[0].Y - XY_FIFO[1].Y))

--- a/pgxp/pgxp_gte.c
+++ b/pgxp/pgxp_gte.c
@@ -113,7 +113,7 @@ void PGXP_pushSXYZ2s(s64 _x, s64 _y, s64 _z, u32 v)
 #define VY(n) (psxRegs.CP2D.p[ n << 1 ].sw.h)
 #define VZ(n) (psxRegs.CP2D.p[ (n << 1) + 1 ].sw.l)
 
-int PGXP_NLCIP_valid(u32 sxy0, u32 sxy1, u32 sxy2)
+int PGXP_NCLIP_valid(u32 sxy0, u32 sxy1, u32 sxy2)
 {
 	Validate(&SXY0, sxy0);
 	Validate(&SXY1, sxy1);

--- a/pgxp/pgxp_gte.h
+++ b/pgxp/pgxp_gte.h
@@ -47,7 +47,7 @@ void	PGXP_pushSXYZ2s(s64 _x, s64 _y, s64 _z, u32 v);
 
 void	PGXP_RTPS(u32 _n, u32 _v);
 
-int		PGXP_NLCIP_valid(u32 sxy0, u32 sxy1, u32 sxy2);
+int		PGXP_NCLIP_valid(u32 sxy0, u32 sxy1, u32 sxy2);
 float	PGXP_NCLIP();
 
 // Data transfer tracking

--- a/pgxp/pgxp_main.h
+++ b/pgxp/pgxp_main.h
@@ -36,6 +36,7 @@
 
 #define PGXP_VERTEX_CACHE (1 << 4)
 #define PGXP_TEXTURE_CORRECTION (1 << 5)
+#define PGXP_NCLIP_IMPL (1 << 6)
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Add option to turn off PGXP's NCLIP implementation. This is a workaround for #490.

Not sure if it's a good idea to add yet another option though this one is in duckstation.

(I spent some time following the suggestion iCB mentioned [here](https://github.com/libretro/beetle-psx-libretro/issues/490#issuecomment-469062488): first a snapshot of the memory is taken when the dma starts then the dma is fed from the snapshot instead of updated ram, could be my implementation being wrong but the game is still locking up in the same place.. So far I've no idea how to workaround this for the widescreen case)