### PR TITLE
osx-arm64: disable lightrec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,10 +143,6 @@ else ifeq ($(platform), osx)
    ifeq ($(OSX_LT_MAVERICKS),"YES")
       fpic += -mmacosx-version-min=10.5
    endif
-   ifeq ($(HAVE_LIGHTREC), 1)
-      LDFLAGS += -lSystem
-      FLAGS += -DHAVE_SHM -DUSE_FIXED
-   endif
    ifeq ($(HAVE_OPENGL),1)
       GL_LIB := -framework OpenGL
    endif
@@ -156,6 +152,11 @@ else ifeq ($(platform), osx)
 	CPPFLAGS += $(TARGET_RULE)
 	CXXFLAGS += $(TARGET_RULE)
 	LDFLAGS  += $(TARGET_RULE)
+	HAVE_LIGHTREC = 0
+   endif
+   ifeq ($(HAVE_LIGHTREC), 1)
+      LDFLAGS += -lSystem
+      FLAGS += -DHAVE_SHM -DUSE_FIXED
    endif
 
 # iOS


### PR DESCRIPTION
On osx arm64 the lightrec seems to be causing several memory corruption issues. Disabling the lightrec makes them all go away. Also the Mac seems to be performant enough not to strictly need it. I'm going to work on fixing and re-enabling the lightrec but until then this is a reasonable workaround.