### PR TITLE
Set game specific tweak to get Monkey Hero running past the title screen

### DIFF
--- a/beetle_psx_globals.c
+++ b/beetle_psx_globals.c
@@ -19,3 +19,4 @@ bool interlace_setting_dirty = false;
 
 int aspect_ratio_setting = 0;
 bool aspect_ratio_dirty = false;
+bool is_monkey_hero = false;

--- a/beetle_psx_globals.h
+++ b/beetle_psx_globals.h
@@ -38,6 +38,7 @@ extern bool interlace_setting_dirty;
 
 extern int aspect_ratio_setting;
 extern bool aspect_ratio_dirty;
+extern bool is_monkey_hero;
 
 #ifdef __cplusplus
 }

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1494,6 +1494,12 @@ static const char *CalcDiscSCEx_BySYSTEMCNF(CDIF *c, unsigned *rr)
             if(!strncasecmp(bootpos, "cdrom:\\", 7))
             {
                bootpos += 7;
+               if(!strncmp(bootpos + 7, "SLUS_007.65", 11) || !strncmp(bootpos + 7, "SLES_009.79", 11))
+               {
+                  is_monkey_hero = true;
+                  log_cb(RETRO_LOG_INFO, "Monkey Hero FBWrite Tweak Activated\n");
+               }
+
                char *tmp;
 
                if((tmp = strchr(bootpos, '_'))) *tmp = 0;

--- a/mednafen/psx/gpu.cpp
+++ b/mednafen/psx/gpu.cpp
@@ -34,6 +34,7 @@
 #include "gpu_line.cpp"
 
 extern bool crop_overscan;
+extern bool is_monkey_hero;
 
 /*
    GPU display timing master clock is nominally 53.693182 MHz for NTSC PlayStations, and 53.203425 MHz for PAL PlayStations.
@@ -534,6 +535,8 @@ static CTEntry Commands[256] =
 
 static INLINE bool CalcFIFOReadyBit(void)
 {
+   uint32_t ctcommand = (GPU_BlitterFIFO.Peek() >> 24);
+
    if(GPU.InCmd & (INCMD_PLINE | INCMD_QUAD))
       return(false);
 
@@ -543,7 +546,8 @@ static INLINE bool CalcFIFOReadyBit(void)
    if(GPU.InCmd & (INCMD_FBREAD | INCMD_FBWRITE))
       return(false);
 
-   if(GPU_BlitterFIFO.in_count >= Commands[GPU_BlitterFIFO.Peek() >> 24].fifo_fb_len)
+   // Change fifo_fb_len from 2 to 3 for Command_FBWrite when running Monkey Hero.
+   if(GPU_BlitterFIFO.in_count >= Commands[GPU_BlitterFIFO.Peek() >> 24].fifo_fb_len + ((ctcommand >= 0xA0) && (ctcommand <= 0xBF) && is_monkey_hero ? 1 : 0))
       return(false);
 
    return(true);


### PR DESCRIPTION
Expending on the suggestion in the PSX-TODO file located in /mednafen/psx/notes/, this sets the Command_FBWrite fifo_fb_len value to 3 when running Monkey Hero by checking for its game ID on startup, which allows the game to continue past the title screen.