### PR TITLE
Shared memory card support with libtetro method

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3621,12 +3621,12 @@ static void check_variables(bool startup)
       {
          if (!strcmp(var.value, "enabled"))
          {
-            if(use_mednafen_memcard0_method)
+            // if(use_mednafen_memcard0_method)
                shared_memorycards = true;
-            else
-               MDFND_DispMessage(3, RETRO_LOG_WARN,
-                     RETRO_MESSAGE_TARGET_ALL, RETRO_MESSAGE_TYPE_NOTIFICATION,
-                     "Memory Card 0 Method not set to Mednafen; shared memory cards could not be enabled.");
+            // else
+               // MDFND_DispMessage(3, RETRO_LOG_WARN,
+                     // RETRO_MESSAGE_TARGET_ALL, RETRO_MESSAGE_TYPE_NOTIFICATION,
+                     // "Memory Card 0 Method not set to Mednafen; shared memory cards could not be enabled.");
          }
          else if (!strcmp(var.value, "disabled"))
          {

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -1032,7 +1032,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       BEETLE_OPT(shared_memory_cards),
       "Shared Memory Cards (Restart)",
-      "When enabled, all games will save to and load from the same memory card files. When disabled, separate memory card files will be generated for each item of loaded content. Note: 'Memory Card 0 Method' must be set to 'Mednafen' for shared memory cards to take effect.",
+      "When enabled, all games will save to and load from the same memory card files. When disabled, separate memory card files will be generated for each item of loaded content. Note: if 'Memory Card 0 Method' is set to 'Libretro', only the right memory card will be affected.",
       {
          { "disabled", NULL },
          { "enabled",  NULL },


### PR DESCRIPTION
Commented the lines preventing beetle to use "shared memory cards" when saving method is set to "libretro".
Edited option description.
Now, when the "libretro save method" option is enabled, only the roght card will use the shared method.  