### PR TITLE
Update dualshock.cpp

### DIFF
--- a/mednafen/psx/input/dualshock.cpp
+++ b/mednafen/psx/input/dualshock.cpp
@@ -162,15 +162,7 @@ void InputDevice_DualShock::SetAMCT(bool enabled)
    else
       analog_mode = true;
 
-   if (amct_prev_info == analog_mode && amct_prev_info == amct_enabled)
-      return;
-
    am_prev_info = analog_mode;
-
-   MDFN_DispMessage(2, RETRO_LOG_INFO,
-         RETRO_MESSAGE_TARGET_OSD, RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
-         "%s: Analog toggle is %s, sticks are %s",
-         gp_name.c_str(), amct_enabled ? "ENABLED" : "DISABLED", analog_mode ? "ON" : "OFF");
 }
 
 //
@@ -209,10 +201,9 @@ void InputDevice_DualShock::CheckManualAnaModeChange(void)
       if(need_mode_toggle)
       {
          if(analog_mode_locked)
-            MDFN_DispMessage(2, RETRO_LOG_INFO,
-                  RETRO_MESSAGE_TARGET_OSD, RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
-                  "%s: Analog toggle is DISABLED, sticks are %s",
-                  gp_name.c_str(), analog_mode ? "ON" : "OFF");
+            {
+				
+			}
          else
             analog_mode = !analog_mode;
       }
@@ -245,7 +236,6 @@ void InputDevice_DualShock::Power(void)
    transmit_pos = 0;
    transmit_count = 0;
 
-   analog_mode = true;
    analog_mode_locked = false;
 
    mad_munchkins = false;
@@ -367,11 +357,11 @@ void InputDevice_DualShock::UpdateInput(const void *data)
    //
    CheckManualAnaModeChange();
 
-   if(am_prev_info != analog_mode || aml_prev_info != analog_mode_locked)
+   if(am_prev_info != analog_mode)
       MDFN_DispMessage(2, RETRO_LOG_INFO,
             RETRO_MESSAGE_TARGET_OSD, RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
-            "%s: Analog toggle is %s, sticks are %s",
-            gp_name.c_str(), amct_enabled ? "ENABLED" : "DISABLED", analog_mode ? "ON" : "OFF");
+            "%s: %s Mode",
+            gp_name.c_str(), analog_mode ? "Analog" : "Digital");
 
    aml_prev_info = analog_mode_locked;
    am_prev_info = analog_mode;


### PR DESCRIPTION
Fix dualshock behavior :

Don't spam notification on startup ;
Don't auto switch to analog mode after soft reset if digital mode ; 
Don't keep locked mode after soft reset if core run game compatible with analog locked mode and core option is digital mode or analog mode ; 
Don't start toggle mode if combo toggle mode when core run games compatibles with analog locked mode ; 
Change notification message for toggle/switch mode like Beetle Saturn.

Notification will appear only if :
Manual combo toggle when core option are analog mode or digital mode (like before) ; 
Auto switch mode by game on startup when core option is digital mode (Final Fantasy IX "analog mode", Ape Escape "analog locked mode") ; 
Change from core option analog mode or analog locked mode to digital mode when core run games compatibles with analog locked mode (auto switch).

Issue not resolve (same behavior than before) :
When core run games compatibles with analog locked mode and core option is analog mode, if we change PlayStation controller or Analog controller to Dualshock controller we need one manual combo toggle to get analog locked mode ; 
When core run games compatibles with analog locked mode and core option is digital mode, if we change PlayStation controller to Dualshock controller we need twice manual combo toggle to get analog locked mode (digital mode to analog mode + analog mode to analog locked mode) ;
When core run games compatibles with analog locked mode and core option is digital mode, if we change Analog controller to Dualshock controller core display one notification for auto switch analog mode to analog locked mode.