### PR TITLE
Update rsx_intf.cpp

### DIFF
--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -950,9 +950,11 @@ float rsx_common_get_aspect_ratio(bool pal_content, int crop_overscan,
             break;
          case WIDTH_MODE_512:
             width_base = crop_overscan ? 512 : 560;
+            return ar;
             break;
          case WIDTH_MODE_640:
             width_base = crop_overscan ? 640 : 700;
+            return ar;
             break;
          case WIDTH_MODE_368:
             // Probably slightly off because of rounding, see libretro.cpp comments
@@ -961,7 +963,7 @@ float rsx_common_get_aspect_ratio(bool pal_content, int crop_overscan,
       }
 
       double height_base = (last_visible_scanline - first_visible_scanline + 1) *
-                           (rsx_height_mode == HEIGHT_MODE_480 ? 2.0 : 1.0);
+                           (rsx_height_mode == HEIGHT_MODE_480 ? 1.0 : 1.0);
 
       // Calculate aspect ratio as quotient of raw native framebuffer width and height
       return width_base / height_base;


### PR DESCRIPTION
Fix Aspect Ratio like provided by mednafen standalone when psx.correct_aspect=0.

Currently, there is not possible to get PAR without shader. But RetroArch introduce option than provide a good solution for some cores like Beetle Saturn to get PAR "Interger Scale Axis = Y + X".

Unfortunatelly, for Beetle PSX core we need more modifications to get same work.

Setup from core option :
- Core Aspect Ratio = Uncorrected ;
- Crop Overscan = None.

Setup from RA option :
- Interger Scale Axis = Y + X ;
- Aspect Ratio = Core provided.

Issues than are fixed.
- When core provide screen with 560 / 240 pixels (Title screen : Castlevania - Symphony of the Night, Sony Computer screen : Gunners Heaven, Main game : Rival School) core will display 280 / 240 pixels ;
- When core provide screen with 700 / 240 pixels (Natsume screen : Gunners Heaven) core will display 350 / 240 pixels ;
- When core provide screen with 400 / 480 pixels (Title screen and Main game : Tekken 3) core will display 800 / 480 pixels.

Another change than maybe not good for everyone.
With Aspect Ratio = 1:1 PAR (4:3 DAR) there are a lot of schemes to force 4:3 every time. After modification, core provide 16:15 when screen is 560 width pixels (512 pixels without Overscan) .
