### PR TITLE
Add option to override the BIOS

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -167,63 +167,63 @@ static bool firmware_is_present(unsigned region)
    https://github.com/mamedev/mame/blob/master/src/mame/drivers/psx.cpp */
 
 
-	if (override_bios)
-	{
-		if (override_bios == 1)
-		{
+   if (override_bios)
+   {
+      if (override_bios == 1)
+      {
 			bios_name_list[0] = "psxonpsp660.bin";
 			bios_name_list[1] = "PSXONPSP660.bin";
 			bios_name_list[2] = NULL;
 			bios_sha1 = "96880D1CA92A016FF054BE5159BB06FE03CB4E14";
-		}
+      }
 		
-		else if (override_bios == 2)
-		{
+      else if (override_bios == 2)
+      {
 			bios_name_list[0] = "ps1_rom.bin";
 			bios_name_list[1] = "PS1_ROM.bin";
 			bios_name_list[2] = NULL;
 			bios_sha1 = "C40146361EB8CF670B19FDC9759190257803CAB7";
-		}
+      }
 	   
-	    size_t i;
-		for (i = 0; i < list_size; ++i)
-		{
-			if (!bios_name_list[i])
-				break;
+      size_t i;
+      for (i = 0; i < list_size; ++i)
+      {
+         if (!bios_name_list[i])
+            break;
 
-			int r = snprintf(bios_path, sizeof(bios_path), "%s%c%s", retro_base_directory, retro_slash, bios_name_list[i]);
-			if (r >= 4096)
-			{
-				bios_path[4095] = '\0';
-				log_cb(RETRO_LOG_ERROR, "Firmware path longer than 4095: %s\n", bios_path);
-				break;
-			}
+         int r = snprintf(bios_path, sizeof(bios_path), "%s%c%s", retro_base_directory, retro_slash, bios_name_list[i]);
+         if (r >= 4096)
+         {
+            bios_path[4095] = '\0';
+            log_cb(RETRO_LOG_ERROR, "Firmware path longer than 4095: %s\n", bios_path);
+            break;
+         }
 
-			if (filestream_exists(bios_path))
-			{
-				firmware_found = true;
-				break;
-			}
-		}
+         if (filestream_exists(bios_path))
+         {
+            firmware_found = true;
+            break;
+         }
+      }
 
-		if (firmware_found)
-		{	
-			char obtained_sha1[41];
-			sha1_calculate(bios_path, obtained_sha1);
-			if (strcmp(obtained_sha1, bios_sha1))
-			{
-				log_cb(RETRO_LOG_WARN, "Override firmware found but has invalid SHA1: %s\n", bios_path);
-				log_cb(RETRO_LOG_WARN, "Expected SHA1: %s\n", bios_sha1);
-				log_cb(RETRO_LOG_WARN, "Obtained SHA1: %s\n", obtained_sha1);
-				log_cb(RETRO_LOG_WARN, "Unsupported firmware may cause emulation glitches.\n");
-				return true;
-			}
+      if (firmware_found)
+      {	
+         char obtained_sha1[41];
+         sha1_calculate(bios_path, obtained_sha1);
+         if (strcmp(obtained_sha1, bios_sha1))
+         {
+            log_cb(RETRO_LOG_WARN, "Override firmware found but has invalid SHA1: %s\n", bios_path);
+            log_cb(RETRO_LOG_WARN, "Expected SHA1: %s\n", bios_sha1);
+            log_cb(RETRO_LOG_WARN, "Obtained SHA1: %s\n", obtained_sha1);
+            log_cb(RETRO_LOG_WARN, "Unsupported firmware may cause emulation glitches.\n");
+            return true;
+         }
 
-			log_cb(RETRO_LOG_INFO, "Override firmware found: %s\n", bios_path);
-			log_cb(RETRO_LOG_INFO, "Override firmware SHA1: %s\n", obtained_sha1);
+         log_cb(RETRO_LOG_INFO, "Override firmware found: %s\n", bios_path);
+         log_cb(RETRO_LOG_INFO, "Override firmware SHA1: %s\n", obtained_sha1);
 
-			return true;
-		}
+         return true;
+      }
       log_cb(RETRO_LOG_WARN, "Override firmware is missing: %s\n", bios_name_list[0]);
       log_cb(RETRO_LOG_WARN, "Fallback to region specific firmware.\n");
    }

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -978,7 +978,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       BEETLE_OPT(override_bios),
       "Override BIOS (Restart)",
       NULL,
-      "Override the standard region specific BIOS with a region-free one if found. Depending on the BIOS, may improve performance at the expence of compatibility",
+      "Override the standard region specific BIOS with a region-free one if found.",
       NULL,
       "hacks",
       {


### PR DESCRIPTION
Inspired by https://github.com/libretro/beetle-psx-libretro/issues/519, this PR adds an option to override the BIOS with either `psxonpsp660.bin` or `ps1_rom.bin` (the PS1 BIOS for the PSP and PS3 respectively), while falling back to the region specific ones if the set region-free BIOS is not found.
This mostly server as a convenience tweak, as you can choose whenever or not you want to use the region-free BIOS, or the region specific ones on a game by game basis without having to replace the BIOS files manually in the system folder, and can be expanded in the future to include stuff like the Open BIOS for example.