### PR TITLE
Fix Vulkan renderer on Metal.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -224,6 +224,11 @@ libretro-build-ios-arm64:
     - .libretro-ios-arm64-make-default
     - .core-defs
 
+libretro-build-ios-arm64-hw:
+  extends:
+    - .libretro-ios-arm64-make-default
+    - .core-defs-hw
+
 # iOS (armv7) [iOS 9 and up]
 libretro-build-ios9:
   extends:

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ else ifneq (,$(findstring ios,$(platform)))
    endif
    HAVE_LIGHTREC = 0
    LDFLAGS += $(IPHONEMINVER)
-   FLAGS   += $(IPHONEMINVER) -DHAVE_UNISTD_H
+   FLAGS   += $(IPHONEMINVER) -DHAVE_UNISTD_H -DIOS=1
    CC      += $(IPHONEMINVER)
    CXX     += $(IPHONEMINVER)
 

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ endif
 else ifeq ($(platform), osx)
    TARGET  := $(TARGET_NAME)_libretro.dylib
    fpic    := -fPIC
-   SHARED  := -dynamiclib
+   SHARED  := -dynamiclib -Wl,-exported_symbols_list,libretro.osx.def
    LDFLAGS += $(PTHREAD_FLAGS)
    FLAGS   += $(PTHREAD_FLAGS)
    ifeq ($(arch),ppc)

--- a/libretro.osx.def
+++ b/libretro.osx.def
@@ -1,0 +1,27 @@
+#LIBRARY "libretro"
+#EXPORTS
+_retro_set_environment
+_retro_set_video_refresh
+_retro_set_audio_sample
+_retro_set_audio_sample_batch
+_retro_set_input_poll
+_retro_set_input_state
+_retro_init
+_retro_deinit
+_retro_api_version
+_retro_get_system_info
+_retro_get_system_av_info
+_retro_set_controller_port_device
+_retro_reset
+_retro_run
+_retro_serialize_size
+_retro_serialize
+_retro_unserialize
+_retro_cheat_reset
+_retro_cheat_set
+_retro_load_game
+_retro_load_game_special
+_retro_unload_game
+_retro_get_region
+_retro_get_memory_data
+_retro_get_memory_size

--- a/parallel-psx/renderer/renderer.cpp
+++ b/parallel-psx/renderer/renderer.cpp
@@ -183,7 +183,7 @@ Renderer::Renderer(Device &device, unsigned scaling_, unsigned msaa_, const Save
 	ImageInitialData dither_initial = { dither_lut_data };
 	dither_lut = device.create_image(dither_info, &dither_initial);
 
-	static const int8_t quad_data[] = {
+	static const float quad_data[] = {
 		-128, -128, +127, -128, -128, +127, +127, +127,
 	};
 
@@ -642,7 +642,7 @@ void Renderer::mipmap_framebuffer()
 		cmd->set_texture(0, 0, *scaled_views[i - 1], StockSampler::LinearClamp);
 
 		cmd->set_quad_state();
-		cmd->set_vertex_binding(0, *quad, 0, 2);
+		cmd->set_vertex_binding(0, *quad, 0, 8);
 		struct Push
 		{
 			float offset[2];
@@ -659,7 +659,7 @@ void Renderer::mipmap_framebuffer()
 			{ (rect.x + rect.width - 0.5f) / FB_WIDTH, (rect.y + rect.height - 0.5f) / FB_HEIGHT },
 		};
 		cmd->push_constants(&push, 0, sizeof(push));
-		cmd->set_vertex_attrib(0, 0, VK_FORMAT_R8G8_SNORM, 0);
+		cmd->set_vertex_attrib(0, 0, VK_FORMAT_R32G32_SFLOAT, 0);
 		cmd->set_primitive_topology(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
 		counters.draw_calls++;
 		counters.vertices += 4;
@@ -941,7 +941,7 @@ ImageHandle Renderer::scanout_vram_to_texture(bool scaled)
 		cmd->set_texture(0, 0, framebuffer->get_view(), StockSampler::LinearClamp);
 	}
 
-	cmd->set_vertex_binding(0, *quad, 0, 2);
+	cmd->set_vertex_binding(0, *quad, 0, 8);
 	struct Push
 	{
 		float offset[2];
@@ -958,7 +958,7 @@ ImageHandle Renderer::scanout_vram_to_texture(bool scaled)
 		          float(scaled_views.size() - 1) };
 
 	cmd->push_constants(&push, 0, sizeof(push));
-	cmd->set_vertex_attrib(0, 0, VK_FORMAT_R8G8_SNORM, 0);
+	cmd->set_vertex_attrib(0, 0, VK_FORMAT_R32G32_SFLOAT, 0);
 	cmd->set_primitive_topology(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
 	counters.draw_calls++;
 	counters.vertices += 4;
@@ -1220,7 +1220,7 @@ ImageHandle Renderer::scanout_to_texture()
 		}
 	}
 
-	cmd->set_vertex_binding(0, *quad, 0, 2);
+	cmd->set_vertex_binding(0, *quad, 0, 8);
 	struct Push
 	{
 		float offset[2];
@@ -1236,7 +1236,7 @@ ImageHandle Renderer::scanout_to_texture()
 		          float(scaled_views.size() - 1) };
 
 	cmd->push_constants(&push, 0, sizeof(push));
-	cmd->set_vertex_attrib(0, 0, VK_FORMAT_R8G8_SNORM, 0);
+	cmd->set_vertex_attrib(0, 0, VK_FORMAT_R32G32_SFLOAT, 0);
 	cmd->set_primitive_topology(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
 	counters.draw_calls++;
 	counters.vertices += 4;
@@ -1264,7 +1264,7 @@ void Renderer::scanout()
 	cmd->set_program(*pipelines.scaled_quad_blitter);
 	cmd->set_texture(0, 0, image->get_view(), StockSampler::LinearClamp);
 
-	cmd->set_vertex_binding(0, *quad, 0, 2);
+	cmd->set_vertex_binding(0, *quad, 0, 8);
 	struct Push
 	{
 		float offset[2];
@@ -1273,7 +1273,7 @@ void Renderer::scanout()
 	const Push push = { { 0.0f, 0.0f }, { 1.0f, 1.0f } };
 
 	cmd->push_constants(&push, 0, sizeof(push));
-	cmd->set_vertex_attrib(0, 0, VK_FORMAT_R8G8_SNORM, 0);
+	cmd->set_vertex_attrib(0, 0, VK_FORMAT_R32G32_SFLOAT, 0);
 	cmd->set_primitive_topology(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
 	counters.draw_calls++;
 	counters.vertices += 4;

--- a/rsx/rsx_lib_gl.cpp
+++ b/rsx/rsx_lib_gl.cpp
@@ -398,12 +398,14 @@ static void get_error(const char *msg)
       case GL_OUT_OF_MEMORY:
          log_cb(RETRO_LOG_ERROR, "GL error flag: GL_OUT_OF_MEMORY [%s]\n", msg);
          break;
+#ifndef __APPLE__
       case GL_STACK_UNDERFLOW:
          log_cb(RETRO_LOG_ERROR, "GL error flag: GL_STACK_UNDERFLOW [%s]\n", msg);
          break;
       case GL_STACK_OVERFLOW:
          log_cb(RETRO_LOG_ERROR, "GL error flag: GL_STACK_OVERFLOW [%s]\n", msg);
          break;
+#endif
       case GL_INVALID_OPERATION:
          log_cb(RETRO_LOG_ERROR, "GL error flag: GL_INVALID_OPERATION [%s]\n", msg);
          break;


### PR DESCRIPTION
Vertex attribute binding strides must be aligned to 4 bytes, so says MoltenVK. So we'll create the quad as R32G32_SFLOAT instead of R8G8_SNORM.

Also when running a debug build of the core in a debug build of retroarch in the debugger, the dynamic linker gets very confused about which spirv-cross functions to call. The easiest way to give it a clue is to reduce the exported symbol list.

Also fix the debug build on Apple.