### PR TITLE
Add 18:9, 19:9 and 20:9 widescreen aspect ratio options

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3232,17 +3232,35 @@ static void check_variables(bool startup)
             has_new_geometry = true;
          widescreen_hack_aspect_ratio_setting = 1;
       }
-      else if (!strcmp(var.value, "21:9")) // 64:27
+      else if (!strcmp(var.value, "18:9"))
       {
          if (!startup && widescreen_hack_aspect_ratio_setting != 2)
             has_new_geometry = true;
          widescreen_hack_aspect_ratio_setting = 2;
       }
-      else if (!strcmp(var.value, "32:9"))
+      else if (!strcmp(var.value, "19:9"))
       {
          if (!startup && widescreen_hack_aspect_ratio_setting != 3)
             has_new_geometry = true;
          widescreen_hack_aspect_ratio_setting = 3;
+      }
+      else if (!strcmp(var.value, "20:9"))
+      {
+         if (!startup && widescreen_hack_aspect_ratio_setting != 4)
+            has_new_geometry = true;
+         widescreen_hack_aspect_ratio_setting = 4;
+      }
+      else if (!strcmp(var.value, "21:9")) // 64:27
+      {
+         if (!startup && widescreen_hack_aspect_ratio_setting != 5)
+            has_new_geometry = true;
+         widescreen_hack_aspect_ratio_setting = 5;
+      }
+      else if (!strcmp(var.value, "32:9"))
+      {
+         if (!startup && widescreen_hack_aspect_ratio_setting != 6)
+            has_new_geometry = true;
+         widescreen_hack_aspect_ratio_setting = 6;
       }
    }
    else

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -588,6 +588,9 @@ struct retro_core_option_definition option_defs_us[] = {
       {
          { "16:10", NULL },
          { "16:9",  NULL },
+         { "18:9",  NULL },
+         { "19:9",  NULL },
+         { "20:9",  NULL },
          { "21:9",  NULL }, // 64:27
          { "32:9",  NULL },
          { NULL,    NULL },

--- a/libretro_core_options_intl.h
+++ b/libretro_core_options_intl.h
@@ -407,6 +407,9 @@ struct retro_core_option_definition option_defs_it[] = {
       {
          { "16:10", NULL },
          { "16:9",  NULL },
+         { "18:9",  NULL },
+         { "19:9",  NULL },
+         { "20:9",  NULL },
          { "21:9",  NULL }, // 64:27
          { "32:9",  NULL },
          { NULL,    NULL },

--- a/mednafen/psx/gte.cpp
+++ b/mednafen/psx/gte.cpp
@@ -1196,10 +1196,19 @@ static INLINE void TransformXY(int64_t h_div_sz, float precise_h_div_sz, float p
       case 1: // 16:9 (default)
          widescreen_hack_aspect_ratio = 0.75f;
          break;
-      case 2: // 21:9 (64:27)
+      case 2: // 18:9 (smartphone)
+         widescreen_hack_aspect_ratio = 0.66f;
+         break;
+      case 3: // 19:9 (smartphone)
+         widescreen_hack_aspect_ratio = 0.63f;
+         break;
+      case 4: // 20:9 (smartphone)
+         widescreen_hack_aspect_ratio = 0.6f;
+         break;
+      case 5: // 21:9 (ultrawide, 64:27)
          widescreen_hack_aspect_ratio = 0.55f;
          break;
-      case 3: // 32:9
+      case 6: // 32:9 (superwide)
          widescreen_hack_aspect_ratio = 0.37f;
          break;
    }

--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -900,8 +900,14 @@ float rsx_common_get_aspect_ratio(bool pal_content, bool crop_overscan,
          case 1:
             return (16.0 / 9.0);
          case 2:
-            return (/*21.0 / 9.0*/ 64.0 / 27.0);
+            return (18.0 / 9.0);
          case 3:
+            return (19.0 / 9.0);
+         case 4:
+            return (20.0 / 9.0);
+         case 5:
+            return (/*21.0 / 9.0*/ 64.0 / 27.0);
+         case 6:
             return (32.0 / 9.0);
       }
 

--- a/rsx/rsx_lib_gl.cpp
+++ b/rsx/rsx_lib_gl.cpp
@@ -2246,10 +2246,16 @@ static struct retro_system_av_info get_av_info(VideoClock std)
          widescreen_hack_aspect_ratio_setting = 0;
       else if (!strcmp(var.value, "16:9"))
          widescreen_hack_aspect_ratio_setting = 1;
-      else if (!strcmp(var.value, "21:9"))
+      else if (!strcmp(var.value, "18:9"))
          widescreen_hack_aspect_ratio_setting = 2;
-      else if (!strcmp(var.value, "32:9"))
+      else if (!strcmp(var.value, "19:9"))
          widescreen_hack_aspect_ratio_setting = 3;
+      else if (!strcmp(var.value, "20:9"))
+         widescreen_hack_aspect_ratio_setting = 4;
+      else if (!strcmp(var.value, "21:9"))
+         widescreen_hack_aspect_ratio_setting = 5;
+      else if (!strcmp(var.value, "32:9"))
+         widescreen_hack_aspect_ratio_setting = 6;
    }
 
    var.key = BEETLE_OPT(crop_overscan);

--- a/rsx/rsx_lib_vulkan.cpp
+++ b/rsx/rsx_lib_vulkan.cpp
@@ -414,10 +414,16 @@ void rsx_vulkan_refresh_variables(void)
          widescreen_hack_aspect_ratio_setting = 0;
       else if (!strcmp(var.value, "16:9"))
          widescreen_hack_aspect_ratio_setting = 1;
-      else if (!strcmp(var.value, "21:9"))
+      else if (!strcmp(var.value, "18:9"))
          widescreen_hack_aspect_ratio_setting = 2;
-      else if (!strcmp(var.value, "32:9"))
+      else if (!strcmp(var.value, "19:9"))
          widescreen_hack_aspect_ratio_setting = 3;
+      else if (!strcmp(var.value, "20:9"))
+         widescreen_hack_aspect_ratio_setting = 4;
+      else if (!strcmp(var.value, "21:9"))
+         widescreen_hack_aspect_ratio_setting = 5;
+      else if (!strcmp(var.value, "32:9"))
+         widescreen_hack_aspect_ratio_setting = 6;
    }
 
    var.key = BEETLE_OPT(track_textures);


### PR DESCRIPTION
These options are intended for mobile devices where aspect ratios wider than 16:9 recently became widespread.

If currently using a 21:9 or 32:9 aspect ratio, the user will have to adjust their settings to get their old aspect ratio back.

This closes https://github.com/libretro/beetle-psx-libretro/issues/806.