### PR TITLE
Add multiple combos for the analog toggle

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3139,6 +3139,8 @@ static bool shared_memorycards = false;
 static bool has_new_geometry = false;
 static bool has_new_timing = false;
 
+uint8_t analog_combo[2] = {0};
+
 extern void PSXDitherApply(bool);
 
 static void check_variables(bool startup)
@@ -3632,6 +3634,61 @@ static void check_variables(bool startup)
       {
          setting_psx_analog_toggle = 0;
          setting_apply_analog_toggle = true;
+      }
+   }
+
+   var.key = BEETLE_OPT(analog_toggle_combo);
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "l1+l2+r1+r2+start+select") == 0)
+      {
+         analog_combo[0] = 0x09;
+         analog_combo[1] = 0x0f;
+      }
+      else if (strcmp(var.value, "l1+r1+select") == 0)
+      {
+         analog_combo[0] = 0x01;
+         analog_combo[1] = 0x0c;
+      }
+      else if (strcmp(var.value, "l1+r1+start") == 0)
+      {
+         analog_combo[0] = 0x08;
+         analog_combo[1] = 0x0c;
+      }
+      else if (strcmp(var.value, "l1+r1+l3") == 0)
+      {
+         analog_combo[0] = 0x02;
+         analog_combo[1] = 0x0c;
+      }
+      else if (strcmp(var.value, "l1+r1+r3") == 0)
+      {
+         analog_combo[0] = 0x04;
+         analog_combo[1] = 0x0c;
+      }
+      else if (strcmp(var.value, "l2+r2+select") == 0)
+      {
+         analog_combo[0] = 0x01;
+         analog_combo[1] = 0x03;
+      }
+      else if (strcmp(var.value, "l2+r2+start") == 0)
+      {
+         analog_combo[0] = 0x08;
+         analog_combo[1] = 0x03;
+      }
+      else if (strcmp(var.value, "l2+r2+l3") == 0)
+      {
+         analog_combo[0] = 0x02;
+         analog_combo[1] = 0x03;
+      }
+      else if (strcmp(var.value, "l2+r2+r3") == 0)
+      {
+         analog_combo[0] = 0x04;
+         analog_combo[1] = 0x03;
+      }
+      else if (strcmp(var.value, "l3+r3") == 0)
+      {
+         analog_combo[0] = 0x06;
+         analog_combo[1] = 0x00;
       }
    }
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -386,7 +386,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       BEETLE_OPT(analog_toggle),
       "Enable DualShock Analog Mode Toggle",
       NULL,
-      "When the input device type is DualShock, this option allows the emulated DualShock to be toggled between DIGITAL and ANALOG mode like original hardware. When disabled, the DualShock is locked to ANALOG mode and when enabled, the DualShock can be toggled between DIGITAL and ANALOG mode by pressing and holding START+SELECT+L1+L2+R1+R2.",
+      "When the input device type is DualShock, this option allows the emulated DualShock to be toggled between DIGITAL and ANALOG mode like original hardware. When disabled, the DualShock is locked to ANALOG mode and when enabled, the DualShock can be toggled between DIGITAL and ANALOG mode by using the selected buttons combination.",
       NULL,
       "input",
       {
@@ -395,6 +395,28 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { NULL, NULL },
       },
       "disabled"
+   },
+   {
+      BEETLE_OPT(analog_toggle_combo),
+      "DualShock Analog Mode Combo",
+      NULL,
+      "Choose the buttons combination that will be used to toggle between DIGITAL and ANALOG mode for the emulated DualShock. Only works when 'Enable DualShock Analog Mode Toggle' is enabled.",
+      NULL,
+      "input",
+      {
+         { "l1+l2+r1+r2+start+select", "L1 + L2 + R1 + R2 + Start + Select" },
+         { "l1+r1+select",             "L1 + R1 + Select" },
+         { "l1+r1+start",              "L1 + R1 + Start" },
+         { "l1+r1+l3",                 "L1 + R1 + L3" },
+         { "l1+r1+r3",                 "L1 + R1 + R3" },
+         { "l2+r2+select",             "L2 + R2 + Select" },
+         { "l2+r2+start",              "L2 + R2 + Start" },
+         { "l2+r2+l3",                 "L2 + R2 + L3" },
+         { "l2+r2+r3",                 "L2 + R2 + R3" },
+         { "l3+r3",                    "L3 + R3" },
+         { NULL, NULL },
+      },
+      "l1+l2+r1+r2+start+select"
    },
    {
       BEETLE_OPT(enable_multitap_port1),

--- a/mednafen/psx/input/dualshock.cpp
+++ b/mednafen/psx/input/dualshock.cpp
@@ -174,7 +174,7 @@ void InputDevice_DualShock::CheckManualAnaModeChange(void)
 
       if(amct_enabled)
       {
-         if(buttons[0] == 0x09 && buttons[1] == 0x0f)
+         if(buttons[0] == analog_combo[0] && buttons[1] == analog_combo[1])
          {
             if(combo_anatoggle_counter == -1)
                combo_anatoggle_counter = 0;
@@ -201,7 +201,7 @@ void InputDevice_DualShock::CheckManualAnaModeChange(void)
          if(analog_mode_locked)
             MDFN_DispMessage(2, RETRO_LOG_INFO,
                   RETRO_MESSAGE_TARGET_OSD, RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
-                  "%s: 2 Analog toggle is DISABLED, sticks are %s",
+                  "%s: Analog toggle is DISABLED, sticks are %s",
                   gp_name.c_str(), analog_mode ? "ON" : "OFF");
          else
             analog_mode = !analog_mode;

--- a/mednafen/psx/psx.h
+++ b/mednafen/psx/psx.h
@@ -134,4 +134,6 @@ static INLINE void overclock_cpu_to_device(int32_t &clock) {
 
 extern unsigned psx_gpu_overclock_shift;
 
+extern uint8_t analog_combo[2];
+
 #endif


### PR DESCRIPTION
As an alternative to #858 I'm proposing a new core option that lets you chose a combo from a predefined list, instead of hardcoding a single one:

![image](https://user-images.githubusercontent.com/33353403/186207334-e8caa27a-8a71-4d1f-9b0e-3464f42087ea.png)

![image](https://user-images.githubusercontent.com/33353403/186207259-5b082f4b-29ba-42c2-9e7b-dea855cb54d5.png)

I say that in pretty much every PR I make but I'm not a dev and there is maybe a better way to handle that, so feel free to edit the PR or to tell me what to change ;) But from my tests and @Sanaki's, it works perfectly fine!

Closes #699