### PR TITLE
Check BIOSes by SHA1 and filesize, not filename.

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -164,6 +164,8 @@ static bool firmware_is_present(unsigned region)
    /* SHA1 and alternate BIOS names sourced from
    https://github.com/mamedev/mame/blob/master/src/mame/drivers/psx.cpp */
 
+
+   
    if (override_bios)
    {
       if (override_bios == 1)
@@ -176,6 +178,8 @@ static bool firmware_is_present(unsigned region)
 			bios_sha1 = "C40146361EB8CF670B19FDC9759190257803CAB7";
       }
    }
+   else
+   {
    switch (region)
    {
    case REGION_JP:
@@ -190,6 +194,8 @@ static bool firmware_is_present(unsigned region)
    default:
       break;
    }
+   }
+   
 
    RDIR *dir= retro_opendir(retro_base_directory);
    if(!dir)return false;

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -188,8 +188,8 @@ static bool firmware_is_present(unsigned region)
    case REGION_NA:
    bios_sha1 = "0555C6FAE8906F3F09BAF5988F00E55F88E9F30B";
    break;
-   bios_sha1 = "F6BC2D1F5EB6593DE7D089C425AC681D6FFFD3F0";
    case REGION_EU:
+   bios_sha1 = "F6BC2D1F5EB6593DE7D089C425AC681D6FFFD3F0";
    break;
    default:
       break;

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -170,11 +170,13 @@ static bool firmware_is_present(unsigned region)
    {
       if (override_bios == 1)
       {
+         //psxonpsp660.bin
 			bios_sha1 = "96880D1CA92A016FF054BE5159BB06FE03CB4E14";
       }
 		
       else if (override_bios == 2)
       {
+         //ps1_rom.bin
 			bios_sha1 = "C40146361EB8CF670B19FDC9759190257803CAB7";
       }
    }
@@ -183,12 +185,15 @@ static bool firmware_is_present(unsigned region)
    switch (region)
    {
    case REGION_JP:
+   //scph5500.bin
    bios_sha1 = "B05DEF971D8EC59F346F2D9AC21FB742E3EB6917";
    break;
    case REGION_NA:
+   //scph5501.bin
    bios_sha1 = "0555C6FAE8906F3F09BAF5988F00E55F88E9F30B";
    break;
    case REGION_EU:
+   //scph5502.bin
    bios_sha1 = "F6BC2D1F5EB6593DE7D089C425AC681D6FFFD3F0";
    break;
    default:


### PR DESCRIPTION
Pretty simple. Removes all the headache of finding files by filename, and instead leaves it to SHA1 instead. Also checks by filesize to remove speed probs.