### PR TITLE
Fix PGXP vertex culling option not being set on startup

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1891,7 +1891,7 @@ static void InitCommon(std::vector<CDIF *> *_CDInterfaces, const bool EmulateMem
          break;
    }
 
-   PGXP_SetModes(psx_pgxp_mode | psx_pgxp_vertex_caching | psx_pgxp_texture_correction);
+   PGXP_SetModes(psx_pgxp_mode | psx_pgxp_vertex_caching | psx_pgxp_texture_correction | psx_pgxp_nclip);
 
    CD_TrayOpen        = true;
    CD_SelectedDisc    = -1;


### PR DESCRIPTION
There are two places where `PGXP_SetModes` is called and I only remembered to change one of them. This PR changes the other one also.