### PR TITLE
Fix some issues with the dynamic overscan cropping

### DIFF
--- a/mednafen/psx/gpu.cpp
+++ b/mednafen/psx/gpu.cpp
@@ -1676,7 +1676,12 @@ int32_t GPU_Update(const int32_t sys_timestamp)
                   && GPU.scanline < (FirstVisibleLine + VisibleLineCount))
             {
                int32 fb_x      = GPU.DisplayFB_XStart * 2;
-               int32 dx_start  = (crop_overscan ? 608 : GPU.HorizStart), dx_end = GPU.HorizEnd;
+               // Restore old center behaviour if GPU.HorizStart is intentionally very high.
+               // 938 fixes Gunbird (1008) and Mobile Light Force (EU release of Gunbird),
+               // but this value should be lowered in the future if necessary.
+               // Additionally cut off everything after GPU.HorizEnd that shouldn't be
+               // in the viewport (the hardware renderers already takes care of this).
+               int32 dx_start  = (crop_overscan && GPU.HorizStart < 938 ? 608 : GPU.HorizStart), dx_end = (crop_overscan && GPU.HorizStart < 938 ? GPU.HorizEnd - GPU.HorizStart + 608 : GPU.HorizEnd - (GPU.HorizStart < 938 ? 0 : 1));
                int32 dest_line =
                   ((GPU.scanline - FirstVisibleLine) << GPU.espec->InterlaceOn)
                   + GPU.espec->InterlaceField;

--- a/parallel-psx/renderer/renderer.cpp
+++ b/parallel-psx/renderer/renderer.cpp
@@ -794,8 +794,14 @@ Renderer::DisplayRect Renderer::compute_display_rect()
 	if (render_state.crop_overscan)
 	{
 		// Horizontal crop amount is currently hardcoded. Future improvement could allow adjusting this.
+		// Restore old center behaviour is render_state.horiz_start is intentionally very high.
+		// 938 fixes Gunbird (1008) and Mobile Light Force (EU release of Gunbird),
+		// but this value should be lowerer in the future if necessary.
 		display_width = (2560/clock_div) - render_state.image_crop;
-		left_offset = floor((render_state.offset_cycles / (double) clock_div) - (render_state.image_crop / 2));
+		if (render_state.horiz_start < 938)
+			left_offset = floor((render_state.offset_cycles / (double) clock_div) - (render_state.image_crop / 2));
+		else
+			left_offset = floor(((render_state.horiz_start + render_state.offset_cycles - 608) / (double) clock_div) - (render_state.image_crop / 2));
 	}
 	else
 	{

--- a/rsx/rsx_lib_gl.cpp
+++ b/rsx/rsx_lib_gl.cpp
@@ -1586,7 +1586,14 @@ static GlDisplayRect compute_gl_display_rect(GlRenderer *renderer)
    {
       width = (uint32_t) ((2560/clock_div) - renderer->image_crop);
       int32_t offset_cycles = renderer->image_offset_cycles;
-      x = floor((offset_cycles / (double) clock_div) - (renderer->image_crop / 2));
+      int32_t h_start = (int32_t) renderer->config.display_area_hrange[0];
+      /* Restore old center behaviour is render_state.horiz_start is intentionally very high.
+       * 938 fixes Gunbird (1008) and Mobile Light Force (EU release of Gunbird),
+       * but this value should be lowerer in the future if necessary. */
+      if (renderer->config.display_area_hrange[0] < 938)
+          x = floor((offset_cycles / (double) clock_div) - (renderer->image_crop / 2));
+      else
+          x = floor(((h_start - 608 + offset_cycles) / (double) clock_div) - (renderer->image_crop / 2));
    }
    else
    {


### PR DESCRIPTION
This fixes the following issues introduced with https://github.com/libretro/beetle-psx-libretro/pull/819:
- The in-game image for Gunbird and Mobile Light Force (an European release of Gunbird) being shifted to the left.
- Garbage textures being shown on the right side of the screen when shifting the image to the left with the software renderer (hardware renderers didn't have this problem).