### PR TITLE
Fix HW second instance runahead crashing and not rendering

### DIFF
--- a/rsx/rsx_intf.cpp
+++ b/rsx/rsx_intf.cpp
@@ -30,7 +30,7 @@
 extern bool fast_pal;
 extern unsigned int image_height;
 
-static enum rsx_renderer_type rsx_type          = RSX_SOFTWARE;
+enum rsx_renderer_type rsx_type          = RSX_SOFTWARE;
 
 static bool gl_initialized                      = false;
 static bool vk_initialized                      = false;

--- a/rsx/rsx_lib_gl.cpp
+++ b/rsx/rsx_lib_gl.cpp
@@ -72,6 +72,7 @@ static const GLushort indices[6] = {0, 1, 2, 1, 2, 3};
 #define VRAM_HEIGHT 512
 #define VRAM_PIXELS (VRAM_WIDTH_PIXELS * VRAM_HEIGHT)
 
+extern enum rsx_renderer_type rsx_type;
 extern retro_log_printf_t log_cb;
 
 /* How many vertices we buffer before forcing a draw. Since the
@@ -1130,7 +1131,7 @@ static void GlRenderer_upload_textures(
       uint16_t dimensions[2],
       uint16_t pixel_buffer[VRAM_PIXELS])
 {
-   if (!renderer)
+   if (!renderer || static_renderer.state == GlState_Invalid)
       return;
 
    if (!DRAWBUFFER_IS_EMPTY(renderer->command_buffer))
@@ -2522,6 +2523,7 @@ void rsx_gl_prepare_frame(void)
    GlRenderer *renderer = static_renderer.state_data;
    if (!renderer)
    {
+      rsx_type = RSX_SOFTWARE;
       log_cb(RETRO_LOG_ERROR, "[rsx_gl_prepare_frame] Renderer state marked as valid but state data is null.\n");
       return;
    }

--- a/rsx/rsx_lib_vulkan.cpp
+++ b/rsx/rsx_lib_vulkan.cpp
@@ -21,9 +21,9 @@ using namespace Vulkan;
 using namespace PSX;
 using namespace std;
 
-static Context *context;
-static Device *device;
-static Renderer *renderer;
+static Context *context = nullptr;
+static Device *device = nullptr;
+static Renderer *renderer = nullptr;
 static unsigned scaling = 4;
 
 // Declare extern as workaround for now to avoid variable
@@ -34,6 +34,8 @@ extern "C" bool content_is_pal;
 extern "C" int filter_mode;
 extern "C" bool currently_interlaced;
 extern "C" int aspect_ratio_setting;
+
+extern enum rsx_renderer_type rsx_type;
 
 extern retro_log_printf_t log_cb;
 namespace Granite
@@ -113,6 +115,11 @@ static void vk_context_reset(void)
 
 static void vk_context_destroy(void)
 {
+   if(device == nullptr)
+   {
+      return;
+   }
+
    save_state = renderer->save_vram_state();
    vulkan     = nullptr;
 
@@ -527,6 +534,12 @@ void rsx_vulkan_refresh_variables(void)
 
 void rsx_vulkan_prepare_frame(void)
 {
+   if(device == nullptr)
+   {
+      rsx_type = RSX_SOFTWARE;
+      return;
+   }
+
    inside_frame = true;
    device->flush_frame();
    vulkan->wait_sync_index(vulkan->handle);
@@ -553,6 +566,9 @@ static Renderer::ScanoutMode get_scanout_mode(bool bpp24)
 void rsx_vulkan_finalize_frame(const void *fb, unsigned width,
                                unsigned height, unsigned pitch)
 {
+   if(device == nullptr)
+      return;
+
    if (frame_duping_enabled && !GPU_get_display_change_count())
    {
       /* Any visual core option changes will be deferred to next non-duped frame */


### PR DESCRIPTION
Stop vulkan renderer crashing with second instance runahead

If the context isn't initialized fall back to software, which also
fixes the second instance in runahead that never gets initialized

Fixes #701