### PR TITLE
Add static crop behavior for "Crop Overscan" alongside dynamic

### DIFF
--- a/beetle_psx_globals.c
+++ b/beetle_psx_globals.c
@@ -11,7 +11,7 @@ int line_render_mode;
 int filter_mode;
 bool opaque_check;
 bool semitrans_check;
-bool crop_overscan = false;
+int crop_overscan = 0;
 
 int core_timing_fps_mode = FORCE_PROGRESSIVE_TIMING;
 bool currently_interlaced = false;

--- a/beetle_psx_globals.h
+++ b/beetle_psx_globals.h
@@ -23,7 +23,7 @@ extern int line_render_mode;
 extern int filter_mode;
 extern bool opaque_check;
 extern bool semitrans_check;
-extern bool crop_overscan;
+extern int crop_overscan;
 
 enum core_timing_fps_modes
 {

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3811,17 +3811,18 @@ static void check_variables(bool startup)
    var.key = BEETLE_OPT(crop_overscan);
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (strcmp(var.value, "enabled") == 0)
+      int old_crop_overscan = crop_overscan;
+      if (strcmp(var.value, "disabled") == 0)
+         crop_overscan = 0;
+      else if (strcmp(var.value, "static") == 0)
+         crop_overscan = 1;
+      else if (strcmp(var.value, "smart") == 0)
+         crop_overscan = 2;
+
+      if(crop_overscan != old_crop_overscan)
       {
-         if (crop_overscan == false)
-            has_new_geometry = true;
-         crop_overscan = true;
-      }
-      else if (strcmp(var.value, "disabled") == 0)
-      {
-         if (crop_overscan == true)
-            has_new_geometry = true;
-         crop_overscan = false;
+         has_new_geometry = true;
+         old_crop_overscan = crop_overscan;
       }
    }
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -1108,15 +1108,16 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       BEETLE_OPT(crop_overscan),
       "Crop Overscan",
       NULL,
-      "By default, the renderers add padding (pillarboxes on either side of the image for NTSC, on all sides for PAL) to emulate the same black bars generated in analog video output by real PSX hardware. Enabling this option removes that padding.",
+      "By default, the renderers add padding (pillarboxes on either side of the image for NTSC, on all sides for PAL) to emulate the same black bars generated in analog video output by real PSX hardware. Dynamic removes all padding, while Static only removes horizontal padding.",
       NULL,
       "video",
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
+         { "disabled",  NULL },
+         { "static",  "Static" },
+         { "smart", "Dynamic" },
          { NULL, NULL },
       },
-      "enabled"
+      "smart"
    },
    {
       BEETLE_OPT(image_crop),

--- a/libretro_core_options_intl.h
+++ b/libretro_core_options_intl.h
@@ -520,8 +520,9 @@ struct retro_core_option_v2_definition option_defs_it[] = {
       NULL,
       NULL,
       {
-         { "disabled", NULL },
-         { "enabled",  NULL },
+         { "disabled",  NULL },
+         { "static",  "Static" },
+         { "smart", "Dynamic" },
          { NULL, NULL },
       },
       NULL

--- a/mednafen/psx/gpu.cpp
+++ b/mednafen/psx/gpu.cpp
@@ -33,7 +33,7 @@
 #include "gpu_sprite.cpp"
 #include "gpu_line.cpp"
 
-extern bool crop_overscan;
+extern int crop_overscan;
 extern bool is_monkey_hero;
 
 /*
@@ -1484,9 +1484,9 @@ int32_t GPU_Update(const int32_t sys_timestamp)
          else
          {
             const unsigned int FirstVisibleLine =
-               GPU.LineVisFirst + (crop_overscan ? GPU.VertStart : (GPU.HardwarePALType ? 20 : 16));
+               GPU.LineVisFirst + (crop_overscan == 2 ? GPU.VertStart : (GPU.HardwarePALType ? 20 : 16));
             const unsigned int VisibleLineCount =
-               (crop_overscan ? (GPU.VertEnd - GPU.VertStart) - ((GPU.HardwarePALType ? 287 : 239) - GPU.LineVisLast) - GPU.LineVisFirst : GPU.LineVisLast + 1 - GPU.LineVisFirst); //HardwarePALType ? 288 : 240;
+               (crop_overscan == 2 ? (GPU.VertEnd - GPU.VertStart) - ((GPU.HardwarePALType ? 287 : 239) - GPU.LineVisLast) - GPU.LineVisFirst : GPU.LineVisLast + 1 - GPU.LineVisFirst); //HardwarePALType ? 288 : 240;
 
             TIMER_SetHRetrace(false);
 
@@ -1685,7 +1685,7 @@ int32_t GPU_Update(const int32_t sys_timestamp)
                // but this value should be lowered in the future if necessary.
                // Additionally cut off everything after GPU.HorizEnd that shouldn't be
                // in the viewport (the hardware renderers already takes care of this).
-               int32 dx_start  = (crop_overscan && GPU.HorizStart < 938 ? 608 : GPU.HorizStart), dx_end = (crop_overscan && GPU.HorizStart < 938 ? GPU.HorizEnd - GPU.HorizStart + 608 : GPU.HorizEnd - (GPU.HorizStart < 938 ? 0 : 1));
+               int32 dx_start  = (crop_overscan == 2 && GPU.HorizStart < 938 ? 608 : GPU.HorizStart), dx_end = (crop_overscan == 2 && GPU.HorizStart < 938 ? GPU.HorizEnd - GPU.HorizStart + 608 : GPU.HorizEnd - (GPU.HorizStart < 938 ? 0 : 1));
                int32 dest_line =
                   ((GPU.scanline - FirstVisibleLine) << GPU.espec->InterlaceOn)
                   + GPU.espec->InterlaceField;

--- a/parallel-psx/renderer/renderer.cpp
+++ b/parallel-psx/renderer/renderer.cpp
@@ -798,7 +798,7 @@ Renderer::DisplayRect Renderer::compute_display_rect()
 		// 938 fixes Gunbird (1008) and Mobile Light Force (EU release of Gunbird),
 		// but this value should be lowerer in the future if necessary.
 		display_width = (2560/clock_div) - render_state.image_crop;
-		if (render_state.horiz_start < 938)
+		if ((render_state.horiz_start < 938) && (render_state.crop_overscan == 2))
 			left_offset = floor((render_state.offset_cycles / (double) clock_div) - (render_state.image_crop / 2));
 		else
 			left_offset = floor(((render_state.horiz_start + render_state.offset_cycles - 608) / (double) clock_div) - (render_state.image_crop / 2));
@@ -811,7 +811,7 @@ Renderer::DisplayRect Renderer::compute_display_rect()
 
 	unsigned display_height;
 	int upper_offset;
-	if (render_state.crop_overscan)
+	if (render_state.crop_overscan == 2)
 	{
 		if (render_state.is_pal)
 		{

--- a/parallel-psx/renderer/renderer.hpp
+++ b/parallel-psx/renderer/renderer.hpp
@@ -117,7 +117,7 @@ public:
 		bool is_pal = false;
 		bool is_480i = false;
 		WidthMode width_mode = WidthMode::WIDTH_MODE_320;
-		bool crop_overscan = false;
+		int crop_overscan = 0;
 		unsigned image_crop = 0;
 
 		// Experimental horizontal offset feature
@@ -238,7 +238,7 @@ public:
 		render_state.width_mode = width_mode;
 	}
 
-	void set_horizontal_overscan_cropping(bool crop_overscan)
+	void set_horizontal_overscan_cropping(int crop_overscan)
 	{
 		render_state.crop_overscan = crop_overscan;
 	}

--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -874,13 +874,13 @@ double rsx_common_get_timing_fps(void)
 }
 
 
-float rsx_common_get_aspect_ratio(bool pal_content, bool crop_overscan,
+float rsx_common_get_aspect_ratio(bool pal_content, int crop_overscan,
                                   int first_visible_scanline, int last_visible_scanline,
                                   int aspect_ratio_setting, bool vram_override, bool widescreen_override,
                                   int widescreen_hack_aspect_ratio_setting)
 {
    // Current assumptions
-   //    A fixed percentage of width is cropped when crop_overscan is true
+   //    A fixed percentage of width is cropped when crop_overscan isn't 0
    //    aspect_ratio_setting is one of the following:
    //          0 - Corrected
    //          1 - Uncorrected (1:1 PAR)

--- a/rsx/rsx_intf.h
+++ b/rsx/rsx_intf.h
@@ -171,7 +171,7 @@ bool rsx_intf_has_software_renderer(void);
 
 double rsx_common_get_timing_fps(void);
 
-float rsx_common_get_aspect_ratio(bool pal_content, bool crop_overscan,
+float rsx_common_get_aspect_ratio(bool pal_content, int crop_overscan,
                                   int first_visible_scanline, int last_visible_scanline,
                                   int aspect_ratio_setting, bool vram_override, bool widescreen_override,
                                   int widescreen_hack_aspect_ratio_setting);

--- a/rsx/rsx_lib_vulkan.cpp
+++ b/rsx/rsx_lib_vulkan.cpp
@@ -59,7 +59,7 @@ static dither_mode dither_mode = DITHER_NATIVE;
 static bool dump_textures = false;
 static bool replace_textures = false;
 static bool track_textures = false;
-static bool crop_overscan;
+static int crop_overscan;
 static int image_offset_cycles;
 static unsigned image_crop;
 static int initial_scanline;
@@ -249,7 +249,7 @@ void rsx_vulkan_refresh_variables(void)
    unsigned old_msaa = msaa;
    bool old_super_sampling = super_sampling;
    bool old_show_vram = show_vram;
-   bool old_crop_overscan = crop_overscan;
+   int old_crop_overscan = crop_overscan;
    unsigned old_image_crop = image_crop;
    bool old_widescreen_hack = widescreen_hack;
    unsigned old_widescreen_hack_aspect_ratio_setting = widescreen_hack_aspect_ratio_setting;
@@ -344,10 +344,12 @@ void rsx_vulkan_refresh_variables(void)
    var.key = BEETLE_OPT(crop_overscan);
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "enabled"))
-         crop_overscan = true;
-      else
-         crop_overscan = false;
+      if (strcmp(var.value, "disabled") == 0)
+         crop_overscan = 0;
+      else if (strcmp(var.value, "static") == 0)
+         crop_overscan = 1;
+      else if (strcmp(var.value, "smart") == 0)
+         crop_overscan = 2;
    }
 
    var.key = BEETLE_OPT(image_offset_cycles);


### PR DESCRIPTION
In response to https://github.com/libretro/beetle-psx-libretro/issues/820, this adds back the old, static crop behavior, while retaining the new, dynamic one as an additional selection for the "Crop Overscan" option.