### PR TITLE
VRAM wraparound for adaptive smoothing

### DIFF
--- a/parallel-psx/renderer/renderer.hpp
+++ b/parallel-psx/renderer/renderer.hpp
@@ -412,7 +412,8 @@ private:
 	Vulkan::ImageHandle framebuffer;
 	Vulkan::ImageHandle framebuffer_ssaa;
 	Vulkan::Semaphore scanout_semaphore;
-	std::vector<Vulkan::ImageViewHandle> scaled_views;
+	Vulkan::ImageHandle scaled_framebuffer_asmooth;
+	std::vector<Vulkan::ImageViewHandle> scaled_views_asmooth;
 	FBAtlas atlas;
 	bool texture_tracking_enabled = false;
 	TextureTracker tracker;


### PR DESCRIPTION
Scanout VRAM wraparound was not implemented for adaptive smoothing.

Follow up to #723 

Please let me know if I miss anything this time.