### PR TITLE
Disable pre-cache for physical media

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3888,7 +3888,14 @@ static bool MDFNI_LoadCD(const char *devicename)
 
          image_label[0] = '\0';
 
-         CDIF *image  = CDIF_Open(&success, devicename, false, cdimagecache);
+         bool cache = cdimagecache;
+         /* don't precache if physical cdrom, will take way too long and be unresponive */
+         if (cdimagecache && devicename && !strncasecmp(devicename, "cdrom:", 6)) {
+            cache = false;
+            log_cb(RETRO_LOG_INFO, "Skipping Pre-Cache due to using physical media: %s\n", devicename);
+         }
+
+         CDIF *image  = CDIF_Open(&success, devicename, false, cache);
          if (!success)
             return false;
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -981,7 +981,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       BEETLE_OPT(cd_access_method),
       "CD Access Method (Restart)",
-      "Select method used to read data from content disk images. 'Synchronous' mimics original hardware. 'Asynchronous' can reduce stuttering on devices with slow storage. 'Pre-Cache' loads the entire disk image into memory when launching content which may improve in-game loading times at the cost of an initial delay at startup. 'Pre-Cache' may cause issues on systems with low RAM.",
+      "Select method used to read data from content disk images. 'Synchronous' mimics original hardware. 'Asynchronous' can reduce stuttering on devices with slow storage. 'Pre-Cache' loads the entire disk image into memory when launching content which may improve in-game loading times at the cost of an initial delay at startup. 'Pre-Cache' may cause issues on systems with low RAM, and will fall back to 'Synchronous' for physical media",
       {
          { "sync",     "Synchronous" },
          { "async",    "Asynchronous" },


### PR DESCRIPTION
This takes way too long and is unresponsive, so don't actually
pre-cache any physical media when pre-cache is enabled

Fixes #795