### PR TITLE
fix build on GNU/Hurd

### DIFF
--- a/libretro-common/compat/compat_strl.c
+++ b/libretro-common/compat/compat_strl.c
@@ -27,7 +27,7 @@
 
 /* Implementation of strlcpy()/strlcat() based on OpenBSD. */
 
-#ifndef __MACH__
+#if !(defined(__MACH__) && defined(__APPLE__))
 
 size_t strlcpy(char *dest, const char *source, size_t size)
 {

--- a/libretro-common/include/compat/strl.h
+++ b/libretro-common/include/compat/strl.h
@@ -34,7 +34,7 @@
 
 RETRO_BEGIN_DECLS
 
-#ifdef __MACH__
+#if defined(__MACH__) && defined(__APPLE__)
 #ifndef HAVE_STRL
 #define HAVE_STRL
 #endif

--- a/libretro-common/include/glsm/glsm.h
+++ b/libretro-common/include/glsm/glsm.h
@@ -41,7 +41,7 @@ typedef double GLclampd;
 #define RARCH_GL_DEPTH24_STENCIL8 GL_DEPTH24_STENCIL8_OES
 #define RARCH_GL_DEPTH_ATTACHMENT GL_DEPTH_ATTACHMENT
 #define RARCH_GL_STENCIL_ATTACHMENT GL_STENCIL_ATTACHMENT
-#elif (defined(__MACH__) && (defined(__ppc__) || defined(__ppc64__)))
+#elif (defined(__MACH__) && defined(__APPLE__) && (defined(__ppc__) || defined(__ppc64__)))
 #define RARCH_GL_RENDERBUFFER GL_RENDERBUFFER_EXT
 #define RARCH_GL_DEPTH24_STENCIL8 GL_DEPTH24_STENCIL8_EXT
 #define RARCH_GL_DEPTH_ATTACHMENT GL_DEPTH_ATTACHMENT_EXT
@@ -62,7 +62,7 @@ typedef double GLclampd;
 #define RARCH_GL_FRAMEBUFFER GL_FRAMEBUFFER_OES
 #define RARCH_GL_FRAMEBUFFER_COMPLETE GL_FRAMEBUFFER_COMPLETE_OES
 #define RARCH_GL_COLOR_ATTACHMENT0 GL_COLOR_ATTACHMENT0_EXT
-#elif (defined(__MACH__) && (defined(__ppc__) || defined(__ppc64__)))
+#elif (defined(__MACH__) && defined(__APPLE__) && (defined(__ppc__) || defined(__ppc64__)))
 #define RARCH_GL_FRAMEBUFFER GL_FRAMEBUFFER_EXT
 #define RARCH_GL_FRAMEBUFFER_COMPLETE GL_FRAMEBUFFER_COMPLETE_EXT
 #define RARCH_GL_COLOR_ATTACHMENT0 GL_COLOR_ATTACHMENT0_EXT

--- a/libretro-common/include/glsym/glsym_gl.h
+++ b/libretro-common/include/glsym/glsym_gl.h
@@ -44,7 +44,7 @@ typedef void *GLeglImageOES;
 #if !defined(GL_OES_fixed_point) && !defined(HAVE_OPENGLES2)
 typedef GLint GLfixed;
 #endif
-#if defined(__MACH__) && !defined(OS_TARGET_IPHONE) && !defined(MAC_OS_X_VERSION_10_7)
+#if defined(__MACH__) && defined(__APPLE__) && !defined(OS_TARGET_IPHONE) && !defined(MAC_OS_X_VERSION_10_7)
 typedef long long int GLint64;
 typedef unsigned long long int GLuint64;
 typedef unsigned long long int GLuint64EXT;

--- a/libretro-common/include/retro_common_api.h
+++ b/libretro-common/include/retro_common_api.h
@@ -71,7 +71,7 @@ typedef __int64 ssize_t;
 typedef int ssize_t;
 #endif
 #endif
-#elif defined(__MACH__)
+#elif defined(__MACH__) && defined(__APPLE__)
 #include <sys/types.h>
 #endif
 

--- a/libretro-common/rthreads/rthreads.c
+++ b/libretro-common/rthreads/rthreads.c
@@ -60,7 +60,7 @@
 #include <sys/time.h>
 #endif
 
-#ifdef __MACH__
+#if defined(__MACH__) && defined(__APPLE__)
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif
@@ -827,7 +827,7 @@ bool scond_wait_timeout(scond_t *cond, slock_t *lock, int64_t timeout_us)
 #else
    int64_t seconds, remainder;
    struct timespec now;
-#ifdef __MACH__
+#if defined(__MACH__) && defined(__APPLE__)
    /* OSX doesn't have clock_gettime. */
    clock_serv_t cclock;
    mach_timespec_t mts;


### PR DESCRIPTION
Guarding Darwin-specific code with `#ifdef __MACH__` is not enough, as Hurd also use Mach.