### PR TITLE
fix #507 again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ else ifneq (,$(findstring ios,$(platform)))
    ifeq ($(HAVE_OPENGL),1)
       GL_LIB := -framework OpenGLES
       GLES = 1
-      GLES3 = 0
+      GLES3 = 1
    endif
 
    CC = cc -arch $(iarch) -isysroot $(IOSSDK)
@@ -352,6 +352,7 @@ else ifeq ($(platform), rpi4_64)
    LDFLAGS += $(PTHREAD_FLAGS) -ldl -lrt
    HAVE_LIGHTREC = 1
    FLAGS += -DHAVE_SHM
+   GLES = 1
    GLES3 = 1
    GL_LIB := -lGLESv2
    HAVE_CDROM = 0

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -2,10 +2,6 @@ LOCAL_PATH := $(call my-dir)
 
 CORE_DIR := $(LOCAL_PATH)/..
 
-# set these
-HAVE_HW = 0
-HAVE_OPENGLES3 = 0
-
 DEBUG                    := 0
 FRONTEND_SUPPORTS_RGB565 := 1
 NEED_CD                  := 1
@@ -28,12 +24,10 @@ ifeq ($(TARGET_ARCH),x86)
 endif
 
 ifeq ($(HAVE_HW),1)
-  ifeq ($(HAVE_OPENGLES3),1)
-    HAVE_OPENGL := 1
-    GLES        := 1
-    GLES3       := 1
-    GL_LIB := -lGLESv3
-  endif
+  HAVE_OPENGL := 1
+  GLES        := 1
+  GLES3       := 1
+  GL_LIB      := -lGLESv3
 
   ifneq ($(TARGET_ARCH_ABI),armeabi)
     HAVE_VULKAN := 1
@@ -76,6 +70,6 @@ LOCAL_SRC_FILES    := $(SOURCES_CXX) $(SOURCES_C)
 LOCAL_CFLAGS       := $(COREFLAGS)
 LOCAL_CXXFLAGS     := $(COREFLAGS) -std=c++11
 LOCAL_LDFLAGS      := -Wl,-version-script=$(CORE_DIR)/link.T -ldl
-LOCAL_LDLIBS       := -llog -landroid
+LOCAL_LDLIBS       := -llog -landroid $(GL_LIB)
 LOCAL_CPP_FEATURES := exceptions rtti
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
fixed the regression in android builds caused by [`3f525d7`](https://github.com/libretro/beetle-psx-libretro/commit/3f525d7d67b7c8f83ca0c951c279abc04decb17f)