### PR TITLE
Change Dualshock Analog Mode Toggle Default

### DIFF
--- a/mednafen/psx/input/dualshock.cpp
+++ b/mednafen/psx/input/dualshock.cpp
@@ -174,7 +174,7 @@ void InputDevice_DualShock::CheckManualAnaModeChange(void)
 
       if(amct_enabled)
       {
-         if(buttons[0] == 0x09 && buttons[1] == 0x0f)
+         if(buttons[0] == 0x00 && buttons[1] == 0x0c)
          {
             if(combo_anatoggle_counter == -1)
                combo_anatoggle_counter = 0;


### PR DESCRIPTION
Changes the default analog mode toggle combo buttons from `Start+Select+L1+L2+R1+R2` to `L1+R1`.

Prevents accidentally performing a soft reset in games that supported it.

Effectively fixes #738.