### PR TITLE
Change DualShock analog toggle combo behavior

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1988,7 +1988,7 @@ static void InitCommon(std::vector<CDIF *> *_CDInterfaces, const bool EmulateMem
       PSX_FIO->SetCrosshairsColor(i, MDFN_GetSettingUI(buf));
    }
 
-	input_set_fio( PSX_FIO );
+   input_set_fio(PSX_FIO);
 
    DMA_Init();
 
@@ -3690,6 +3690,11 @@ static void check_variables(bool startup)
       {
          analog_combo[0] = 0x06;
          analog_combo[1] = 0x00;
+      }
+      else
+      {
+         analog_combo[0] = 0xFF;
+         analog_combo[1] = 0xFF;
       }
    }
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -384,14 +384,14 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       BEETLE_OPT(analog_toggle),
-      "Enable DualShock Analog Mode Toggle",
+      "DualShock Analog Mode Toggle",
       NULL,
-      "When the input device type is DualShock, this option allows the emulated DualShock to be toggled between DIGITAL and ANALOG mode like original hardware. When disabled, the DualShock is locked to ANALOG mode and when enabled, the DualShock can be toggled between DIGITAL and ANALOG mode by using the selected buttons combination.",
+      "When the input device type is DualShock, this option allows the emulated DualShock to be toggled between DIGITAL and ANALOG mode like original hardware. Mode can also be toggled by using the selected button combination.",
       NULL,
       "input",
       {
-         { "disabled", NULL },
-         { "enabled",  NULL },
+         { "disabled", "Analog" },
+         { "enabled",  "Digital" },
          { NULL, NULL },
       },
       "disabled"
@@ -400,7 +400,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       BEETLE_OPT(analog_toggle_combo),
       "DualShock Analog Mode Combo",
       NULL,
-      "Choose the buttons combination that will be used to toggle between DIGITAL and ANALOG mode for the emulated DualShock. Only works when 'Enable DualShock Analog Mode Toggle' is enabled.",
+      "Choose the button combination that will be used to toggle between DIGITAL and ANALOG mode for the emulated DualShock.",
       NULL,
       "input",
       {
@@ -414,6 +414,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "l2+r2+l3",                 "L2 + R2 + L3" },
          { "l2+r2+r3",                 "L2 + R2 + R3" },
          { "l3+r3",                    "L3 + R3" },
+         { "none",                     "None" },
          { NULL, NULL },
       },
       "l1+r1+select"
@@ -422,7 +423,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       BEETLE_OPT(analog_toggle_hold),
       "DualShock Analog Mode Combo Hold Delay",
       NULL,
-      "Sets the hold time for the analog mode combo buttons. Only works when 'Enable DualShock Analog Mode Toggle' is enabled.",
+      "Set the hold time for the analog mode combo buttons.",
       NULL,
       "input",
       {

--- a/mednafen/psx/input/dualshock.cpp
+++ b/mednafen/psx/input/dualshock.cpp
@@ -172,7 +172,11 @@ void InputDevice_DualShock::CheckManualAnaModeChange(void)
    {
       bool need_mode_toggle = false;
 
+#ifdef __LIBRETRO__
+      if (1)
+#else
       if(amct_enabled)
+#endif
       {
          if(buttons[0] == analog_combo[0] && buttons[1] == analog_combo[1])
          {


### PR DESCRIPTION
Currently the analog toggle combo feature is rather unusable, since when enabled it disables analogs by default. Therefore having DualShock as the default controller is annoying, since analogs have to be enabled manually.

This changes the behavior as such:
- Toggle core option acts as the default state
- Combo works always unless "None" mode is selected

