### PR TITLE
Handle DIV overflow in lightrec

### DIFF
--- a/deps/lightrec/interpreter.c
+++ b/deps/lightrec/interpreter.c
@@ -823,6 +823,9 @@ static u32 int_special_DIV(struct interpreter *inter)
 	if (rt == 0) {
 		hi = rs;
 		lo = (rs < 0) * 2 - 1;
+	} else if ((rs == 0x80000000) && (rt == 0xFFFFFFFF)) {
+		lo = rs;
+		hi = 0;
 	} else {
 		lo = rs / rt;
 		hi = rs % rt;


### PR DESCRIPTION
This PR handles an undocumented edge case of division overflow in the DIV instruction in lightrec. Without this patch, guest code will get unexpected results, and may even crash the core on x86, as AmiDog's basic CPU test shows. The PR a [pcsx_rearmed counterpart](https://github.com/libretro/pcsx_rearmed/pull/530).