### PR TITLE
Make "Additional Cropping" option compatible with hardware renderers

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -4163,8 +4163,6 @@ bool retro_load_game(const struct retro_game_info *info)
 
          option_display.key = BEETLE_OPT(image_offset);
          environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
-         option_display.key = BEETLE_OPT(image_crop);
-         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 
          option_display.key = BEETLE_OPT(frame_duping);
          environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
@@ -4182,8 +4180,6 @@ bool retro_load_game(const struct retro_game_info *info)
          environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 
          option_display.key = BEETLE_OPT(image_offset);
-         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
-         option_display.key = BEETLE_OPT(image_crop);
          environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 
          break;

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -1107,7 +1107,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       BEETLE_OPT(image_crop),
       "Additional Cropping",
       NULL,
-      "When 'Crop Horizontal Overscan' is enabled, this option further reduces the width of the cropped image by the specified number of pixels. Only supported by the software renderer.",
+      "When 'Crop Horizontal Overscan' is enabled, this option further reduces the width of the cropped image by the specified number of pixels",
       NULL,
       "video",
       {

--- a/parallel-psx/renderer/renderer.cpp
+++ b/parallel-psx/renderer/renderer.cpp
@@ -794,8 +794,8 @@ Renderer::DisplayRect Renderer::compute_display_rect()
 	if (render_state.crop_overscan)
 	{
 		// Horizontal crop amount is currently hardcoded. Future improvement could allow adjusting this.
-		display_width = 2560/clock_div;
-		left_offset = floor((render_state.horiz_start + render_state.offset_cycles - 608) / (double) clock_div);
+		display_width = (2560/clock_div) - render_state.image_crop;
+		left_offset = floor(((render_state.horiz_start + render_state.offset_cycles - 608) / (double) clock_div) - (render_state.image_crop / 2));
 	}
 	else
 	{

--- a/parallel-psx/renderer/renderer.hpp
+++ b/parallel-psx/renderer/renderer.hpp
@@ -118,6 +118,7 @@ public:
 		bool is_480i = false;
 		WidthMode width_mode = WidthMode::WIDTH_MODE_320;
 		bool crop_overscan = false;
+		unsigned image_crop = 0;
 
 		// Experimental horizontal offset feature
 		int offset_cycles = 0;
@@ -245,6 +246,11 @@ public:
 	void set_horizontal_offset_cycles(int offset_cycles)
 	{
 		render_state.offset_cycles = offset_cycles;
+	}
+	
+	void set_horizontal_additional_cropping(unsigned image_crop)
+	{
+		render_state.image_crop = image_crop;
 	}
 
 	void set_visible_scanlines(int slstart, int slend, int slstart_pal, int slend_pal)

--- a/rsx/rsx_lib_vulkan.cpp
+++ b/rsx/rsx_lib_vulkan.cpp
@@ -61,6 +61,7 @@ static bool replace_textures = false;
 static bool track_textures = false;
 static bool crop_overscan;
 static int image_offset_cycles;
+static unsigned image_crop;
 static int initial_scanline;
 static int last_scanline;
 static int initial_scanline_pal;
@@ -249,6 +250,7 @@ void rsx_vulkan_refresh_variables(void)
    bool old_super_sampling = super_sampling;
    bool old_show_vram = show_vram;
    bool old_crop_overscan = crop_overscan;
+   unsigned old_image_crop = image_crop;
    bool old_widescreen_hack = widescreen_hack;
    unsigned old_widescreen_hack_aspect_ratio_setting = widescreen_hack_aspect_ratio_setting;
    bool visible_scanlines_changed = false;
@@ -352,6 +354,15 @@ void rsx_vulkan_refresh_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       image_offset_cycles = atoi(var.value);
+   }
+   
+   var.key = BEETLE_OPT(image_crop);
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "disabled") == 0)
+         image_crop = 0;
+      else
+         image_crop = atoi(var.value);
    }
 
    var.key = BEETLE_OPT(initial_scanline);
@@ -493,6 +504,7 @@ void rsx_vulkan_refresh_variables(void)
         old_msaa != msaa ||
         old_show_vram != show_vram ||
         old_crop_overscan != crop_overscan ||
+		old_image_crop != image_crop ||
         old_widescreen_hack != widescreen_hack ||
         old_widescreen_hack_aspect_ratio_setting != widescreen_hack_aspect_ratio_setting ||
         visible_scanlines_changed)
@@ -559,6 +571,7 @@ void rsx_vulkan_finalize_frame(const void *fb, unsigned width,
    renderer->set_horizontal_overscan_cropping(crop_overscan);
    renderer->set_horizontal_offset_cycles(image_offset_cycles);
    renderer->set_visible_scanlines(initial_scanline, last_scanline, initial_scanline_pal, last_scanline_pal);
+   renderer->set_horizontal_additional_cropping(image_crop);
 
    renderer->set_display_filter(super_sampling ? Renderer::ScanoutFilter::SSAA : Renderer::ScanoutFilter::None);
    if (renderer->get_scanout_mode() == Renderer::ScanoutMode::BGR24)

--- a/rsx/rsx_lib_vulkan.cpp
+++ b/rsx/rsx_lib_vulkan.cpp
@@ -504,7 +504,7 @@ void rsx_vulkan_refresh_variables(void)
         old_msaa != msaa ||
         old_show_vram != show_vram ||
         old_crop_overscan != crop_overscan ||
-		old_image_crop != image_crop ||
+        old_image_crop != image_crop ||
         old_widescreen_hack != widescreen_hack ||
         old_widescreen_hack_aspect_ratio_setting != widescreen_hack_aspect_ratio_setting ||
         visible_scanlines_changed)


### PR DESCRIPTION
This PR makes the "Additional Cropping" option work with not only the software renderer, but also with both the Vulkan and OpenGL renderers.