### PR TITLE
Core option category adjustments

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -4863,17 +4863,16 @@ void retro_set_environment(retro_environment_t cb)
    environ_cb = cb;
 
    libretro_supports_option_categories = false;
-   libretro_set_core_options(environ_cb,
-           &libretro_supports_option_categories);
+   libretro_set_core_options(environ_cb, &libretro_supports_option_categories);
 
    vfs_iface_info.required_interface_version = 1;
    vfs_iface_info.iface                      = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_iface_info))
-	   filestream_vfs_init(&vfs_iface_info);
+      filestream_vfs_init(&vfs_iface_info);
 
-  if(environ_cb(RETRO_ENVIRONMENT_GET_LED_INTERFACE, &led_interface))
-   if (led_interface.set_led_state && !led_state_cb)
-      led_state_cb = led_interface.set_led_state;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_LED_INTERFACE, &led_interface))
+      if (led_interface.set_led_state && !led_state_cb)
+         led_state_cb = led_interface.set_led_state;
 
    input_set_env(cb);
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -59,8 +59,8 @@ struct retro_core_option_v2_category option_cats_us[] = {
    },
    {
       "osd",
-      "Onscreen Notifications",
-      "Change the notifications being shown onscreen."
+      "On-Screen Display",
+      "Change notifications being shown on-screen."
    },
    {
       "input",
@@ -79,7 +79,7 @@ struct retro_core_option_v2_category option_cats_us[] = {
    },
    {
       "hacks",
-      "Emulation hacks",
+      "Emulation Hacks",
       "Change processor overclocking and emulation accuracy settings affecting low-level performance and compatibility."
    },
    { NULL, NULL, NULL },


### PR DESCRIPTION
In order to show correct category icons:
- Changed "hacks" to "Hacks" 
- Changed "Onscreen Notifications" to "On-Screen Display"

Also some cleanups to reduce compilation warnings.
