### PR TITLE
fix emscripten builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,93 +327,10 @@ else ifeq ($(platform), emscripten)
    fpic    := -fPIC
    SHARED  := -shared -Wl,--no-undefined -Wl,--version-script=link.T
    LDFLAGS += $(PTHREAD_FLAGS)
-   FLAGS   += $(PTHREAD_FLAGS) -Dretro_fopen=gg_retro_fopen\
-               -Dmain=gg_main\
-               -Dretro_fclose=gg_retro_fclose\
-               -Dretro_fseek=gg_retro_fseek\
-               -Dretro_fread=gg_retro_fread\
-               -Dretro_fwrite=gg_retro_fwrite\
-               -Dpath_is_directory=gg_path_is_directory\
-               -Dscond_broadcast=gg_scond_broadcast\
-               -Dscond_wait_timeout=gg_scond_wait_timeout\
-               -Dscond_signal=gg_scond_signal\
-               -Dscond_wait=gg_scond_wait\
-               -Dscond_free=gg_scond_free\
-               -Dscond_new=gg_scond_new\
-               -Dslock_unlock=gg_slock_unlock\
-               -Dslock_lock=gg_slock_lock\
-               -Dslock_free=gg_slock_free\
-               -Dslock_new=gg_slock_new\
-               -Dsthread_join=gg_sthread_join\
-               -Dsthread_detach=gg_sthread_detach\
-               -Dsthread_create=gg_sthread_create\
-               -Dscond=gg_scond\
-               -Dslock=gg_slock\
-               -Drglgen_symbol_map=mupen_rglgen_symbol_map \
-               -Dmain_exit=mupen_main_exit \
-               -Dadler32=mupen_adler32 \
-               -Drglgen_resolve_symbols_custom=mupen_rglgen_resolve_symbols_custom \
-               -Drglgen_resolve_symbols=mupen_rglgen_resolve_symbols \
-               -Dsinc_resampler=mupen_sinc_resampler \
-               -Dnearest_resampler=mupen_nearest_resampler \
-               -DCC_resampler=mupen_CC_resampler \
-               -Daudio_resampler_driver_find_handle=mupen_audio_resampler_driver_find_handle \
-               -Daudio_resampler_driver_find_ident=mupen_audio_resampler_driver_find_ident \
-               -Drarch_resampler_realloc=mupen_rarch_resampler_realloc \
-               -Daudio_convert_s16_to_float_C=mupen_audio_convert_s16_to_float_C \
-               -Daudio_convert_float_to_s16_C=mupen_audio_convert_float_to_s16_C \
-               -Daudio_convert_init_simd=mupen_audio_convert_init_simd \
-               -Dfilestream_open=gg_filestream_open\
-               -Dfilestream_get_fd=gg_filestream_get_fd\
-               -Dfilestream_read=gg_filestream_read\
-               -Dfilestream_seek=gg_filestream_seek\
-               -Dfilestream_close=gg_filestream_close\
-               -Dfilestream_tell=gg_filestream_tell\
-               -Dfilestream_set_size=gg_filestream_set_size\
-               -Dfilestream_get_ext=gg_filestream_get_ext\
-               -Dfilestream_get_size=gg_filestream_get_size\
-               -Dfilestream_read_file=gg_filestream_read_file\
-               -Dfilestream_write_file=gg_filestream_write_file\
-               -Dfilestream_write=gg_filestream_write\
-               -Dfilestream_rewind=gg_filestream_rewind\
-               -Dfilestream_putc=gg_filestream_putc\
-               -Dfilestream_getline=gg_filestream_getline\
-               -Dfilestream_getc=gg_filestream_getc\
-               -Dfilestream_gets=gg_filestream_gets\
-               -Dfilestream_eof=gg_filestream_eof\
-               -Dfilestream_flush=gg_filestream_flush\
-               -Dpath_is_character_special=gg_path_is_character_special\
-               -Dpath_is_valid=gg_path_is_valid\
-               -Dpath_is_compressed=gg_path_is_compressed\
-               -Dpath_is_compressed_file=gg_path_is_compressed_file\
-               -Dpath_is_absolute=gg_path_is_absolute\
-               -Dpath_is_directory=gg_path_is_directory\
-               -Dpath_get_size=gg_path_get_size\
-               -Dpath_get_extension=gg_path_get_extension\
-               -Dstring_is_empty=gg_string_is_empty\
-               -Dstring_is_equal=gg_string_is_equal\
-               -Dstring_to_upper=gg_string_to_upper\
-               -Dstring_to_lower=gg_string_to_lower\
-               -Dstring_ucwords=gg_string_ucwords\
-               -Dstring_replace_substring=gg_string_replace_substring\
-               -Dstring_trim_whitespace_left=gg_string_trim_whitespace_left\
-               -Dstring_trim_whitespace_right=gg_string_trim_whitespace_right\
-               -Dstring_trim_whitespace_left=gg_string_trim_whitespace_left\
-               -Dstring_trim_whitespace=gg_string_trim_whitespace\
-               -Dsthread_isself=gg_sthread_isself\
-               -Dstring_is_equal_noncase=gg_string_is_equal_noncase\
-               -Dmkdir_norecurse=gg_mkdir_norecurse
-
    STATIC_LINKING = 1
-
-   ifeq ($(HAVE_OPENGL),1)
-      ifneq (,$(findstring gles,$(platform)))
-         GLES = 1
-         GL_LIB := -lGLESv2
-      else
-         GL_LIB := -lGL
-      endif
-   endif
+   HAVE_LIGHTREC = 0
+   NEED_THREADING = 0
+   HAVE_CDROM = 0
 
 # Raspberry Pi 4 in 64bit mode
 else ifeq ($(platform), rpi4_64)


### PR DESCRIPTION
This builds and functions as a core though CPU only. 
I would be interested in if WEBGL could function here, I kind of ran into dependency hell when trying to build it against the frontend, but it already uses glsym_es2 for it's menu rendering IE: 

```
[INFO] [EMSCRIPTEN/EGL]: Dimensions: 800x600
[INFO] [GL]: Found GL context: egl_emscripten
[INFO] [GL]: Detecting screen resolution 800x600.
[INFO] [GL]: Vendor: WebKit, Renderer: WebKit WebGL.
[INFO] [GL]: Version: OpenGL ES 2.0 (WebGL 1.0 (OpenGL ES 2.0 Chromium)).
```

Just giving reason as to why I pulled out the GL settings as it will not work when building against the frontend anyway and might confuse users. 

Regardless this should not hurt to merge, the current fake deps are no longer needed. 