### PR TITLE
Adds configurable hold delay for analog toggle

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3140,6 +3140,7 @@ static bool has_new_geometry = false;
 static bool has_new_timing = false;
 
 uint8_t analog_combo[2] = {0};
+uint8_t HOLD = {0};
 
 extern void PSXDitherApply(bool);
 
@@ -3692,6 +3693,34 @@ static void check_variables(bool startup)
       }
    }
 
+   var.key = BEETLE_OPT(analog_toggle_hold);
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "0") == 0)
+      {
+         HOLD = 0;
+      }
+      else if (strcmp(var.value, "1") == 0)
+      {
+         HOLD = 1;
+      }
+      else if (strcmp(var.value, "2") == 0)
+      {
+         HOLD = 2;
+      }
+      else if (strcmp(var.value, "3") == 0)
+      {
+         HOLD = 3;
+      }
+      else if (strcmp(var.value, "4") == 0)
+      {
+         HOLD = 4;
+      }
+      else if (strcmp(var.value, "5") == 0)
+      {
+         HOLD = 5;
+      }
+   }
    var.key = BEETLE_OPT(crosshair_color_p1);
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -419,6 +419,24 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "l1+l2+r1+r2+start+select"
    },
    {
+      BEETLE_OPT(analog_toggle_hold),
+      "DualShock Analog Mode Combo Hold Delay",
+      NULL,
+      "Sets the hold time for the analog mode combo buttons. Only works when 'Enable DualShock Analog Mode Toggle' is enabled.",
+      NULL,
+      "input",
+      {
+         { "0", "0 Second Delay" },
+         { "1", "1 Second Delay" },
+         { "2", "2 Second Delay" },
+         { "3", "3 Second Delay" },
+         { "4", "4 Second Delay" },
+         { "5", "5 Second Delay" },
+         { NULL, NULL },
+      },
+      "1"
+   },
+   {
       BEETLE_OPT(enable_multitap_port1),
       "Port 1: Multitap Enable",
       NULL,

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -416,7 +416,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "l3+r3",                    "L3 + R3" },
          { NULL, NULL },
       },
-      "l1+l2+r1+r2+start+select"
+      "l1+r1+select"
    },
    {
       BEETLE_OPT(analog_toggle_hold),

--- a/mednafen/psx/input/dualshock.cpp
+++ b/mednafen/psx/input/dualshock.cpp
@@ -178,7 +178,7 @@ void InputDevice_DualShock::CheckManualAnaModeChange(void)
          {
             if(combo_anatoggle_counter == -1)
                combo_anatoggle_counter = 0;
-            else if(combo_anatoggle_counter >= (44100 * 768))
+            else if(combo_anatoggle_counter >= (44100 * (768 * HOLD)))
             {
                need_mode_toggle = true;
                combo_anatoggle_counter = -2;

--- a/mednafen/psx/psx.h
+++ b/mednafen/psx/psx.h
@@ -136,4 +136,6 @@ extern unsigned psx_gpu_overclock_shift;
 
 extern uint8_t analog_combo[2];
 
+extern uint8_t HOLD;
+
 #endif


### PR DESCRIPTION
Adds a user configurable hold delay for the analog mode combo toggle option.

Configurable from 0-5 seconds.

Also changes the default analog mode combo toggle to `L1 + R1 + Select` to prevent accidentally performing a soft-reset in supported games.