### PR TITLE
Fix dynamic crop aspect ratio

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -99,6 +99,7 @@ int64 cd_slow_timeout = 8000; // microseconds
 
 // If true, PAL games will run at 60fps
 bool fast_pal = false;
+unsigned image_height = 0;
 
 #ifdef HAVE_LIGHTREC
 enum DYNAREC psx_dynarec;
@@ -4476,6 +4477,22 @@ void retro_unload_game(void)
 static uint64_t video_frames, audio_frames;
 #define SOUND_CHANNELS 2
 
+static bool retro_set_geometry(void)
+{
+   struct retro_system_av_info new_av_info;
+
+   retro_get_system_av_info(&new_av_info);
+   return environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &new_av_info);
+}
+
+static bool retro_set_system_av_info(void)
+{
+   struct retro_system_av_info new_av_info;
+
+   retro_get_system_av_info(&new_av_info);
+   return environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &new_av_info);
+}
+
 void retro_run(void)
 {
    bool updated = false;
@@ -4502,13 +4519,11 @@ void retro_run(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
    {
       check_variables(false);
-      struct retro_system_av_info new_av_info;
 
       /* Max width/height changed, need to call SET_SYSTEM_AV_INFO */
       if (GPU_get_upscale_shift() != psx_gpu_upscale_shift)
       {
-         retro_get_system_av_info(&new_av_info);
-         if (environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &new_av_info))
+         if (retro_set_system_av_info())
          {
             // We successfully changed the frontend's resolution, we can
             // apply the change immediately
@@ -4532,8 +4547,7 @@ void retro_run(void)
        */
       if (has_new_timing)
       {
-         retro_get_system_av_info(&new_av_info);
-         if (environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &new_av_info))
+         if (retro_set_system_av_info())
             has_new_timing = false;
       }
 
@@ -4541,11 +4555,8 @@ void retro_run(void)
          changed, need to call SET_GEOMETRY to change aspect ratio */
       if (has_new_geometry)
       {
-         retro_get_system_av_info(&new_av_info);
-         if (environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &new_av_info))
-         {
+         if (retro_set_geometry())
             has_new_geometry = false;
-         }
       }
 
       switch (psx_gpu_dither_mode)
@@ -4768,10 +4779,7 @@ void retro_run(void)
    // Check if aspect ratio needs to be changed due to display mode change on this frame
    if (MDFN_UNLIKELY((aspect_ratio_setting == 1) && aspect_ratio_dirty))
    {
-      struct retro_system_av_info new_av_info;
-      retro_get_system_av_info(&new_av_info);
-
-      if (environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &new_av_info.geometry))
+      if (retro_set_geometry())
          aspect_ratio_dirty = false;
 
       // If unable to change geometry here, defer to next frame and leave aspect_ratio_dirty flagged
@@ -4783,10 +4791,7 @@ void retro_run(void)
    {
       // This may cause video and audio reinit on the frontend, so it may be preferable to
       // set the core option to force progressive or interlaced timings
-      struct retro_system_av_info new_av_info;
-      retro_get_system_av_info(&new_av_info);
-
-      if (environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &new_av_info))
+      if (retro_set_system_av_info())
          interlace_setting_dirty = false;
 
       // If unable to change AV info here, defer to next frame and leave interlace_setting_dirty flagged
@@ -4816,10 +4821,8 @@ void retro_run(void)
          PrevInterlaced = false;
 #endif
       // PSX is rather special, and needs specific handling ...
-
       width = rects[0]; // spec.DisplayRect.w is 0. Only rects[0].w seems to return something sane.
       height = spec.DisplayRect.h;
-      //fprintf(stderr, "(%u x %u)\n", width, height);
 
       // PSX core inserts padding on left and right (overscan). Optionally crop this.
       const uint32_t *pix = surf->pixels;
@@ -4866,8 +4869,17 @@ void retro_run(void)
                // This shouldn't happen.
                break;
          }
-      }
 
+         /* Smart/dynamic height geometry trigger */
+         if (crop_overscan == 2)
+         {
+            if (image_height != height)
+            {
+               image_height = height;
+               retro_set_geometry();
+            }
+         }
+      }
 
       width  <<= upscale_shift;
       height <<= upscale_shift;

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -1032,6 +1032,24 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "100%(native)"
    },
    {
+      BEETLE_OPT(gpu_overclock),
+      "GPU Rasterizer Overclock",
+      NULL,
+      "Enable overclocking of the 2D rasterizer contained within the emulated PSX's GPU. Does not improve 3D rendering, and in general has little effect.",
+      NULL,
+      "hacks",
+      {
+         { "1x(native)", "1x (Native)" },
+         { "2x",         NULL },
+         { "4x",         NULL },
+         { "8x",         NULL },
+         { "16x",        NULL },
+         { "32x",        NULL },
+         { NULL, NULL },
+      },
+      "1x(native)"
+   },
+   {
       BEETLE_OPT(gte_overclock),
       "GTE Overclock",
       NULL,
@@ -1213,6 +1231,21 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
+      BEETLE_OPT(aspect_ratio),
+      "Core Aspect Ratio",
+      NULL,
+      "Choose core provided aspect ratio. This setting is ignored when the Widescreen Mode Hack or Display Full VRAM options are enabled.",
+      NULL,
+      "video",
+      {
+         { "corrected", "Corrected" },
+         { "uncorrected", "Uncorrected" },
+         { "4:3",  "Force 4:3" },
+         { "ntsc", "Force NTSC" },
+      },
+      "corrected"
+   },
+   {
       BEETLE_OPT(crop_overscan),
       "Crop Overscan",
       NULL,
@@ -1280,7 +1313,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "-3px",     NULL },
          { "-2px",     NULL },
          { "-1px",     NULL },
-         { "disabled", "0 (Default)" },
+         { "disabled", "0" },
          { "+1px",     NULL },
          { "+2px",     NULL },
          { "+3px",     NULL },
@@ -1346,7 +1379,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "-3",       NULL },
          { "-2",       NULL },
          { "-1",       NULL },
-         { "0",        "0 (Default)" },
+         { "0",        "0" },
          { "+1",       NULL },
          { "+2",       NULL },
          { "+3",       NULL },
@@ -1393,39 +1426,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
 #endif
    {
-      BEETLE_OPT(gpu_overclock),
-      "GPU Rasterizer Overclock",
-      NULL,
-      "Enable overclocking of the 2D rasterizer contained within the emulated PSX's GPU. Does not improve 3D rendering, and in general has little effect.",
-      NULL,
-      "video",
-      {
-         { "1x(native)", "1x (Native)" },
-         { "2x",         NULL },
-         { "4x",         NULL },
-         { "8x",         NULL },
-         { "16x",        NULL },
-         { "32x",        NULL },
-         { NULL, NULL },
-      },
-      "1x(native)"
-   },
-   {
-      BEETLE_OPT(aspect_ratio),
-      "Core Aspect Ratio",
-      NULL,
-      "Choose core provided aspect ratio. This setting is ignored when the Widescreen Mode Hack or Display Full VRAM options are enabled.",
-      NULL,
-      "video",
-      {
-         { "corrected", "Corrected" },
-         { "uncorrected", "Uncorrected" },
-         { "4:3",  "Force 4:3" },
-         { "ntsc", "Force NTSC" },
-      },
-      "corrected"
-   },
-   {
       BEETLE_OPT(initial_scanline),
       "Initial Scan Line - NTSC",
       NULL,
@@ -1433,7 +1433,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       NULL,
       "video",
       {
-         { "0",  NULL },
+         { "0",  "0 (Default)" },
          { "1",  NULL },
          { "2",  NULL },
          { "3",  NULL },
@@ -1528,7 +1528,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       NULL,
       "video",
       {
-         { "0",  NULL },
+         { "0",  "0 (Default)" },
          { "1",  NULL },
          { "2",  NULL },
          { "3",  NULL },


### PR DESCRIPTION
Currently if the default dynamic cropping option decides to crop top and bottom, like for example in Crash Team Racing, it is not taken into account when calculating aspect ratio. It only uses the manual scanline positions, which also for reasons unknown will crop the already cropped image even more starting from the cropped state, but I couldn't figure out how to ignore the values up to the point of current dynamic cropping.

Also reordered some core options a bit and moved "GPU Rasterizer Overclock" away from between video crop settings to hacks submenu.
