### PR TITLE
Change DualShock analog toggle combo behavior

### DIFF
--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -384,14 +384,15 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       BEETLE_OPT(analog_toggle),
-      "Enable DualShock Analog Mode Toggle",
+      "DualShock Analog Mode Toggle",
       NULL,
-      "When the input device type is DualShock, this option allows the emulated DualShock to be toggled between DIGITAL and ANALOG mode like original hardware. When disabled, the DualShock is locked to ANALOG mode and when enabled, the DualShock can be toggled between DIGITAL and ANALOG mode by using the selected buttons combination.",
+      "When the input device type is DualShock, this option allows the emulated DualShock to be toggled between DIGITAL and ANALOG mode like original hardware. Mode can also be toggled by using the selected button combination.",
       NULL,
       "input",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
+         { "enabled-analog", "Default-Analog" },
          { NULL, NULL },
       },
       "disabled"
@@ -400,7 +401,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       BEETLE_OPT(analog_toggle_combo),
       "DualShock Analog Mode Combo",
       NULL,
-      "Choose the buttons combination that will be used to toggle between DIGITAL and ANALOG mode for the emulated DualShock. Only works when 'Enable DualShock Analog Mode Toggle' is enabled.",
+      "Choose the button combination that will be used to toggle between DIGITAL and ANALOG mode for the emulated DualShock.",
       NULL,
       "input",
       {
@@ -422,7 +423,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       BEETLE_OPT(analog_toggle_hold),
       "DualShock Analog Mode Combo Hold Delay",
       NULL,
-      "Sets the hold time for the analog mode combo buttons. Only works when 'Enable DualShock Analog Mode Toggle' is enabled.",
+      "Set the hold time for the analog mode combo buttons.",
       NULL,
       "input",
       {

--- a/mednafen/psx/input/dualshock.cpp
+++ b/mednafen/psx/input/dualshock.cpp
@@ -149,13 +149,23 @@ void InputDevice_DualShock::ResetTS(void)
    lastts = 0;
 }
 
+#ifdef __LIBRETRO__
+extern bool setting_apply_analog_default;
+#endif
+
 void InputDevice_DualShock::SetAMCT(bool enabled)
 {
+   bool amct_prev_info = amct_enabled;
    amct_enabled = enabled;
    if(amct_enabled)
-      analog_mode = false;
+      analog_mode = setting_apply_analog_default;
    else
       analog_mode = true;
+
+   if (amct_prev_info == analog_mode && amct_prev_info == amct_enabled)
+      return;
+
+   am_prev_info = analog_mode;
 
    MDFN_DispMessage(2, RETRO_LOG_INFO,
          RETRO_MESSAGE_TARGET_OSD, RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,


### PR DESCRIPTION
Since the previous attempt #893 was half-baked, this time current behavior is not touched. But instead:
- New toggle mode which sets the default state as analog instead of digital
- Cleaned up notifications to not spam duplicates
