### PR TITLE
Vulkan: HD texture replacement overhaul — dump modes, cross-mode fallback, palette-range hashing, threaded dump decode, lazy-sync, folder relocation, hotkeys

### DIFF
--- a/HD_TEXTURE_CACHE.md
+++ b/HD_TEXTURE_CACHE.md
@@ -45,20 +45,23 @@ Packs are authored exactly as before: textures live in
 
 ## Technical detail
 
-All changes are in `rhi/rhi_lib_vulkan.cpp` (the texture system is compiled only
-with `HAVE_VULKAN` / `TEXTURE_DUMPING_ENABLED`).
+All changes are in `rhi/rhi_lib_vulkan.c` (the texture system is compiled only
+with `HAVE_VULKAN` / `TEXTURE_DUMPING_ENABLED`). The renderer — and this caching
+system with it — has been ported to C (C89) alongside upstream's Vulkan backend,
+so the type names below are now C `struct`s with hand-rolled equivalents of the
+original C++ containers: an intrusive LRU list indexed through `HdKeySet`, and a
+manual-refcount `ImageHandle` in place of the STL/`shared_ptr` types.
 
 ### New types
 
-- **`CachedHdImage` / `HdImageCache`** — a byte-budgeted LRU cache (`std::list` +
-  `std::map`, keyed by `HdTextureId = {texture hash, palette hash}`) holding
-  **decoded CPU pixel levels** (RGBA + mips) and alpha flags. Default budget
-  `HD_CACHE_RAM_BUDGET = 2 GB`.
+- **`CachedHdImage` / `HdImageCache`** — a byte-budgeted LRU cache (an intrusive
+  linked list with an `HdKeySet` index, keyed by `HdTextureId = {texture hash,
+  palette hash}`) holding **decoded CPU pixel levels** (RGBA + mips) and alpha
+  flags. Default budget `HD_CACHE_RAM_BUDGET = 2 GB`.
 - **`CachedGpuImage` / `HdGpuCache`** — an analogous LRU cache holding
-  **uploaded `Vulkan::ImageHandle`s** (ready to bind, in VRAM). Default budget
+  **uploaded `ImageHandle`s** (ready to bind, in VRAM). Default budget
   `HD_CACHE_VRAM_BUDGET = 3 GB`. Eviction releases the handle, freeing VRAM once
   no live draw references it.
-- Added `#include <list>`.
 
 ### `TextureTracker` changes
 
@@ -110,9 +113,9 @@ the next safe point), and `dbg_*` diagnostic counters.
   into a **pool worker**: it takes one request at a time, runs PNG decode +
   mipmap generation **outside** the channel lock (workers run in parallel),
   pushes the response under the lock, and cascade-signals the next worker.
-- **`IOThread`** — the constructor spawns `NUM_IO_THREADS` (4) detached workers,
-  each given its own heap-allocated `shared_ptr` to the channel; the destructor
-  uses `scond_broadcast` to wake all workers for shutdown.
+- **`IOThread`** — spins up `NUM_IO_THREADS` (4) detached workers, each given its
+  own heap-allocated pointer to the shared channel; shutdown uses
+  `scond_broadcast` to wake all workers.
 
 ### Core options
 
@@ -123,10 +126,23 @@ the next safe point), and `dbg_*` diagnostic counters.
 Budgets are runtime-adjustable (lowering one evicts immediately). The `[hdcache]`
 INFO log line shows the active mode and `used/budget` for each tier.
 
+### Palette-range hashing (opt-in)
+
+- **HD Reduce Palette Range** — when enabled, a texture's palette hash covers only
+  the CLUT entries the texture actually indexes (`reduce_palette_bounds()` finds
+  the used `lo..hi` range) instead of the whole CLUT. Games frequently leave unused
+  CLUT entries as garbage or rewrite them over time; ignoring them lets a single
+  replacement keep matching across those variations — fewer dumps and much better
+  match coverage, most noticeably for 8bpp textures. It applies to **both** the
+  upload-rect and page-aligned paths. Dump **filenames are unchanged** and remain
+  loadable; when no reduced-range file is present the matcher falls back to the
+  full-palette hash, so existing full-palette packs still match with it enabled.
+  Off by default — re-dump a game to benefit.
+
 ### Build
 
 Build the HW core as usual — `make HAVE_HW=1` — then optionally `strip` the
-result. No new dependencies; the caches use only the C++ standard library plus
+result. No new dependencies; the caches use only the C standard library plus
 the `stb_image` and libretro threading already vendored in the tree.
 
 Built and tested on **Windows** (`mednafen_psx_hw_libretro.dll`, MSYS2/MinGW-w64)

--- a/PAGE_ALIGN.md
+++ b/PAGE_ALIGN.md
@@ -1,0 +1,162 @@
+# Page-Aligned Texture Dump + Replacement (experimental)
+
+An **opt-in** alternative dumping/replacement mode for the Vulkan ("Beetle PSX HW")
+renderer that works at **whole VRAM texture-page** granularity instead of per-upload
+rectangles. It targets the fragmented-"sections" problem with the existing dumper
+(libretro/beetle-psx #918): the upload-rect dumper emits many small, oddly-cropped
+fragments of a page, whereas page-aligned mode emits one clean 256×256 tile per page
+— much friendlier for an artist to replace.
+
+It is layered on top of the existing HD texture-replacement system (see
+`HD_TEXTURE_CACHE.md`) and reuses its three-tier cache, IO worker pool, priority
+queue, caching-method option, and budgets unchanged. Default behaviour is the
+classic upload-rect mode, so existing packs are completely unaffected.
+
+All code is in `rhi/rhi_lib_vulkan.c` + `libretro_core_options.h` (Vulkan-only,
+built under `TEXTURE_DUMPING_ENABLED`). It is implemented in C on top of upstream's
+C/C89 `rhi_lib_vulkan.c` (the renderer's MSVC-C89 target: declarations at block top,
+`-Werror=declaration-after-statement`), reusing the C `HdImageCache`/`HdGpuCache` LRU
+caches, `HdKeySet`, the `IOThread` worker pool and the manual-refcount `ImageHandle`.
+The page vs upload-rect cache entries are namespaced by a `pages` flag folded into the
+packed cache key, so both pack types share one cache + budget without aliasing.
+
+## Compatibility model
+
+Two independent core options:
+
+- `beetle_psx_hw_hd_dump_mode`        — how textures are **dumped**: `{upload_rect (default), page_aligned, both}`.
+- `beetle_psx_hw_hd_replacement_mode` — how replacements are **looked up**: `{upload_rect (default), page_aligned}`.
+
+`hd_dump_mode = both` writes **both** pack types in a single playthrough (to their two
+separate folders below), so you don't have to replay the game once per mode. The two
+dumps are independent and deduplicated; the decode/encode runs on the IO worker pool,
+so dumping both at once doesn't stall the render thread.
+
+Each mode uses its own folders so the two pack types never collide (the same
+filename does **not** mean the same texture between them):
+
+| | dump | replacements |
+|---|---|---|
+| upload-rect (default) | `<cd>-texture-dump/` | `<cd>-texture-replacements/` |
+| page-aligned | `<cd>-texture-dump-pages/` | `<cd>-texture-replacements-pages/` |
+
+The two sides are independent — you can dump page-aligned while still replacing from
+an existing upload-rect pack, or vice versa. **Page packs and upload-rect packs are
+NOT interchangeable and cannot be converted offline** (a re-dump is required): the
+hash is computed over a different region of VRAM.
+
+The folder *location* honours the **HD Texture Folder** core option
+(`beetle_psx_hw_texture_directory`: content / system / save directory), and the
+folders are created automatically when dumping/replacement is enabled.
+
+## Cross-mode replacement fallback
+
+`beetle_psx_hw_hd_replacement_fallback` (`{disabled (default), enabled}`) lets the two
+replacement modes back each other up rather than being strictly one-or-the-other. When
+the **active** `hd_replacement_mode` finds no match for a draw, the renderer checks the
+**other** mode's pack before falling back to native:
+
+- in **upload-rect** mode, a miss is retried against the page-aligned (`-pages`) pack;
+- in **page-aligned** mode, a miss is retried against the upload-rect pack.
+
+So you can pick whichever mode fits the bulk of a game and let the other cover the
+exceptions — e.g. a mostly page-aligned pack for the static art, with a handful of
+upload-rect textures filling in animated sprites — without converting anything. It is
+**off by default**, costs nothing on a hit, and only does the extra lookup on a genuine
+miss (best paired with **Lazy** caching, so the fallback's loads stay on demand).
+
+Internally both packs share the one three-tier cache; a 1-bit discriminator on the
+cache key namespaces page vs upload-rect entries so they can never alias, even on a
+32-bit hash collision.
+
+## How it works
+
+### Page geometry
+
+A PS1 texture page, in VRAM 16-bit coordinates, is `{page_x, page_y, page_w, 256}`
+where `page_w = 64 (4bpp) / 128 (8bpp) / 256 (16bpp)`. The draw path already knows
+`page_x, page_y` (from `render_state.texture_offset_x/y`). Every page decodes to a
+256×256-texel image regardless of bit depth.
+
+### CPU VRAM mirror
+
+Page hashing/dumping needs the live page bytes, but the draw path carries no CPU
+VRAM pointer. The tracker therefore keeps a `vram_mirror` (1024×512 ×16-bit = 1 MB)
+updated in every VRAM mutation hook (`upload`, `blit`, `clearRegion`/fill,
+`notifyReadback`). All page reads come from this mirror. *(Correctness depends on
+every VRAM write going through one of those hooks.)*
+
+### Page hash
+
+`hash_page()` is a CRC32 over the page rect read from `vram_mirror`. The palette hash
+is unchanged from upload-rect mode. A page hash is just a `uint32_t`, so a page slots
+into the existing `HdTextureId{hash, palette}` keyspace and reuses all of the cache
+machinery as-is.
+
+### Dump
+
+When `hd_dump_mode = page_aligned` (or `both`), a textured draw snapshots the **full**
+page's raw VRAM words + palette and queues a low-priority dump request for
+`<cd>-texture-dump-pages/<pagehash>-<palettehash>.png`, deduplicated per
+`(page_hash, palette_hash)`. The palette→RGBA decode (same conversion as the
+upload-rect dumper) and the PNG encode then run on the **IO worker pool**, not the
+render thread, so a burst of first-seen pages — or dumping both pack types at once
+under `both` — doesn't stall input. Files named `…-missing.png` mean the palette
+wasn't resident when the page was captured (grayscale index data, not a usable
+replacement); `…-0.png` is a genuine palette-less (ABGR1555) texture.
+
+### Match + binding
+
+When `hd_replacement_mode = page_aligned`, the draw path computes the page hash,
+looks it up through the **same** three-tier cache / loader / IO pool (sourced from
+the `-pages` folder and a separate `known_files_pages` listing), and binds the
+resulting page image. No shader changes are needed: binding returns an `HdTexture`
+with `vram_rect = page_rect` and `texel_rect = {0, 0, img_w, img_h}`, which the
+existing sampling push-constants map correctly for any sub-rect draw — the same shape
+the renderer's fused-page path already produces. Eager / Lazy / Lazy-synchronous
+caching methods and the VRAM/RAM budgets all apply unchanged.
+
+### Performance note
+
+Page match has no per-draw "same as last time" short-circuit, so it would otherwise
+hash a 32–128 KB page on every textured draw (hundreds per frame in busy 2D scenes).
+A memo (`hash_page_cached`) avoids this: a VRAM write only marks overlapping pages
+dirty, and any page is re-hashed at most once per frame. Steady-state cost is ~1 page
+CRC per frame. The `[hdcache]` INFO log gains a page line
+(`binds / native-misses / page-CRCs / memo entries`) for tuning — `page-CRCs` should
+sit near 1/frame; a value near the bind count means the memo has regressed.
+
+## When to use it
+
+Page-aligned mode shines on **static, reused art** — backgrounds, UI, tilemaps, and
+(by extension) 3D games, where a page is uploaded once and drawn many times.
+
+It is a poor fit for **2D animated multi-palette sprites** (e.g. Alucard in *Symphony
+of the Night*): each animation frame uploads new index data, and because the page
+hash also folds in the surrounding VRAM context, one logical sprite explodes into
+many distinct page hashes. That needs far more replacement files than the upload-rect
+equivalent and churns the cache, so such sprites mostly fall back to native. Use
+upload-rect replacement for that kind of content. Since the two modes are
+independent, you can choose per game.
+
+## Usage
+
+Build the HW core as usual (`make HAVE_HW=1`, then optionally `strip`).
+
+**Dump page tiles:** enable **Track Textures** + **Dump Textures**, set **HD Dump
+Mode = Page-aligned**, run the game, and inspect `<cd>-texture-dump-pages/` (compare
+the clean tiles against the old `<cd>-texture-dump/` fragments).
+
+**Dump both at once:** set **HD Dump Mode = Both** to populate `<cd>-texture-dump/`
+*and* `<cd>-texture-dump-pages/` in one playthrough, then decide which to work from.
+
+**Mix packs:** to use a page-aligned pack but cover its gaps from an upload-rect pack
+(or vice versa), enable **HD Replacement Cross-Mode Fallback** alongside your chosen
+**HD Replacement Mode**.
+
+**Use replacements:** put edited tiles in `<cd>-texture-replacements-pages/` (keep
+dimensions a power-of-two multiple of 256, e.g. 256/512/1024 square), enable **Track
+Textures** + **Replace Textures**, and set **HD Replacement Mode = Page-aligned**.
+The `[hdcache]` log shows `replace=page` and the page bind counts. First appearance
+is native for one frame under Lazy; use **HD Texture Caching Method = Lazy
+(synchronous)** for no pop-in while evaluating.

--- a/README.md
+++ b/README.md
@@ -13,12 +13,35 @@ Notable additions in this fork are:
 * PGXP perspective correct texturing and subpixel precision, developed by iCatButler;
 * OpenBIOS, allowing the emulator to be used without a BIOS file;
 * HD texture replacement caching overhaul (Vulkan renderer), see [HD_TEXTURE_CACHE.md](HD_TEXTURE_CACHE.md);
+* Page-aligned HD texture dump/replacement, an opt-in mode for static/3D art (Vulkan renderer), see [PAGE_ALIGN.md](PAGE_ALIGN.md);
+* HD Reduce Palette Range, an opt-in hash of only a texture's used palette entries for better replacement match coverage (Vulkan renderer);
 
 ## HD texture replacement caching
 
 This fork overhauls the Vulkan renderer's HD texture replacement pipeline so packs stay smooth on demanding content — particularly multi-palette animated sprites like Alucard in *Castlevania: Symphony of the Night*. It adds a three-tier, decode-once cache (VRAM images → RAM pixels → disk, LRU-evicted), binds cached textures in the same frame they're drawn to eliminate per-frame pop-in, and decodes PNGs on a 4-thread pool. New core options let you choose the **caching method** — *Eager* (the stock-Beetle default: prefetch all of a texture's palettes) or *Lazy* (load each texture+palette on demand) — and set the **VRAM/RAM cache budgets** (defaults 3 GB / 2 GB). The on-disk pack format is unchanged. Full details: [HD_TEXTURE_CACHE.md](HD_TEXTURE_CACHE.md).
 
 Tested with **RetroArch 1.22.2** (git 69a4f0e, build date Nov 20 2025, Compiler: MinGW 10.2.0 64-bit) on Windows.
+
+## Page-aligned texture replacement (experimental)
+
+An opt-in alternative to per-upload-rectangle HD textures: the Vulkan renderer can
+dump and replace at whole VRAM texture-page granularity (clean 256×256 tiles) instead
+of the fragmented upload-rectangle sections, which is friendlier for authoring static
+backgrounds, UI and 3D art. It layers on top of the HD texture cache above and reuses
+the same three-tier cache, IO pool and budgets. Default behaviour is unchanged
+(upload-rect), so existing packs are unaffected.
+
+Options (all default to the classic upload-rect behaviour):
+* **HD Dump Mode** — `Upload-rect` / `Page-aligned` / `Both` (collect both pack types in one playthrough).
+* **HD Replacement Mode** — `Upload-rect` / `Page-aligned`, with an optional **Cross-Mode Fallback** so one pack type can fill gaps from the other without converting packs.
+* **HD Reduce Palette Range** — hash only the CLUT entries a texture actually uses (not the whole CLUT), so one replacement keeps matching across unused/rewritten palette slots; applies to both upload-rect and page paths. Backward-compatible with existing packs.
+* **HD Texture Caching Method** also gains **Lazy (synchronous)** — load on first use but block until ready (no pop-in, may briefly stutter when many new textures appear at once).
+* **HD Texture Folder** — keep the dump/replacement folders under the Content, System or Save directory (auto-created).
+* Live hotkeys (requires RetroArch **Game Focus**): `]` toggles HD replacements with an on-screen message; `'` reloads replacements from disk.
+
+Page packs and upload-rect packs are **not** interchangeable (the hash covers a
+different region of VRAM). Full details and the authoring workflow:
+[PAGE_ALIGN.md](PAGE_ALIGN.md).
 
 ## Building
 

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -530,6 +530,21 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       },
       "disabled"
    },
+   {
+      BEETLE_OPT(hd_dump_mode),
+      "HD Dump Mode",
+      NULL,
+      "How dumped textures are laid out (experimental). 'Upload-rect' (default) dumps each tracked upload to <cd>-texture-dump/ (matches stock Beetle). 'Page-aligned' dumps whole VRAM texture pages to <cd>-texture-dump-pages/ for cleaner tiles. 'Both' dumps to both folders simultaneously, so a single playthrough collects both pack types (folders stay separate; pick which to edit afterwards). Page packs are NOT interchangeable with upload-rect packs (the hash covers a different region).",
+      NULL,
+      "video",
+      {
+         { "upload_rect",  "Upload-rect (match master)" },
+         { "page_aligned", "Page-aligned (experimental)" },
+         { "both",         "Both (dump to both folders)" },
+         { NULL, NULL },
+      },
+      "upload_rect"
+   },
 #endif
    {
       BEETLE_OPT(replace_textures),
@@ -546,15 +561,73 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
-      BEETLE_OPT(hd_caching_method),
-      "HD Texture Caching Method",
+      BEETLE_OPT(texture_directory),
+      "HD Texture Folder",
       NULL,
-      "How HD replacement textures are loaded. 'Eager' prefetches all palette variants of a texture when it is uploaded (matches stock Beetle); 'Lazy' loads each texture+palette only when first drawn (leaner; better for large multi-palette packs). Both use the VRAM/RAM caches and budgets below.",
+      "Where texture dump and replacement folders are kept. 'Content directory' (default) keeps them next to the game image (current behaviour). 'System directory' / 'Save directory' put them under RetroArch's configured System or Save folder instead - one central location for every game's packs (set those paths in Settings > Directory). Each game still gets its own '<name>-texture-dump' / '-replacements' subfolder, so games never collide. Changing this re-scans replacements from the new folder.",
       NULL,
       "video",
       {
-         { "eager", "Eager (match master)" },
-         { "lazy",  "Lazy (on demand)" },
+         { "content", "Content directory (default)" },
+         { "system",  "System directory" },
+         { "save",    "Save directory" },
+         { NULL, NULL },
+      },
+      "content"
+   },
+   {
+      BEETLE_OPT(hd_replacement_mode),
+      "HD Replacement Mode",
+      NULL,
+      "Where replacement textures are looked up (experimental). 'Upload-rect' (default) matches per-upload textures from <cd>-texture-replacements/ (matches stock Beetle). 'Page-aligned' matches whole VRAM pages from <cd>-texture-replacements-pages/. Independent of HD Dump Mode; page packs are NOT interchangeable with upload-rect packs.",
+      NULL,
+      "video",
+      {
+         { "upload_rect",  "Upload-rect (match master)" },
+         { "page_aligned", "Page-aligned (experimental)" },
+         { NULL, NULL },
+      },
+      "upload_rect"
+   },
+   {
+      BEETLE_OPT(hd_replacement_fallback),
+      "HD Replacement Cross-Mode Fallback",
+      NULL,
+      "On an HD texture miss in the active HD Replacement Mode, also check the OTHER mode's folder before falling back to native. Works both ways: an upload-rect pack can fill gaps from a page-aligned pack and vice-versa, without converting packs. Best with the Lazy caching method.",
+      NULL,
+      "video",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      BEETLE_OPT(reduce_palette_range),
+      "HD Reduce Palette Range",
+      NULL,
+      "Opt-in. When dumping/replacing HD textures, hash only the palette (CLUT) entries the texture actually uses instead of the whole CLUT. This makes a texture's hash ignore unused palette entries that games often leave as garbage or rewrite over time, so one replacement keeps matching across those variations - fewer dumps and far better match coverage (most useful for 8bpp textures). Filenames are unchanged in format and remain loadable; old full-palette packs still match with this enabled (the matcher falls back to the full-palette hash when no reduced file is present). Applies to both the upload-rect and page-aligned paths. Re-dump a game to benefit.",
+      NULL,
+      "video",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      BEETLE_OPT(hd_caching_method),
+      "HD Texture Caching Method",
+      NULL,
+      "How HD replacement textures are loaded. 'Eager' prefetches all palette variants of a texture when it is uploaded (matches stock Beetle). 'Lazy' loads each texture+palette only when first drawn, in the background (leaner; brief pop-in possible on first use). 'Lazy (synchronous)' also loads on first use but blocks the renderer until ready (no pop-in, but may briefly stutter when many new textures appear at once). Both use the VRAM/RAM caches and budgets below.",
+      NULL,
+      "video",
+      {
+         { "eager",     "Eager (match master)" },
+         { "lazy",      "Lazy (async, on demand)" },
+         { "lazy_sync", "Lazy (synchronous, no pop-in)" },
          { NULL, NULL },
       },
       "eager"

--- a/rhi/rhi_lib_vulkan.c
+++ b/rhi/rhi_lib_vulkan.c
@@ -5347,11 +5347,12 @@ extern retro_log_printf_t log_cb;
  * the arguments are type-checked and counted as used. This replaced an earlier
  * `(void)sizeof((void)0, __VA_ARGS__)` form, whose discarded comma operands
  * tripped -Wunused-value on every call. */
-#ifdef DEBUG
+/* Fork: the [hdcache] INFO diagnostics and the load/dimension WARN/ERROR lines are
+ * meant to be visible in a normal RetroArch INFO log (the C++ fork emitted them
+ * unconditionally), so TT_LOG always calls log_cb - not DEBUG-gated like upstream.
+ * TT_LOG_VERBOSE (per-draw spam) stays gated below. Variables used only inside a
+ * TT_LOG are therefore genuinely used, so no -Wunused-but-set-variable concern. */
 #define TT_LOG(...) log_cb(__VA_ARGS__)
-#else
-#define TT_LOG(...) do { if (0) log_cb(__VA_ARGS__); } while (0)
-#endif
 
 #if defined(DEBUG) && defined(VERBOSE_TEXTURE_TRACKING)
 #define TT_LOG_VERBOSE(...) TT_LOG(__VA_ARGS__)
@@ -5364,6 +5365,11 @@ extern retro_log_printf_t log_cb;
    struct HdTextureId {
       uint32_t hash;
       uint32_t palette_hash;
+      /* false = upload-rect combo, true = page-aligned combo (page-aligned
+       * experiment). Namespaces the SHARED requested/hd_cache/hd_gpu_cache via
+       * hd_pack_key's salt so the two pack types never alias. C field-assignment
+       * construction sites must set this explicitly (no aggregate zero-fill). */
+      bool pages;
    };
 
    typedef int RectIndex;
@@ -5375,19 +5381,30 @@ extern retro_log_printf_t log_cb;
       RectIndex index;
       uint32_t palette_hash;
       bool fused;
+      /* Page-aligned experiment: a page-replacement handle. index points into the
+       * tracker's ephemeral page_bindings; resolved by get_hd_texture. Mutually
+       * exclusive with `fused`. (See PAGE_ALIGN.md section 6.) */
+      bool page;
    };
 
    static INLINE struct HdTextureHandle hd_handle_make(RectIndex index,
          uint32_t palette_hash)
    {
       struct HdTextureHandle h;
-      h.index = index; h.palette_hash = palette_hash; h.fused = false;
+      h.index = index; h.palette_hash = palette_hash; h.fused = false; h.page = false;
       return h;
    }
    static INLINE struct HdTextureHandle hd_handle_make_fused(RectIndex index)
    {
       struct HdTextureHandle h;
-      h.index = index; h.palette_hash = 0; h.fused = true;
+      h.index = index; h.palette_hash = 0; h.fused = true; h.page = false;
+      return h;
+   }
+   static INLINE struct HdTextureHandle hd_handle_make_page(RectIndex index,
+         uint32_t palette_hash)
+   {
+      struct HdTextureHandle h;
+      h.index = index; h.palette_hash = palette_hash; h.fused = false; h.page = true;
       return h;
    }
    static INLINE struct HdTextureHandle hd_handle_make_none(void)
@@ -5396,12 +5413,12 @@ extern retro_log_printf_t log_cb;
    }
    static INLINE bool hd_handle_is_none(const struct HdTextureHandle *h)
    {
-      return h->index == (RectIndex)-1 && h->palette_hash == 0 && h->fused == false;
+      return h->index == (RectIndex)-1 && h->palette_hash == 0 && h->fused == false && h->page == false;
    }
    static INLINE bool hd_handle_eq(const struct HdTextureHandle *a,
          const struct HdTextureHandle *b)
    {
-      return a->index == b->index && a->palette_hash == b->palette_hash && a->fused == b->fused;
+      return a->index == b->index && a->palette_hash == b->palette_hash && a->fused == b->fused && a->page == b->page;
    }
    static INLINE bool hd_handle_ne(const struct HdTextureHandle *a,
          const struct HdTextureHandle *b)
@@ -5415,7 +5432,9 @@ extern retro_log_printf_t log_cb;
          return a->index > b->index;
       if (a->palette_hash != b->palette_hash)
          return a->palette_hash > b->palette_hash;
-      return a->fused > b->fused;
+      if (a->fused != b->fused)
+         return a->fused > b->fused;
+      return a->page > b->page;
    }
 
    /* SRect: plain C struct (was a value type with ctors / accessors / equality
@@ -5624,6 +5643,12 @@ extern retro_log_printf_t log_cb;
       int         dumped_modes_count;
       int         dumped_modes_cap;
       HdTexMap textures; /* palette hash -> (image, alpha) */
+      /* Reduce Palette Range memo: the [min,max] CLUT indices this upload's index
+       * data references, cached per sampling mode (recomputed when reduce_pal_mode
+       * changes). reduce_pal_min < 0 = no valid range (use the full-palette hash). */
+      int reduce_pal_min;
+      int reduce_pal_max;
+      int reduce_pal_mode;
                /* (HD load bookkeeping lives on the TextureTracker: hd_gpu_cache
                 * / hd_cache / requested / pending_attach, keyed by
                 * (hash,palette) so it survives this upload being recreated as
@@ -5648,6 +5673,9 @@ extern retro_log_printf_t log_cb;
       u->dumped_modes = NULL;
       u->dumped_modes_count = 0;
       u->dumped_modes_cap = 0;
+      u->reduce_pal_min = -1;
+      u->reduce_pal_max = -1;
+      u->reduce_pal_mode = -1;
       hd_tex_map_init(&u->textures);
    }
    static void texture_upload_destroy(TextureUpload *u)
@@ -5677,6 +5705,9 @@ extern retro_log_printf_t log_cb;
       dst->width = src->width;
       dst->height = src->height;
       dst->hash = src->hash;
+      dst->reduce_pal_min = -1; /* memo: force recompute on the copy */
+      dst->reduce_pal_max = -1;
+      dst->reduce_pal_mode = -1;
       if (dst->image_count) {
          dst->image = (uint16_t *)malloc((size_t)dst->image_count * sizeof(uint16_t));
          if (!dst->image)
@@ -5833,18 +5864,27 @@ static void loaded_levels_move(LoadedLevels *dst, LoadedLevels *src)
       /* Load payload (valid when kind == Load): */
       uint32_t hash;
       uint32_t palette_hash;
+      bool     pages;                /* page-aligned experiment: load/dump in the -pages folder */
       /* Dump payload (valid when kind == Dump): */
       char     path[PATH_MAX_TT];
       int      width;
       int      height;
-      uint8_t *bytes;                /* owned RGBA bytes (NULL if none) */
-      size_t   bytes_len;
+      /* Raw VRAM source + palette snapshot; the palette->RGBA->tri-alpha decode is
+       * deferred to the IO worker (decode_dump_rgba) so it doesn't burst on the
+       * render thread - the render thread only takes these cheap copies. */
+      uint16_t *src;                 /* VRAM source words, row-major (owned; NULL if none) */
+      size_t    src_len;             /* element count */
+      uint16_t *palette;             /* CLUT copy (owned; NULL = no palette) */
+      size_t    palette_len;         /* element count */
+      int       dump_mode;           /* TextureMode as int (distinguishes ABGR1555 direct colour) */
+      int       ppp;                 /* texels packed per 16-bit source word (1/2/4) */
    };
 
    static void io_request_free(IORequest *r)
    {
       if (r) {
-         free(r->bytes);
+         free(r->src);
+         free(r->palette);
          free(r);
       }
    }
@@ -5858,6 +5898,7 @@ static void loaded_levels_move(LoadedLevels *dst, LoadedLevels *src)
       uint32_t hash;
       uint32_t palette_hash;
       int alpha_flags;
+      bool pages;                    /* page-aligned experiment: routes to the page attach pass */
       LoadedLevels levels;
    };
 
@@ -5875,7 +5916,8 @@ static void loaded_levels_move(LoadedLevels *dst, LoadedLevels *src)
       /* Intrusive FIFO lists (protected by `lock`). Heads are popped/drained,
        * tails are where producers append. Dynamic arrays of IORequest /
        * IOResponse. */
-      IORequest  *req_head,  *req_tail;
+      IORequest  *req_head,  *req_tail;            /* low priority: prefetch, savestate warm, dumps */
+      IORequest  *req_high_head, *req_high_tail;   /* high priority: on-demand draw-time loads */
       IOResponse *resp_head, *resp_tail;
       bool done;
       /* Cross-thread refcount. The owning IOThread holds one reference and each
@@ -5891,6 +5933,7 @@ static void loaded_levels_move(LoadedLevels *dst, LoadedLevels *src)
       c->lock = slock_new();
       c->cond = scond_new();
       c->req_head = c->req_tail = NULL;
+      c->req_high_head = c->req_high_tail = NULL;
       c->resp_head = c->resp_tail = NULL;
       c->done = false;
       c->refcount = 1;
@@ -5926,13 +5969,31 @@ static void loaded_levels_move(LoadedLevels *dst, LoadedLevels *src)
 
    /* FIFO helpers (caller holds channel->lock). Defined here so the IO worker
     * (io_thread) and the producers can all see them. */
-   static void io_channel_push_request(IOChannel *c, IORequest *r) {
+   static void io_channel_push_request(IOChannel *c, IORequest *r) {       /* low priority */
       r->next = NULL;
       if (c->req_tail) c->req_tail->next = r; else c->req_head = r;
       c->req_tail = r;
    }
+   static void io_channel_push_request_high(IOChannel *c, IORequest *r) {  /* high priority */
+      r->next = NULL;
+      if (c->req_high_tail) c->req_high_tail->next = r; else c->req_high_head = r;
+      c->req_high_tail = r;
+   }
+   /* True if either queue has pending work (caller holds the lock). */
+   static bool io_channel_has_requests(const IOChannel *c) {
+      return c->req_high_head != NULL || c->req_head != NULL;
+   }
+   /* Pop one request, draining the high-priority queue first so on-demand
+    * draw-time loads jump ahead of background prefetch/dumps. */
    static IORequest *io_channel_pop_request(IOChannel *c) {
-      IORequest *r = c->req_head;
+      IORequest *r = c->req_high_head;
+      if (r) {
+         c->req_high_head = r->next;
+         if (!c->req_high_head) c->req_high_tail = NULL;
+         r->next = NULL;
+         return r;
+      }
+      r = c->req_head;
       if (r) {
          c->req_head = r->next;
          if (!c->req_head) c->req_tail = NULL;
@@ -6359,6 +6420,9 @@ static void rect_tracker_clear(struct RectTracker *self, SRect rect)
       bool dirty;
       bool dead;
 
+      size_t   bytes;      /* approx VRAM footprint of texture (w*h*4); for the LRU budget */
+      uint64_t last_used;  /* LRU tick (higher = more recently used) */
+
       FusionRects fusion;
    };
 
@@ -6376,6 +6440,8 @@ static void fp_copy(FusedPage *dst, const FusedPage *src) {
       dst->full_page_rect  = src->full_page_rect;
       dst->dirty           = src->dirty;
       dst->dead            = src->dead;
+      dst->bytes           = src->bytes;
+      dst->last_used       = src->last_used;
       dst->fusion.vram_rect = src->fusion.vram_rect;
       dst->fusion.scaleX    = src->fusion.scaleX;
       dst->fusion.scaleY    = src->fusion.scaleY;
@@ -6391,6 +6457,8 @@ static void fp_copy(FusedPage *dst, const FusedPage *src) {
     * has a live dst and must NOT use this. */
 static void fp_init_raw(FusedPage *p) {
       ownedrects_init(&p->fusion.rects);
+      p->bytes = 0;
+      p->last_used = 0;
    }
 static void fp_destroy(FusedPage *p) {
       ih_reset(&p->texture);
@@ -6465,9 +6533,19 @@ static void fused_page_vec_truncate(struct FusedPageVec *v, int n)
 
    struct FusedPages {
       FusedPageVec pages;
+      /* LRU budget: composited page images are unbudgeted otherwise and grow without
+       * bound (they are the dominant HD VRAM sink in heavy-overlap games). Evicted at
+       * the on_queues_reset safe point (no fused handles live). */
+      size_t   budget_bytes;
+      uint64_t tick;        /* monotonic LRU clock (bumped on each page access) */
    };
 
-static void fused_pages_init(struct FusedPages *self) { fused_page_vec_init_empty(&self->pages); }
+static void fused_pages_init(struct FusedPages *self) {
+      fused_page_vec_init_empty(&self->pages);
+      self->budget_bytes = 0;
+      self->tick = 0;
+   }
+static void fused_pages_set_budget(struct FusedPages *self, size_t bytes) { self->budget_bytes = bytes; }
 static void fused_pages_deinit(struct FusedPages *self) { fused_page_vec_deinit(&self->pages); }
    static HdTextureHandle fused_pages_get_or_make(struct FusedPages *self,
          Rect page_rect,
@@ -6483,6 +6561,8 @@ static void fused_pages_deinit(struct FusedPages *self) { fused_page_vec_deinit(
          struct RectTracker *tracker,
          Renderer *uploader);
    static void fused_pages_remove_dead(struct FusedPages *self);
+   static void fused_pages_evict(struct FusedPages *self); /* LRU-evict live pages to the budget */
+   static int64_t page_bytes(FusionRects *fusion); /* approx VRAM footprint of a fused page */
 
    struct RestorableRect {
       Rect rect;
@@ -6601,6 +6681,10 @@ static void fused_pages_deinit(struct FusedPages *self) { fused_page_vec_deinit(
 
    struct CacheEntry {
       Rect rect;
+      /* Lookup key (the draw's full palette hash). Kept separate from
+       * handle.palette_hash because with Reduce Palette Range the bound handle may
+       * carry a reduced palette hash, while the cache is keyed by the full hash. */
+      uint32_t key_palette_hash;
       HdTextureHandle handle;
    };
 
@@ -6881,7 +6965,17 @@ static void RestorableRectSaveStateVec_free_storage(struct RestorableRectSaveSta
     * one int with no comparator / tree descent. */
    static uint64_t hd_pack_key(HdTextureId id)
    {
-      return ((uint64_t)id.hash << 32) | (uint64_t)id.palette_hash;
+      uint64_t k = ((uint64_t)id.hash << 32) | (uint64_t)id.palette_hash;
+      /* Namespace page-aligned combos away from upload-rect combos in the SHARED
+       * structures (requested / hd_cache / hd_gpu_cache). The C key has no spare
+       * bit (hash + palette fill all 64), so fold the page flag in with a fixed
+       * 64-bit salt rather than the C++ struct's extra comparison field. The
+       * shared structures are point-access only (never unpacked back to a hash),
+       * so the salt is safe; page-only sets that ARE unpacked (pending_attach_pages)
+       * store the un-salted base key instead. */
+      if (id.pages)
+         k ^= UINT64_C(0x9E3779B97F4A7C15);
+      return k;
    }
 
    /* -------------------------------------------------------------------------
@@ -7340,6 +7434,44 @@ static void RestorableRectSaveStateVec_free_storage(struct RestorableRectSaveSta
       s->count--;
    }
 
+   /* Page-aligned experiment: memoized page CRC keyed by the page rect (VRAM
+    * words). dirty = the page's VRAM was written since we last hashed it;
+    * hashed_frame caps re-hashing to once per page per frame (busy VRAM regions
+    * otherwise re-CRC a 256-row page on nearly every draw). */
+   struct CachedPageHash {
+      Rect rect;
+      uint32_t hash;
+      bool dirty;
+      uint64_t hashed_frame;
+   };
+   typedef struct CachedPageHash CachedPageHash;
+
+   /* Reduce Palette Range memo for the page path: the [min,max] CLUT indices a
+    * page's index data references. Keyed by (rect, hash) - content-addressed, so it
+    * self-invalidates when the page content (and thus its hash) changes; no dirty
+    * coupling with CachedPageHash. pal_min < 0 means "no palette / no range". */
+   struct CachedPageBounds {
+      Rect rect;
+      uint32_t hash;
+      int pal_min;
+      int pal_max;
+   };
+   typedef struct CachedPageBounds CachedPageBounds;
+
+   /* Page-aligned experiment: a resolved page replacement ready to bind for one
+    * draw. Built each frame in get_hd_texture_index from a loaded page image; the
+    * page HdTextureHandle indexes the tracker's ephemeral page_bindings vector
+    * (cleared at on_queues_reset, exactly like handle_cache). page_rect is the
+    * page in VRAM 16-bit words {page_x, page_y, page_w, 256}; the shader maps it
+    * to the full image via (vram_rect, texel_rect={0,0,img_w,img_h}).
+    * (PAGE_ALIGN.md section 6.) */
+   struct ReplacedPage {
+      Rect page_rect;        /* VRAM words */
+      ImageHandle texture;
+      int alpha_flags;
+   };
+   typedef struct ReplacedPage ReplacedPage;
+
    /* TextureTracker: the HD-texture replacement engine -- tracks VRAM rects,
     * resolves (hash,palette) combos to HD textures, and drives the disk/CPU/GPU
     * cache tiers and the IO worker thread. A
@@ -7397,6 +7529,64 @@ static void RestorableRectSaveStateVec_free_storage(struct RestorableRectSaveSta
       DbgHotkey reload_key;
       DbgHotkey fastpath_key;
       bool fastpath_enabled;
+
+      /* ---- Page-aligned experiment + HD QoL (see PAGE_ALIGN.md). ---- */
+      /* HD Dump Mode: rect -> -texture-dump/, pages -> -texture-dump-pages/.
+       * Both can be set ("Both" mode). Default = upload-rect (master-consistent). */
+      bool dump_mode_rect;
+      bool dump_mode_pages;
+      bool replacement_mode_pages;  /* HD Replacement Mode = Page-aligned */
+      bool replacement_fallback;    /* on a miss in the active mode, also try the other pack */
+      bool lazy_sync;               /* Lazy mode only: load+upload synchronously on the render thread */
+      bool reduce_palette_range;    /* opt-in: hash only the CLUT entries a texture uses */
+
+      /* CPU mirror of 16-bit VRAM (FB_WIDTH x FB_HEIGHT), kept current by every
+       * VRAM mutation hook. Page hashing/dumping reads page bytes from here
+       * because the draw path carries no CPU VRAM pointer (PAGE_ALIGN.md sec 3). */
+      uint16_t *vram_mirror;
+
+      /* Scratch CLUT buffer for palette reads that fall back to the VRAM mirror
+       * (see texture_tracker_get_palette). One 8bpp CLUT = 256 entries. Filled
+       * and consumed synchronously on the render thread, so one reused buffer is
+       * safe. */
+      uint16_t palette_scratch[256];
+
+      /* Last dump/replacement folders ensure_directories() created (skip re-mkdir
+       * unless the target path changes - game load, mode switch, or folder option). */
+      char ensured_dump_dir[PATH_MAX_TT];
+      char ensured_dump_pages_dir[PATH_MAX_TT];
+      char ensured_replace_dir[PATH_MAX_TT];
+
+      /* Page-aligned replacement: reuses the 3-tier cache / requested / IO pool,
+       * keyed by {page_hash, palette, pages=true}. These sets are page-only. */
+      HdKeySet known_files_pages;      /* files in the -pages folder */
+      HdKeySet pending_attach_pages;   /* page combos decoded, awaiting GPU attach (stores BASE keys) */
+      HdKeySet dumped_pages;           /* dedup of dumped (page_hash, palette_hash) */
+
+      /* Per-frame resolved page bindings; a page HdTextureHandle indexes this.
+       * Cleared at on_queues_reset (same contract as handle_cache). */
+      ReplacedPage *page_bindings;
+      int page_bindings_count;
+      int page_bindings_cap;
+
+      /* Memo of page CRCs by page rect; invalidated on overlapping mirror writes
+       * so the per-draw page hash isn't recomputed for repeated draws of a page. */
+      CachedPageHash *cached_page_hashes;
+      int cached_page_hashes_count;
+      int cached_page_hashes_cap;
+
+      /* Reduce Palette Range (page path): per-page [min,max] CLUT window memo. */
+      CachedPageBounds *cached_page_bounds;
+      int cached_page_bounds_count;
+      int cached_page_bounds_cap;
+
+      uint64_t dbg_gpu_uploads_peak;  /* max uploads in a single on_queues_reset within the window */
+      uint64_t dbg_page_binds;        /* page combos bound for a draw (cache hit) */
+      uint64_t dbg_page_binds_last;
+      uint64_t dbg_page_miss;         /* page draws with no resident replacement (native) */
+      uint64_t dbg_page_miss_last;
+      uint64_t dbg_page_hashes;       /* actual full-page CRC32s computed (memo misses) */
+      uint64_t dbg_page_hashes_last;
    };
 
    static void texture_tracker_init(struct TextureTracker *self);
@@ -7414,7 +7604,7 @@ static void RestorableRectSaveStateVec_free_storage(struct RestorableRectSaveSta
          Rect dst,
          Rect src);
    static void texture_tracker_clearRegion(struct TextureTracker *self,
-         Rect rect);
+         Rect rect, uint16_t fill16);
    static void texture_tracker_notifyReadback(struct TextureTracker *self,
          Rect rect,
          uint16_t *vram);
@@ -7440,6 +7630,10 @@ static void texture_tracker_set_cache_budgets(struct TextureTracker *self,
    {
       HdImageCache_set_budget(&self->hd_cache, ram_bytes);
       HdGpuCache_set_budget(&self->hd_gpu_cache, vram_bytes);
+      /* Fused-page composites are a separate VRAM tier; bound them by the same VRAM
+       * budget so they can't grow without limit (worst-case total HD VRAM ~= 2x the
+       * cap: GPU cache + fused pages). */
+      fused_pages_set_budget(&self->fused_pages, vram_bytes);
    }
 
    static Palette texture_tracker_get_palette(struct TextureTracker *self,
@@ -7447,7 +7641,7 @@ static void texture_tracker_set_cache_budgets(struct TextureTracker *self,
    static uint32_t texture_tracker_get_palette_hash(struct TextureTracker *self,
          Rect palette_rect);
    static void texture_tracker_want_combo(struct TextureTracker *self,
-         HdTextureId id);
+         HdTextureId id, bool high_priority, bool pages);
    static void texture_tracker_dump_texture(struct TextureTracker *self,
          TextureUpload *upload,
          UsedMode *mode,
@@ -7460,8 +7654,20 @@ static void texture_tracker_set_cache_budgets(struct TextureTracker *self,
    static void texture_tracker_reload_textures_from_disk(struct TextureTracker *self);
    static void texture_tracker_dump_image(struct TextureTracker *self,
          TextureUpload *upload,
-         UsedMode *mode);
-
+         UsedMode *mode,
+         uint32_t palette_hash_override);
+   /* ---- Page-aligned experiment + HD QoL forward declarations (PAGE_ALIGN.md) ---- */
+   static void texture_tracker_mirror_store(struct TextureTracker *self, Rect rect, const uint16_t *vram);
+   static void texture_tracker_mirror_blit(struct TextureTracker *self, Rect dst, Rect src);
+   static void texture_tracker_mirror_fill(struct TextureTracker *self, Rect rect, uint16_t value);
+   static void texture_tracker_invalidate_page_hashes(struct TextureTracker *self, Rect written);
+   static uint32_t texture_tracker_hash_page(struct TextureTracker *self, Rect page_rect);
+   static uint32_t texture_tracker_hash_page_cached(struct TextureTracker *self, Rect page_rect);
+   static void texture_tracker_dump_page(struct TextureTracker *self, Rect page_rect, uint32_t page_hash, UsedMode *mode, uint32_t palette_hash);
+   static void texture_tracker_ensure_directories(struct TextureTracker *self, bool dump, bool replace);
+   static void texture_tracker_sync_load_combo(struct TextureTracker *self, TextureUpload *upload, uint32_t palette_hash);
+   static void texture_tracker_sync_load_page(struct TextureTracker *self, HdTextureId id);
+   static HdTextureHandle texture_tracker_match_page(struct TextureTracker *self, Rect page_rect, uint32_t page_hash, uint32_t palette_hash);
 static void texture_tracker_clear_palette_cache(struct TextureTracker *self,
       Rect rect)
    {
@@ -8966,7 +9172,13 @@ static void renderer_clear_rect(Renderer *self,
       uint32_t fb_color)
 {
    if (self->texture_tracking_enabled) {
-      texture_tracker_clearRegion(&self->tracker, *rect);
+      /* fb_color is 0x00BBGGRR (8-bit channels, low 3 bits ignored). Pack to
+       * ABGR1555 (R in the low bits, mask/alpha bit cleared) to match how the
+       * VRAM mirror is read back (page-aligned experiment). */
+      uint16_t fill16 = (uint16_t)(((fb_color >> 3) & 0x1f)
+            | (((fb_color >> 11) & 0x1f) << 5)
+            | (((fb_color >> 19) & 0x1f) << 10));
+      texture_tracker_clearRegion(&self->tracker, *rect, fill16);
    }
    ih_reset(&self->last_scanout);
    fbatlas_clear_rect(&self->atlas, rect, fb_color);
@@ -9881,7 +10093,7 @@ static void renderer_build_attribs(Renderer *self, BufferVertex *output, const V
    bool *filtering_out, bool *scaled_read_out, unsigned *shift_out, bool *offset_uv_out){
       int16_t param;
       float z;
-   unsigned shift; bool filtering, scaled_read, offset_uv; HdTextureHandle hd_texture_index = hd_handle_make_none(); /* local working copies; written back to *_out at function end. Seeded to 'none' so untextured draws (which skip the hd_texture_vram.height > 0 assignment below) don't write back / test an indeterminate handle. */
+   unsigned shift; bool filtering, scaled_read, offset_uv; HdTextureHandle hd_texture_index = hd_handle_make_none(); /* local working copies; written back to *_out at function end. hd_texture_index MUST be initialised: it is only assigned for textured primitives (hd_texture_vram.height > 0); untextured draws would otherwise write back an uninitialised garbage HD handle (benign zeros at -O0, real garbage at -O3 -> bogus handles -> stale-handle flood and crashes). */
    switch (self->render_state.texture_mode)
    {
    case TextureMode_Palette4bpp:
@@ -10675,6 +10887,13 @@ static void renderer_hd_texture_uniforms(Renderer *self,
       hd.texel_rect.x, hd.texel_rect.y, hd.texel_rect.width, hd.texel_rect.height
    };
    commandbuffer_push_constants(cbh_get(&self->cmd), &push, 0, sizeof(push)); }
+   /* get_hd_texture returns an OWNED (+1) reference in hd.texture (every path now
+    * increfs). In the C++ fork the ImageHandle member released it via RAII at scope
+    * exit; C89 has no destructor, so release it explicitly here. The command buffer
+    * keeps the bound view alive for GPU execution, so this is safe. Omitting this was
+    * the page-mode VRAM leak: each distinct drawn image never hit refcount 0, which is
+    * bounded for upload-rect's stable set but unbounded under page-mode churn. */
+   ih_reset(&hd.texture);
 }
 
 static void renderer_render_semi_transparent_primitives(Renderer *self){
@@ -12645,6 +12864,11 @@ static void da_heap_garbage_collect(struct DeviceAllocatorHeap *self,
       vkFreeMemory(device, block->memory, NULL);
       self->size -= block->size;
    }
+   /* Empty the recycle list so this is safe to call mid-session (not just at
+    * teardown): the blocks were just vkFreeMemory'd, so the entries must not be
+    * left behind for the allocator to hand back. Keeps the backing array (cap) for
+    * reuse. */
+   self->blocks.count = 0;
 }
 
 static void deviceallocator_free(struct DeviceAllocator *self,
@@ -17486,6 +17710,41 @@ static void device_next_frame_context(Device *self)
             deviceallocation_free_immediate_alloc(DeviceAllocationVec_at(&self->allocations, _i), &self->managers->memory);
       }
 
+      /* Return pooled-but-unused device memory to the driver. The allocator only
+       * reuses a recycled block on an EXACT size match, so varying-size HD-texture
+       * uploads strand freed blocks in the recycle list, and GC otherwise runs only
+       * at teardown - the pool grows to all VRAM and never shrinks (observed: cache
+       * pinned at its 1 GB budget while actual VRAM climbs to 11 GB). Once the unused
+       * recycle list of any heap exceeds a modest reuse budget, free it back. */
+      {
+         struct DeviceAllocator *mem = &self->managers->memory;
+         int _hi;
+         uint64_t total_alloc = 0;   /* device memory vkAllocateMemory'd and not freed (~= GPU-Z) */
+         uint64_t total_recycle = 0; /* of that, sitting unused in recycle lists */
+         static uint64_t dbg_alloc_frames = 0;
+         for (_hi = 0; _hi < mem->heaps.count; _hi++)
+         {
+            struct DeviceAllocatorHeap *heap = da_heap_vec_at(&mem->heaps, _hi);
+            uint64_t recycle_bytes = 0;
+            int _bi;
+            for (_bi = 0; _bi < da_alloc_vec_size(&heap->blocks); _bi++)
+               recycle_bytes += (uint64_t)da_alloc_vec_at(&heap->blocks, _bi)->size;
+            if (recycle_bytes > (uint64_t)256u * 1024u * 1024u) /* keep up to 256 MB pooled for reuse */
+            {
+               da_heap_garbage_collect(heap, self->device);
+               recycle_bytes = 0;
+            }
+            total_alloc   += heap->size;
+            total_recycle += recycle_bytes;
+         }
+         /* Diagnostic: the allocator's actual total (what GPU-Z shows) and how much is
+          * reclaimable pool vs live. Printed ~every 300 frames alongside [hdcache]. */
+         if ((++dbg_alloc_frames % 300u) == 0u)
+            TT_LOG(RETRO_LOG_INFO, "[hdcache] alloc: %llu MiB total device memory, %llu MiB reclaimable pool\n",
+                  (unsigned long long)(total_alloc / (1024u * 1024u)),
+                  (unsigned long long)(total_recycle / (1024u * 1024u)));
+      }
+
       {
          int _bi;
          for (_bi = 0; _bi < self->vbo_blocks.count; _bi++)
@@ -19353,26 +19612,82 @@ extern retro_input_state_t dbg_input_state_cb;
 
 extern char retro_cd_base_name[4096];
 extern char retro_cd_base_directory[4096];
+/* RetroArch System / Save directories (defined in libretro.c). Used by the HD
+ * Texture Folder option to relocate the dump/replacement folders off the content
+ * directory to a single central location. */
+extern char retro_base_directory[4096];   /* System directory */
+extern char retro_save_directory[4096];   /* Save directory */
 #ifdef _WIN32
 static char retro_slash = '\\';
 #else
 static char retro_slash = '/';
 #endif
 
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <sys/stat.h>
+#endif
+
+   /* HD Texture Folder mode: 0 = content dir (default), 1 = system, 2 = save. */
+   static int texture_dir_mode = 0;
+
+   /* Base directory for the texture dump/replacement folders, chosen by the HD
+    * Texture Folder option. Falls back to the content directory if the selected
+    * frontend directory is unset. Trailing separators are trimmed so the helpers
+    * below append retro_slash uniformly. */
+   static char *texture_root(char *out, size_t cap) {
+      const char *dir = retro_cd_base_directory;       /* 0 = content (default) */
+      size_t len;
+      if (texture_dir_mode == 1 && retro_base_directory[0] != '\0')
+         dir = retro_base_directory;                    /* 1 = system */
+      else if (texture_dir_mode == 2 && retro_save_directory[0] != '\0')
+         dir = retro_save_directory;                    /* 2 = save */
+      strncpy(out, dir, cap - 1);
+      out[cap - 1] = '\0';
+      len = strlen(out);
+      while (len > 0 && (out[len - 1] == '/' || out[len - 1] == '\\'))
+         out[--len] = '\0';
+      return out;
+   }
+
+   /* Create a single directory if it doesn't exist (page-aligned experiment - the
+    * dump folders must exist before stbi_write_png can write into them; this
+    * libretro-common snapshot has no path_mkdir). Trailing slash trimmed first
+    * since _mkdir dislikes it on Windows. */
+   static void ensure_directory(const char *dir_in) {
+      char dir[PATH_MAX_TT];
+      size_t len;
+      strncpy(dir, dir_in, sizeof(dir) - 1);
+      dir[sizeof(dir) - 1] = '\0';
+      len = strlen(dir);
+      while (len > 0 && (dir[len - 1] == '/' || dir[len - 1] == '\\'))
+         dir[--len] = '\0';
+      if (len == 0)
+         return;
+#ifdef _WIN32
+      _mkdir(dir);
+#else
+      mkdir(dir, 0755);
+#endif
+   }
+
    /* Path helpers write into a caller-provided buffer (PATH_MAX_TT bytes) and
     * return it C-style, no allocation. */
 
    static char *dump_path(char *out, size_t cap) {
+      char root[PATH_MAX_TT];
       int n = snprintf(out, cap, "%s%c%s-texture-dump%c",
-            retro_cd_base_directory, retro_slash, retro_cd_base_name, retro_slash);
+            texture_root(root, sizeof(root)), retro_slash, retro_cd_base_name, retro_slash);
       if (n < 0 || (size_t)n >= cap)
          out[cap - 1] = '\0';
       return out;
    }
 
    static char *replacements_path(char *out, size_t cap) {
+      char root[PATH_MAX_TT];
       int n = snprintf(out, cap, "%s%c%s-texture-replacements%c",
-            retro_cd_base_directory, retro_slash, retro_cd_base_name, retro_slash);
+            texture_root(root, sizeof(root)), retro_slash, retro_cd_base_name, retro_slash);
       if (n < 0 || (size_t)n >= cap)
          out[cap - 1] = '\0';
       return out;
@@ -19386,6 +19701,42 @@ static char retro_slash = '/';
       int n;
       replacements_path(base, sizeof(base));
       n = snprintf(out, cap, "%s%x-%x.png", base, (unsigned)hash, (unsigned)palette_hash);
+      if (n < 0 || (size_t)n >= cap)
+         out[cap - 1] = '\0';
+      return out;
+   }
+
+   /* Page-aligned experiment folders (kept separate so page packs and upload-rect
+    * packs never collide - same filename != same texture; see PAGE_ALIGN.md). */
+   static char *dump_pages_path(char *out, size_t cap) {
+      char root[PATH_MAX_TT];
+      int n = snprintf(out, cap, "%s%c%s-texture-dump-pages%c",
+            texture_root(root, sizeof(root)), retro_slash, retro_cd_base_name, retro_slash);
+      if (n < 0 || (size_t)n >= cap)
+         out[cap - 1] = '\0';
+      return out;
+   }
+
+   static char *replacements_pages_path(char *out, size_t cap) {
+      char root[PATH_MAX_TT];
+      int n = snprintf(out, cap, "%s%c%s-texture-replacements-pages%c",
+            texture_root(root, sizeof(root)), retro_slash, retro_cd_base_name, retro_slash);
+      if (n < 0 || (size_t)n >= cap)
+         out[cap - 1] = '\0';
+      return out;
+   }
+
+   /* Page-aligned experiment: filename of a page replacement (mirrors the
+    * upload-rect helper, but in the -pages folder; page_hash takes the
+    * texture-hash slot). */
+   static char *replacement_pages_filename_from_hash(char *out,
+         size_t cap,
+         uint32_t page_hash,
+         uint32_t palette_hash){
+      char base[PATH_MAX_TT];
+      int n;
+      replacements_pages_path(base, sizeof(base));
+      n = snprintf(out, cap, "%s%x-%x.png", base, (unsigned)page_hash, (unsigned)palette_hash);
       if (n < 0 || (size_t)n >= cap)
          out[cap - 1] = '\0';
       return out;
@@ -19514,6 +19865,61 @@ static uint8_t *loaded_pixel(LoadedImage *image, int x, int y) {
       return levels;
    }
 
+   /* Worker-side dump decode: expand a snapshot of raw VRAM source words (req->src)
+    * into RGBA with the tri-alpha convention, on the IO thread instead of the
+    * render thread. Bit-identical to the old inline loops in dump_image/dump_page
+    * (same math + order), so existing dumps still round-trip. Empty palette +
+    * non-ABGR1555 = grayscale "missing". Returns a malloc'd buffer the caller frees;
+    * *out_len receives its size. */
+   static uint8_t *decode_dump_rgba(const IORequest *req, size_t *out_len) {
+      size_t cap = (size_t)req->width * req->height * 4u;
+      uint8_t *bytes = (uint8_t *)malloc(cap ? cap : 1);
+      size_t bi = 0;
+      bool is_abgr1555 = (req->dump_mode == (int)TextureMode_ABGR1555);
+      bool has_pal = (req->palette != NULL && req->palette_len > 0);
+      int ppp = req->ppp;
+      int bpp = 16 / ppp;
+      int mask = (1 << bpp) - 1;
+      size_t wi;
+      for (wi = 0; wi < req->src_len; wi++) {
+         uint16_t word = req->src[wi];
+         int p;
+         for (p = 0; p < ppp; p++) {
+            uint16_t subpixel = (word >> (p * bpp)) & mask;
+            if (!is_abgr1555 && !has_pal) {
+               /* Missing palette: grayscale of the raw index. */
+               bytes[bi++] = (uint8_t)(255.0 * subpixel / mask);
+               bytes[bi++] = (uint8_t)(255.0 * subpixel / mask);
+               bytes[bi++] = (uint8_t)(255.0 * subpixel / mask);
+               bytes[bi++] = (uint8_t)255;
+            } else {
+               uint16_t abgr1555 = is_abgr1555 ? subpixel : req->palette[subpixel];
+               int r = ((abgr1555 >> 0) & 0x1f) * 255.0 / 31.0;
+               int g = ((abgr1555 >> 5) & 0x1f) * 255.0 / 31.0;
+               int b = ((abgr1555 >> 10) & 0x1f) * 255.0 / 31.0;
+               int a = (abgr1555 >> 15) * 255.0;
+               /* Convert psx alpha to the tri convention. */
+               if (a == 0) {
+                  if (r == 0 && g == 0 && b == 0) {
+                     /* Transparent: already (0,0,0,0). */
+                  } else {
+                     a = 255; /* Opaque */
+                  }
+               } else {
+                  a = 127; /* Semi-transparent */
+               }
+               bytes[bi++] = (uint8_t)r;
+               bytes[bi++] = (uint8_t)g;
+               bytes[bi++] = (uint8_t)b;
+               bytes[bi++] = (uint8_t)a;
+            }
+         }
+      }
+      if (out_len)
+         *out_len = bi;
+      return bytes;
+   }
+
    static void io_thread(void *user_data) {
       /* Pool worker. Each worker is handed the channel pointer with a reference
        * already taken on its behalf (at spawn); it releases that reference on
@@ -19525,7 +19931,7 @@ static uint8_t *loaded_pixel(LoadedImage *image, int x, int y) {
          IORequest *request = NULL;
          {
             slock_lock(channel->lock);
-            while (channel->req_head == NULL && !channel->done) {
+            while (!io_channel_has_requests(channel) && !channel->done) {
                scond_wait(channel->cond, channel->lock);
             }
             if (channel->done) {
@@ -19535,26 +19941,28 @@ static uint8_t *loaded_pixel(LoadedImage *image, int x, int y) {
                slock_unlock(channel->lock);
                break;
             }
-            /* Take ONE request from the front so work spreads across the pool
-             * and the producer's priority order (visible palette first) is
-             * preserved. Wake another worker if more remain. */
+            /* Take ONE request (high priority first) so work spreads across the
+             * pool. Wake another worker if anything remains. */
             request = io_channel_pop_request(channel);
-            if (channel->req_head != NULL) {
+            if (io_channel_has_requests(channel)) {
                scond_signal(channel->cond);
             }
             slock_unlock(channel->lock);
          }
 
-         /* The expensive part (PNG decode + mipmaps, or PNG write) runs WITHOUT
-          * the lock so workers process in parallel; only the queue access and
-          * the response push are serialised. */
+         /* The expensive part (PNG decode + mipmaps, or decode + PNG write) runs
+          * WITHOUT the lock so workers process in parallel; only the queue access
+          * and the response push are serialised. */
          if (request->kind == IORequestKind_Load) {
             uint32_t hash = request->hash;
             uint32_t palette_hash = request->palette_hash;
 
             char path[PATH_MAX_TT];
             RGBAImage image;
-            replacement_filename_from_hash(path, sizeof(path), hash, palette_hash);
+            if (request->pages)
+               replacement_pages_filename_from_hash(path, sizeof(path), hash, palette_hash);
+            else
+               replacement_filename_from_hash(path, sizeof(path), hash, palette_hash);
             image.data = NULL;
             load_image(path, &image);
             if (image.data != NULL) {
@@ -19565,6 +19973,7 @@ static uint8_t *loaded_pixel(LoadedImage *image, int x, int y) {
                response->hash         = hash;
                response->palette_hash = palette_hash;
                response->alpha_flags  = alpha_flags_out;
+               response->pages        = request->pages;
                loaded_levels_init(&response->levels);
                loaded_levels_move(&response->levels, &levels);
 
@@ -19577,10 +19986,16 @@ static uint8_t *loaded_pixel(LoadedImage *image, int x, int y) {
                TT_LOG(RETRO_LOG_ERROR, "failed to load: %s\n", path);
             }
          } else if (request->kind == IORequestKind_Dump) {
-            int success = write_image(request->path, request->width, request->height, request->bytes);
+            /* Decode (palette->RGBA->tri-alpha) here on the worker, then encode+write,
+             * so the burst stays off the render thread (it only snapshotted raw
+             * src+CLUT). */
+            size_t blen = 0;
+            uint8_t *bytes = decode_dump_rgba(request, &blen);
+            int success = write_image(request->path, request->width, request->height, bytes);
             if (success == 0) {
                TT_LOG(RETRO_LOG_ERROR, "failed to write to: %s\n", request->path);
             }
+            free(bytes);
          }
          io_request_free(request);
       }
@@ -19590,8 +20005,10 @@ static uint8_t *loaded_pixel(LoadedImage *image, int x, int y) {
 
    static void io_channel_destroy(IOChannel *c) {
       /* Free any nodes still queued at shutdown. */
-      IORequest *r = c->req_head;
+      IORequest *r = c->req_high_head;
       IOResponse *p = c->resp_head;
+      while (r) { IORequest *n = r->next; io_request_free(r); r = n; }
+      r = c->req_head;
       while (r) { IORequest *n = r->next; io_request_free(r); r = n; }
       while (p) { IOResponse *n = p->next; io_response_free(p); p = n; }
       slock_free(c->lock);
@@ -19630,7 +20047,7 @@ static uint8_t *loaded_pixel(LoadedImage *image, int x, int y) {
       t->channel = NULL;
    }
 
-   static void texture_tracker_dump_image(struct TextureTracker *self, TextureUpload *upload, UsedMode *mode) {
+   static void texture_tracker_dump_image(struct TextureTracker *self, TextureUpload *upload, UsedMode *mode, uint32_t palette_hash_override) {
       int bpp;
       char path[PATH_MAX_TT];
       int ppp;
@@ -19671,7 +20088,9 @@ static uint8_t *loaded_pixel(LoadedImage *image, int x, int y) {
          if (p.data != NULL) {
             palette = p.data;
             plen = strlen(path);
-            snprintf(path + plen, sizeof(path) - plen, "-%x", (unsigned)p.hash);
+            /* Filename hash from the caller (reduced range when enabled, else the
+             * full-palette hash). p.data is still used below for the PNG decode. */
+            snprintf(path + plen, sizeof(path) - plen, "-%x", (unsigned)palette_hash_override);
          }
       }
 
@@ -19681,94 +20100,55 @@ static uint8_t *loaded_pixel(LoadedImage *image, int x, int y) {
          plen = strlen(path);
          snprintf(path + plen, sizeof(path) - plen, "-missing");
          TT_LOG_VERBOSE(RETRO_LOG_INFO, "MISSING palette %i, %i.\n", mode->palette_offset_x, mode->palette_offset_y);
+      } else {
+         /* ABGR1555: direct colour, no palette. The loader looks up palette hash 0,
+          * so tag the file -0 to round-trip (was <hash>.png, which never reloaded). */
+         plen = strlen(path);
+         snprintf(path + plen, sizeof(path) - plen, "-0");
       }
 
       ppp = 1 << shift;
-      bpp = 16 >> shift;
-      { int mask = (1 << bpp) - 1;
-      /* Output is exactly 4 bytes per (subpixel) = image.size() * ppp * 4. */
-      img_count = (size_t)upload->image_count;
-      bytes_len = img_count * (size_t)ppp * 4u;
-      bytes = (uint8_t *)malloc(bytes_len ? bytes_len : 1);
-      bi = 0;
-      {
-         size_t ii;
-         for (ii = 0; ii < img_count; ii++) {
-            uint16_t pixel = upload->image[ii];
-            int p;
-            for (p = 0; p < ppp; p++) {
-               uint16_t subpixel = (pixel >> (p * bpp)) & mask;
-               if (mode->mode != TextureMode_ABGR1555 && palette == NULL) {
-                  /* Missing palette, dump a grayscale version of the image data */
-                  bytes[bi++] = (uint8_t)(255.0 * subpixel / mask);
-                  bytes[bi++] = (uint8_t)(255.0 * subpixel / mask);
-                  bytes[bi++] = (uint8_t)(255.0 * subpixel / mask);
-                  bytes[bi++] = (uint8_t)255;
-               } else {
-                  int g;
-                  int r;
-                  uint16_t abgr1555;
-                  if (mode->mode == TextureMode_ABGR1555) {
-                     abgr1555 = subpixel;
-                  } else {
-                     abgr1555 = palette[subpixel];
-                  }
-                  r = ((abgr1555 >> 0) & 0x1f) * 255.0 / 31.0;
-                  g = ((abgr1555 >> 5) & 0x1f) * 255.0 / 31.0;
-                  { int b = ((abgr1555 >> 10) & 0x1f) * 255.0 / 31.0;
-                  int a = (abgr1555 >> 15) * 255.0;
-                  /* Convert psx to tri */
-                  if (a == 0) {
-                     if (r == 0 && g == 0 && b == 0) {
-                        /* Transparent
-                         * do nothing, pixel is already in the correct format */
-                     } else {
-                        /* Opaque */
-                        a = 255;
-                     }
-                  } else {
-                     /* Semi-transparent */
-                     a = 127;
-                  }
-                  bytes[bi++] = (uint8_t)r;
-                  bytes[bi++] = (uint8_t)g;
-                  bytes[bi++] = (uint8_t)b;
-                  bytes[bi++] = (uint8_t)a;
-                  }
-               }
-            }
-         }
-      }
+      (void)bpp; (void)bytes; (void)bytes_len; (void)bi; (void)img_count;
 
       plen = strlen(path);
       snprintf(path + plen, sizeof(path) - plen, ".png");
 
-      TT_LOG_VERBOSE(RETRO_LOG_INFO, "Dump info: mode=%i, w=%i, h=%i, len=%i, bytesLen=%i\n", mode->mode, upload->width, upload->height, upload->image_count, (int)bytes_len);
-      TT_LOG_VERBOSE(RETRO_LOG_INFO, "Dumping to %s.\n", path);
-
-      /* stbi_write_png(path, upload.width * ppp, upload.height, 4, bytes, 4 * upload.width * ppp); */
-      TT_LOG_VERBOSE(RETRO_LOG_INFO, "requesting dump: %s\n", path);
+      /* Snapshot the raw indexed words + CLUT (cheap copies); the IO worker
+       * (decode_dump_rgba) expands palette->RGBA->tri-alpha off the render thread. */
+      TT_LOG_VERBOSE(RETRO_LOG_INFO, "requesting dump: %s (%ux%u)\n", path,
+            (unsigned)(upload->width * ppp), (unsigned)upload->height);
       {
          IORequest *dump = (IORequest *)malloc(sizeof(IORequest));
          dump->next = NULL;
          dump->kind = IORequestKind_Dump;
          snprintf(dump->path, sizeof(dump->path), "%s", path);
-         dump->width = upload->width * ppp;
+         dump->width  = upload->width * ppp;
          dump->height = upload->height;
-         dump->bytes = bytes;          /* transfer ownership to the request */
-         dump->bytes_len = bytes_len;
+         dump->pages  = false;
+         dump->dump_mode = (int)mode->mode;
+         dump->ppp    = ppp;
+         dump->src_len = (size_t)upload->image_count;
+         dump->src = (uint16_t *)malloc((dump->src_len ? dump->src_len : 1) * sizeof(uint16_t));
+         memcpy(dump->src, upload->image, dump->src_len * sizeof(uint16_t));
+         if (palette != NULL) {
+            dump->palette_len = (size_t)(mode->mode == TextureMode_Palette8bpp ? 256 : 16);
+            dump->palette = (uint16_t *)malloc(dump->palette_len * sizeof(uint16_t));
+            memcpy(dump->palette, palette, dump->palette_len * sizeof(uint16_t));
+         } else {
+            dump->palette = NULL;
+            dump->palette_len = 0;
+         }
 
          slock_lock(self->iothread.channel->lock);
-         io_channel_push_request(self->iothread.channel, dump);
+         io_channel_push_request(self->iothread.channel, dump); /* texture dumps = background */
          slock_unlock(self->iothread.channel->lock);
          scond_signal(self->iothread.channel->cond);
       }
       }
       }
-      }
    }
 
-   static void read_texture_directory(HdKeySet *out, const char *path) {
+   static void read_texture_directory(HdKeySet *out, const char *path, bool pages) {
       RDIR *dir;
       hd_key_set_clear(out);
       dir = retro_opendir(path);
@@ -19778,6 +20158,7 @@ static uint8_t *loaded_pixel(LoadedImage *image, int x, int y) {
             uint32_t hash;
             uint32_t palette_hash;
             int chars_read;
+            HdTextureId id;
             const char *name = retro_dirent_get_name(dir);
             if (sscanf(name, "%x-%x.png%n", &hash, &palette_hash, &chars_read) != 2 ||
                   chars_read != strlen(name)
@@ -19785,7 +20166,10 @@ static uint8_t *loaded_pixel(LoadedImage *image, int x, int y) {
                continue;
             }
 
-            hd_key_set_insert(out, ((uint64_t)hash << 32) | (uint64_t)palette_hash);
+            /* pages=true sets id.pages so hd_pack_key salts these away from the
+             * upload-rect keyspace (they share the cache, separate known_files). */
+            id.hash = hash; id.palette_hash = palette_hash; id.pages = pages;
+            hd_key_set_insert(out, hd_pack_key(id));
             TT_LOG_VERBOSE(RETRO_LOG_INFO, "file found: %s\n", name);
          }
          retro_closedir(dir);
@@ -19828,8 +20212,40 @@ static uint8_t *loaded_pixel(LoadedImage *image, int x, int y) {
       self->cached_palette_hashes = NULL;
       self->cached_palette_hashes_count = 0;
       self->cached_palette_hashes_cap = 0;
-      read_texture_directory(&self->known_files, replacements_path(rpath, sizeof(rpath)));
+      /* ---- page-aligned experiment + HD QoL members ---- */
+      hd_key_set_init(&self->known_files_pages);
+      hd_key_set_init(&self->pending_attach_pages);
+      hd_key_set_init(&self->dumped_pages);
+      self->dump_mode_rect        = true;
+      self->dump_mode_pages       = false;
+      self->replacement_mode_pages= false;
+      self->replacement_fallback  = false;
+      self->lazy_sync             = false;
+      self->reduce_palette_range  = false;
+      self->vram_mirror           = (uint16_t*)calloc((size_t)FB_WIDTH * FB_HEIGHT, sizeof(uint16_t));
+      self->ensured_dump_dir[0]       = '\0';
+      self->ensured_dump_pages_dir[0] = '\0';
+      self->ensured_replace_dir[0]    = '\0';
+      self->page_bindings         = NULL;
+      self->page_bindings_count   = 0;
+      self->page_bindings_cap     = 0;
+      self->cached_page_hashes    = NULL;
+      self->cached_page_hashes_count = 0;
+      self->cached_page_hashes_cap   = 0;
+      self->cached_page_bounds    = NULL;
+      self->cached_page_bounds_count = 0;
+      self->cached_page_bounds_cap   = 0;
+      self->dbg_gpu_uploads_peak  = 0;
+      self->dbg_page_binds        = 0;
+      self->dbg_page_binds_last   = 0;
+      self->dbg_page_miss         = 0;
+      self->dbg_page_miss_last    = 0;
+      self->dbg_page_hashes       = 0;
+      self->dbg_page_hashes_last  = 0;
+      read_texture_directory(&self->known_files, replacements_path(rpath, sizeof(rpath)), false);
       TT_LOG(RETRO_LOG_INFO, "num hd textures: %d\n", (int)self->known_files.count);
+      read_texture_directory(&self->known_files_pages, replacements_pages_path(rpath, sizeof(rpath)), true);
+      TT_LOG(RETRO_LOG_INFO, "num hd page textures: %d\n", (int)self->known_files_pages.count);
 
       /* Read in the dump config file */
       dump_path(cfg, sizeof(cfg));
@@ -19851,6 +20267,14 @@ static uint8_t *loaded_pixel(LoadedImage *image, int x, int y) {
       hd_key_set_free(&self->known_files);
       hd_key_set_free(&self->requested);
       hd_key_set_free(&self->pending_attach);
+      hd_key_set_free(&self->known_files_pages);
+      hd_key_set_free(&self->pending_attach_pages);
+      hd_key_set_free(&self->dumped_pages);
+      free(self->vram_mirror);
+      { int i; for (i = 0; i < self->page_bindings_count; i++) ih_reset(&self->page_bindings[i].texture); }
+      free(self->page_bindings);
+      free(self->cached_page_hashes);
+      free(self->cached_page_bounds);
       free(self->cached_palette_hashes);
       fused_pages_deinit(&self->fused_pages); /* embedded FusedPages: explicit deinit (was default teardown) */
       rect_tracker_deinit(&self->tracker); /* embedded RectTracker: explicit deinit (was default teardown) */
@@ -19897,6 +20321,28 @@ static Rect fromSRect(SRect rect) {
             }
          }
       } }
+
+      /* Fallback: the CLUT wasn't inside a tracked, zero-offset upload rect, so the
+       * rect-tracker lookup above found nothing - this produced the bulk of the
+       * "-missing" palette dumps and palette_hash==0 keys. Read the CLUT straight
+       * from the CPU VRAM mirror instead; it is kept current by every VRAM mutation
+       * hook, exactly as the hardware reads its CLUT from live VRAM. Columns are
+       * masked so a CLUT near the right VRAM edge wraps around correctly. */
+      if (self->vram_mirror != NULL) {
+         unsigned n  = (unsigned)palette_rect.width;   /* 16 (4bpp) or 256 (8bpp) */
+         unsigned py = (unsigned)palette_rect.y & (FB_HEIGHT - 1);
+         unsigned i;
+         uint32_t hash;
+         if (n > 256u)
+            n = 256u;
+         for (i = 0; i < n; i++) {
+            unsigned px = ((unsigned)palette_rect.x + i) & (FB_WIDTH - 1);
+            self->palette_scratch[i] = self->vram_mirror[py * FB_WIDTH + px];
+         }
+         hash = crc32(0, (unsigned char*)self->palette_scratch, n * sizeof(uint16_t));
+         { Palette _p; _p.data = self->palette_scratch; _p.hash = hash; return _p; }
+      }
+
       { Palette _p; _p.data = NULL; _p.hash = 0; return _p; }
       }
    }
@@ -19929,13 +20375,14 @@ static Rect fromSRect(SRect rect) {
    }
 
    static void texture_tracker_clearRegion(struct TextureTracker *self,
-         Rect rect){
+         Rect rect, uint16_t fill16){
       if (rect.width == 0 || rect.height == 0) {
          /* Some games do this, apparently. */
          return;
       }
       rect_tracker_clear(&self->tracker, make_srect(rect.x, rect.y, rect.width, rect.height));
       fused_pages_mark_dead(&self->fused_pages, rect);
+      texture_tracker_mirror_fill(self, rect, fill16); /* keep the page mirror current */
 
       texture_tracker_clear_palette_cache(self, rect);
    }
@@ -19945,6 +20392,7 @@ static Rect fromSRect(SRect rect) {
          Rect dst,
          Rect src){
       rect_tracker_blit(&self->tracker, make_srect(dst.x, dst.y, dst.width, dst.height), make_srect(src.x, src.y, src.width, src.height));
+      texture_tracker_mirror_blit(self, dst, src); /* keep the page mirror current */
       fused_pages_mark_dirty(&self->fused_pages, dst);
       fused_pages_rebuild_dirty(&self->fused_pages, &self->tracker, self->uploader);
       texture_tracker_clear_palette_cache(self, dst);
@@ -20031,6 +20479,8 @@ static Rect fromSRect(SRect rect) {
 
       hash = texture_tracker_dbgHashVram(self, rect, vram);
 
+      texture_tracker_mirror_store(self, rect, vram); /* keep the page mirror current */
+
       { int i; for (i = 0; i < rrvec_size(&self->restorable_rects); ) {
          if (rect_intersects(&self->restorable_rects.items[i].rect, &rect))
             rrvec_erase_at(&self->restorable_rects, i);
@@ -20076,6 +20526,7 @@ static Rect fromSRect(SRect rect) {
          /* probably loading a save state, this is the entirety of vram */
          rect_tracker_clear(&self->tracker, toSRect(rect));
          fused_pages_mark_dead(&self->fused_pages, rect);
+         texture_tracker_mirror_store(self, rect, vram); /* refresh the whole mirror */
          return;
       }
 
@@ -20083,6 +20534,10 @@ static Rect fromSRect(SRect rect) {
       if (rect.width == 0 || rect.height == 0) {
          return;
       }
+
+      /* Keep the CPU VRAM mirror current with the uploaded bytes (page-aligned
+       * experiment), unconditionally regardless of dedup/restore below. */
+      texture_tracker_mirror_store(self, rect, vram);
 
       upload = NULL;
       { bool preexisting = false;
@@ -20163,7 +20618,7 @@ static Rect fromSRect(SRect rect) {
        * the cache. Routed through want_combo so it still respects the cache
        * (decode-once / dedup) and the VRAM/RAM budgets, unlike stock Beetle's
        * raw load_hd_texture. */
-      if (self->eager_textures && self->hd_textures_enabled && !preexisting) {
+      if (self->eager_textures && self->hd_textures_enabled && !preexisting && !self->replacement_mode_pages) {
          int lo = hd_key_set_lower_bound(&self->known_files, (uint64_t)upload->hash << 32);
          int hi = hd_key_set_lower_bound(&self->known_files, ((uint64_t)upload->hash + 1) << 32);
          int ki;
@@ -20171,7 +20626,8 @@ static Rect fromSRect(SRect rect) {
             HdTextureId combo;
             combo.hash = upload->hash;
             combo.palette_hash = (uint32_t)self->known_files.keys[ki];
-            texture_tracker_want_combo(self, combo);
+            combo.pages = false;
+            texture_tracker_want_combo(self, combo, false, false); /* eager prefetch = low priority */
          }
       }
       texture_upload_release(upload); /* drop the local ref; rects hold their own */
@@ -20192,9 +20648,9 @@ static Rect fromSRect(SRect rect) {
             load->kind = IORequestKind_Load;
             load->hash = hash;
             load->palette_hash = palette_hash;
-            load->bytes = NULL;
-            load->bytes_len = 0;
-            io_channel_push_request(self->iothread.channel, load);
+            load->pages = false;
+            load->src = NULL; load->palette = NULL; /* Load: no dump payload to free */
+            io_channel_push_request(self->iothread.channel, load); /* savestate warm = background */
          }
          slock_unlock(self->iothread.channel->lock);
          scond_signal(self->iothread.channel->cond);
@@ -20207,12 +20663,15 @@ static Rect fromSRect(SRect rect) {
     * cache. The IO thread only pushes a response on success, so a
     * failed/missing load stays in `requested` and is never retried (until a
     * reload clears it). */
-   static void texture_tracker_want_combo(struct TextureTracker *self, HdTextureId id) {
+   static void texture_tracker_want_combo(struct TextureTracker *self, HdTextureId id, bool high_priority, bool pages) {
+      /* pages=true sources the file from the -pages folder and checks
+       * known_files_pages; both feed the SAME 3-tier cache (id.pages namespaces
+       * the shared requested/hd_cache/hd_gpu_cache via hd_pack_key's salt). */
       if (HdGpuCache_contains(&self->hd_gpu_cache, hd_pack_key(id)) || HdImageCache_contains(&self->hd_cache, hd_pack_key(id)))
          return; /* already resident in VRAM, or already decoded in RAM */
       if (!hd_key_set_insert(&self->requested, hd_pack_key(id)))
          return; /* already in flight, or negatively cached */
-      if (!hd_key_set_contains(&self->known_files, hd_pack_key(id)))
+      if (!hd_key_set_contains(pages ? &self->known_files_pages : &self->known_files, hd_pack_key(id)))
          return; /* no file on disk */
 
       slock_lock(self->iothread.channel->lock);
@@ -20222,9 +20681,14 @@ static Rect fromSRect(SRect rect) {
          load->kind = IORequestKind_Load;
          load->hash = id.hash;
          load->palette_hash = id.palette_hash;
-         load->bytes = NULL;
-         load->bytes_len = 0;
-         io_channel_push_request(self->iothread.channel, load);
+         load->pages = pages;
+         load->src = NULL; load->palette = NULL; /* Load: no dump payload to free */
+         /* High priority = needed for an on-screen draw (jumps ahead of prefetch);
+          * low priority = speculative prefetch that fills idle IO time. */
+         if (high_priority)
+            io_channel_push_request_high(self->iothread.channel, load);
+         else
+            io_channel_push_request(self->iothread.channel, load);
       }
       slock_unlock(self->iothread.channel->lock);
       scond_signal(self->iothread.channel->cond);
@@ -20264,10 +20728,18 @@ static Rect fromSRect(SRect rect) {
 
       /* CPU-cache hit (decoded but not in VRAM): needs a GPU upload, which we
        * keep at the safe point - schedule it for on_queues_reset. */
+      /* Lazy (synchronous): get this combo ready on the render thread NOW so the
+       * current frame uses it (no pop-in), at the cost of a brief stall. Handles
+       * both the CPU-cache hit (just upload) and the full miss (disk+decode+upload). */
+      if (self->lazy_sync) {
+         texture_tracker_sync_load_combo(self, upload, palette_hash);
+         return;
+      }
+
       if (HdImageCache_contains(&self->hd_cache, hd_pack_key(current)))
          hd_key_set_insert(&self->pending_attach, hd_pack_key(current));
       else
-         texture_tracker_want_combo(self, current); /* queue a single disk load for the drawn combo */
+         texture_tracker_want_combo(self, current, true, false); /* on-demand: high priority */
       }
    }
 
@@ -20304,7 +20776,9 @@ static Rect fromSRect(SRect rect) {
          upload->dumped_modes[upload->dumped_modes_count++] = dump_mode;
          if (self->dump_enabled) {
             TT_LOG_VERBOSE(RETRO_LOG_INFO, "Dumping %x\n", upload->hash);
-            texture_tracker_dump_image(self, upload, mode);
+            /* dump_mode.palette_hash is the effective hash (reduced range when the
+             * option is on, else full) chosen by the caller: dedup key + filename. */
+            texture_tracker_dump_image(self, upload, mode, dump_mode.palette_hash);
          }
       }
    }
@@ -20316,7 +20790,7 @@ static Rect fromSRect(SRect rect) {
       int i, j;
       for (i = 0; i < self->count; i++) {
          CacheEntry *entry = &self->entries[i];
-         if (entry->handle.palette_hash == palette_hash && rect_contains(&entry->rect, &rect)) {
+         if (entry->key_palette_hash == palette_hash && rect_contains(&entry->rect, &rect)) {
             CacheEntry hit = *entry;
             for (j = i; j > 0; j--) {
                self->entries[j] = self->entries[j - 1];
@@ -20340,6 +20814,7 @@ static Rect fromSRect(SRect rect) {
       int j;
       CacheEntry e;
       e.rect = rect;
+      e.key_palette_hash = palette_hash;
       e.handle = handle;
       /* If full, the entry at index max_size-1 (the LRU) is dropped by the
        * shift below not preserving it. Otherwise grow by one. */
@@ -20350,6 +20825,146 @@ static Rect fromSRect(SRect rect) {
       self->entries[0] = e;
    }
    static INLINE void handle_lru_cache_clear(struct HandleLRUCache *self) { self->count = 0; }
+
+   /* Reduce Palette Range (see the "HD Reduce Palette Range" core option). Scans a
+    * texture's raw index words to find the lowest/highest CLUT index it references,
+    * so the palette hash can ignore unused CLUT entries (games often leave those as
+    * garbage or rewrite them over time). Mirrors Duckstation's ReducePaletteBounds.
+    * Returns false for non-palettised modes or empty input (caller uses full hash).
+    * min/max inclusive. */
+   static bool reduce_palette_bounds(const uint16_t *words, size_t word_count, int mode,
+         unsigned *out_min, unsigned *out_max) {
+      unsigned pal_min, pal_max;
+      size_t i;
+      if (mode == (int)TextureMode_Palette4bpp) {
+         pal_min = 15; pal_max = 0;
+         for (i = 0; i < word_count; i++) {
+            uint16_t v = words[i];
+            unsigned p0 = v & 0xf, p1 = (v >> 4) & 0xf, p2 = (v >> 8) & 0xf, p3 = (v >> 12) & 0xf;
+            if (p0 < pal_min) pal_min = p0;
+            if (p0 > pal_max) pal_max = p0;
+            if (p1 < pal_min) pal_min = p1;
+            if (p1 > pal_max) pal_max = p1;
+            if (p2 < pal_min) pal_min = p2;
+            if (p2 > pal_max) pal_max = p2;
+            if (p3 < pal_min) pal_min = p3;
+            if (p3 > pal_max) pal_max = p3;
+         }
+      } else if (mode == (int)TextureMode_Palette8bpp) {
+         pal_min = 255; pal_max = 0;
+         for (i = 0; i < word_count; i++) {
+            uint16_t v = words[i];
+            unsigned p0 = v & 0xff, p1 = (v >> 8) & 0xff;
+            if (p0 < pal_min) pal_min = p0;
+            if (p0 > pal_max) pal_max = p0;
+            if (p1 < pal_min) pal_min = p1;
+            if (p1 > pal_max) pal_max = p1;
+         }
+      } else {
+         return false; /* direct colour / no palette */
+      }
+      if (word_count == 0 || pal_min > pal_max)
+         return false;
+      *out_min = pal_min;
+      *out_max = pal_max;
+      return true;
+   }
+
+   /* CRC32 over palette[min..max] inclusive. When min==0 and max==width-1 this
+    * equals the full-palette CRC, so a texture using its whole CLUT yields an
+    * identical hash/filename to the non-reduced path (packs stay interchangeable). */
+   static uint32_t hash_partial_palette(const uint16_t *palette, unsigned min, unsigned max) {
+      return crc32(0, (const unsigned char *)(palette + min), (size_t)(max - min + 1) * sizeof(uint16_t));
+   }
+
+   /* Effective palette hash for an upload-rect texture: reduced range (option on and
+    * a valid range) else full_hash. The [min,max] scan is memoised on the upload. */
+   static uint32_t texture_tracker_effective_palette_hash_upload(struct TextureTracker *self,
+         TextureUpload *upload, int mode, const uint16_t *palette, uint32_t full_hash) {
+      if (!self->reduce_palette_range || palette == NULL)
+         return full_hash;
+      if (upload->reduce_pal_mode != mode) {
+         unsigned lo, hi;
+         if (reduce_palette_bounds(upload->image, (size_t)upload->image_count, mode, &lo, &hi)) {
+            upload->reduce_pal_min = (int)lo;
+            upload->reduce_pal_max = (int)hi;
+         } else {
+            upload->reduce_pal_min = -1;
+         }
+         upload->reduce_pal_mode = mode;
+      }
+      if (upload->reduce_pal_min < 0)
+         return full_hash;
+      return hash_partial_palette(palette, (unsigned)upload->reduce_pal_min, (unsigned)upload->reduce_pal_max);
+   }
+
+   /* Page-aligned counterpart. The [min,max] scan over the page's index words (read
+    * from vram_mirror) is memoised in cached_page_bounds keyed by (rect, page_hash). */
+   static uint32_t texture_tracker_effective_palette_hash_page(struct TextureTracker *self,
+         Rect page_rect, uint32_t page_hash, const uint16_t *palette, uint32_t full_hash) {
+      int mode;
+      int i;
+      CachedPageBounds *slot = NULL;
+      if (!self->reduce_palette_range || palette == NULL)
+         return full_hash;
+      /* Mode implied by page width: 64 = 4bpp, 128 = 8bpp (256 = direct colour). */
+      if (page_rect.width == 64)       mode = (int)TextureMode_Palette4bpp;
+      else if (page_rect.width == 128) mode = (int)TextureMode_Palette8bpp;
+      else                             return full_hash;
+
+      for (i = 0; i < self->cached_page_bounds_count; i++) {
+         if (rect_eq(&self->cached_page_bounds[i].rect, &page_rect)) {
+            slot = &self->cached_page_bounds[i];
+            break;
+         }
+      }
+      if (slot == NULL) {
+         if (self->cached_page_bounds_count == self->cached_page_bounds_cap) {
+            int ncap = self->cached_page_bounds_cap ? self->cached_page_bounds_cap * 2 : 16;
+            CachedPageBounds *nb = (CachedPageBounds*)realloc(self->cached_page_bounds,
+                  (size_t)ncap * sizeof(CachedPageBounds));
+            if (!nb)
+               return full_hash;
+            self->cached_page_bounds = nb;
+            self->cached_page_bounds_cap = ncap;
+         }
+         slot = &self->cached_page_bounds[self->cached_page_bounds_count++];
+         slot->rect = page_rect;
+         slot->hash = page_hash ^ 1u; /* guarantee a mismatch -> first compute */
+         slot->pal_min = -1;
+         slot->pal_max = -1;
+      }
+
+      if (slot->hash != page_hash) {
+         size_t n = (size_t)page_rect.width * page_rect.height;
+         uint16_t *words = (uint16_t*)malloc((n ? n : 1) * sizeof(uint16_t));
+         unsigned lo, hi;
+         unsigned j, x;
+         size_t k = 0;
+         if (!words)
+            return full_hash;
+         for (j = 0; j < page_rect.height; j++) {
+            unsigned vy = (page_rect.y + j) & (FB_HEIGHT - 1);
+            for (x = 0; x < page_rect.width; x++) {
+               unsigned vx = (page_rect.x + x) & (FB_WIDTH - 1);
+               words[k++] = self->vram_mirror[vy * FB_WIDTH + vx];
+            }
+         }
+         if (reduce_palette_bounds(words, n, mode, &lo, &hi)) {
+            slot->pal_min = (int)lo;
+            slot->pal_max = (int)hi;
+         } else {
+            slot->pal_min = -1;
+            slot->pal_max = -1;
+         }
+         slot->hash = page_hash;
+         free(words);
+      }
+
+      if (slot->pal_min < 0)
+         return full_hash;
+      return hash_partial_palette(palette, (unsigned)slot->pal_min, (unsigned)slot->pal_max);
+   }
 
    static HdTextureHandle texture_tracker_get_hd_texture_index(struct TextureTracker *self,
          Rect rect,
@@ -20367,14 +20982,29 @@ static Rect fromSRect(SRect rect) {
       /* TODO: I'm pretty sure this doesn't handle TextureMode_ABGR1555 */
 
       { uint32_t palette_hash = 0;
+      /* Reduce Palette Range needs the gathered CLUT data (not just its hash) to
+       * compute per-upload/per-page reduced hashes below. Copy it into a local
+       * because get_palette may return a pointer into the volatile palette_scratch. */
+      uint16_t pal_local[256];
+      bool have_pal_data = false;
       (*cache_hit) = false;
       if (self->hd_textures_enabled || self->dump_enabled) {
          if (mode->mode == TextureMode_Palette8bpp || mode->mode == TextureMode_Palette4bpp) {
-            palette_hash = texture_tracker_get_palette_hash(self, palette_rect);
+            if (self->reduce_palette_range) {
+               Palette p = texture_tracker_get_palette(self, palette_rect);
+               if (p.data != NULL) {
+                  palette_hash = p.hash;
+                  memcpy(pal_local, p.data, (size_t)palette_rect.width * sizeof(uint16_t));
+                  have_pal_data = true;
+               }
+            } else {
+               palette_hash = texture_tracker_get_palette_hash(self, palette_rect);
+            }
          }
       }
-      if (self->hd_textures_enabled) {
-         /* Check if the same texture as last time is used. */
+      if (self->hd_textures_enabled && !self->replacement_mode_pages) {
+         /* Check if the same texture as last time is used. (The handle cache stores
+          * non-fused upload-rect handles; page mode resolves its own way below.) */
          HandleCacheResult cache_result = handle_lru_cache_get(&self->handle_cache, rect, palette_hash);
          (*cache_hit) = cache_result.found;
          if ((*cache_hit)) {
@@ -20384,26 +21014,73 @@ static Rect fromSRect(SRect rect) {
              * rect is still alive (since HdTextureHandle's index would be -1) */
             EnduringTextureRect *tex = &self->tracker.textures.a[cache_result.handle.index]; /* Forgive me */
             if (tex->alive) {
-               (*fastpath_capable_out) = self->fastpath_enabled && ((hd_tex_map_find(&tex->texture_rect.upload->textures, palette_hash) ? hd_tex_map_find(&tex->texture_rect.upload->textures, palette_hash)->alpha_flags : 0) & ALPHA_FLAG_TRANSPARENT) == 0;
+               /* Index by the handle's own palette hash (may be a reduced-range hash),
+                * not the draw's full palette_hash. */
+               uint32_t hh = cache_result.handle.palette_hash;
+               (*fastpath_capable_out) = self->fastpath_enabled && ((hd_tex_map_find(&tex->texture_rect.upload->textures, hh) ? hd_tex_map_find(&tex->texture_rect.upload->textures, hh)->alpha_flags : 0) & ALPHA_FLAG_TRANSPARENT) == 0;
                return cache_result.handle;
             }
          }
       }
 
       { static RectIndexSet overlap = { NULL, 0, 0 };
-      rect_tracker_overlapping(&self->tracker, rect, &overlap);
+      /* A page-match-only draw needs neither the overlap set nor the upload-rect
+       * dump loop, so skip the spatial query in that common case. */
+      bool need_overlap = self->dump_enabled || (self->hd_textures_enabled && !self->replacement_mode_pages);
+      if (need_overlap)
+         rect_tracker_overlapping(&self->tracker, rect, &overlap);
 
-      /* Dump texture */
-      { int oi; for (oi = 0; oi < overlap.count; oi++) {
-         RectIndex index = overlap.items[oi];
-         TextureRect *tex = rect_tracker_get_index(&self->tracker, index);
-         {
+      /* Dump texture (upload-rect). The two folders are independent, so "Both"
+       * mode collects both pack types in a single playthrough. */
+      if (self->dump_enabled && self->dump_mode_rect) {
+         int oi; for (oi = 0; oi < overlap.count; oi++) {
+            RectIndex index = overlap.items[oi];
+            TextureRect *tex = rect_tracker_get_index(&self->tracker, index);
             DumpedMode _dm;
+            uint32_t dump_phash;
+            /* Reduce Palette Range: dump under the reduced hash (per-upload; falls
+             * back to the full hash when disabled or no valid range). */
+            dump_phash = have_pal_data
+               ? texture_tracker_effective_palette_hash_upload(self, tex->upload, (int)mode->mode, pal_local, palette_hash)
+               : palette_hash;
             _dm.mode = mode->mode;
-            _dm.palette_hash = palette_hash;
+            _dm.palette_hash = dump_phash;
             texture_tracker_dump_texture(self, tex->upload, mode, _dm);
          }
-      } }
+      }
+      /* Dump texture (page-aligned): dump the WHOLE VRAM page once per
+       * (page_hash, palette_hash). Require a real dumpable tracked upload to overlap. */
+      if (self->dump_enabled && self->dump_mode_pages) {
+         bool dumpable = false;
+         int oi;
+         for (oi = 0; oi < overlap.count; oi++) {
+            if (rect_tracker_get_index(&self->tracker, overlap.items[oi])->upload->dumpable) {
+               dumpable = true;
+               break;
+            }
+         }
+         if (dumpable && mode->mode != TextureMode_None) {
+            unsigned width
+               = mode->mode == TextureMode_Palette4bpp ? 64
+               : mode->mode == TextureMode_Palette8bpp ? 128
+               : 256;
+            Rect page_rect = { 0, 0, 0, 0 };
+            uint32_t page_hash;
+            uint32_t page_phash;
+            HdTextureId page_id;
+            page_rect.x = page_x; page_rect.y = page_y; page_rect.width = width; page_rect.height = 256;
+            page_hash = texture_tracker_hash_page_cached(self, page_rect);
+            /* Reduce Palette Range (page path): dump under the page's reduced hash. */
+            page_phash = have_pal_data
+               ? texture_tracker_effective_palette_hash_page(self, page_rect, page_hash, pal_local, palette_hash)
+               : palette_hash;
+            page_id.hash = page_hash; page_id.palette_hash = page_phash; page_id.pages = true;
+            if (!hd_key_set_contains(&self->dumped_pages, hd_pack_key(page_id))) {
+               hd_key_set_insert(&self->dumped_pages, hd_pack_key(page_id));
+               texture_tracker_dump_page(self, page_rect, page_hash, mode, page_phash);
+            }
+         }
+      }
       if (self->frame_dump != NULL) {
          if (self->frame_dump_need_comma) {
             filestream_printf(self->frame_dump, ",");
@@ -20422,26 +21099,76 @@ static Rect fromSRect(SRect rect) {
          return hd_handle_make_none();
       }
 
+      /* Page-aligned replacement: match the whole VRAM page from the -pages pack
+       * instead of per-upload rects. Bypasses the overlap/fuse path. */
+      if (self->replacement_mode_pages) {
+         unsigned width;
+         Rect page_rect = { 0, 0, 0, 0 };
+         uint32_t page_hash;
+         uint32_t page_phash;
+         HdTextureHandle page;
+         (*fastpath_capable_out) = false;
+         if (mode->mode == TextureMode_None)
+            return hd_handle_make_none();
+         width = mode->mode == TextureMode_Palette4bpp ? 64
+               : mode->mode == TextureMode_Palette8bpp ? 128 : 256;
+         page_rect.x = page_x; page_rect.y = page_y; page_rect.width = width; page_rect.height = 256;
+         page_hash = texture_tracker_hash_page_cached(self, page_rect);
+         /* Reduce Palette Range (page path): prefer the reduced hash only when a
+          * reduced page file exists, else keep the full hash (backward compatible). */
+         page_phash = palette_hash;
+         if (have_pal_data) {
+            uint32_t rh = texture_tracker_effective_palette_hash_page(self, page_rect, page_hash, pal_local, palette_hash);
+            if (rh != palette_hash) {
+               HdTextureId rid;
+               rid.hash = page_hash; rid.palette_hash = rh; rid.pages = true;
+               if (hd_key_set_contains(&self->known_files_pages, hd_pack_key(rid)))
+                  page_phash = rh;
+            }
+         }
+         page = texture_tracker_match_page(self, page_rect, page_hash, page_phash);
+         if (!hd_handle_is_none(&page) || !self->replacement_fallback)
+            return page;
+         /* Direction B fallback: page-aligned found no match. Page mode skipped the
+          * overlap query (need_overlap was false), so run it now for the upload-rect
+          * overlap/fuse loop below. */
+         rect_tracker_overlapping(&self->tracker, rect, &overlap);
+      }
+
       result = hd_handle_make_none();
 
       { int oi; for (oi = 0; oi < overlap.count; oi++) {
          RectIndex index = overlap.items[oi];
          TextureRect *tex = rect_tracker_get_index(&self->tracker, index);
-         HdTexEntry *overlapped_image = hd_tex_map_find(&tex->upload->textures, palette_hash);
+         uint32_t eff = palette_hash;
+         HdTexEntry *overlapped_image;
+         /* Reduce Palette Range: prefer this upload's reduced hash, but only if a
+          * reduced file exists on disk - else keep the full hash so existing
+          * full-palette packs still match with the option enabled. Memoised scan. */
+         if (have_pal_data) {
+            uint32_t rh = texture_tracker_effective_palette_hash_upload(self, tex->upload, (int)mode->mode, pal_local, palette_hash);
+            if (rh != palette_hash) {
+               HdTextureId rid;
+               rid.hash = tex->upload->hash; rid.palette_hash = rh; rid.pages = false;
+               if (hd_key_set_contains(&self->known_files, hd_pack_key(rid)))
+                  eff = rh;
+            }
+         }
+         overlapped_image = hd_tex_map_find(&tex->upload->textures, eff);
          if (overlapped_image == NULL) {
             /* Not bound to this upload yet. Bind it now: a GPU-cache hit binds
              * in-frame (handle copy, used by THIS draw - no 1-self->frame
              * native flicker), otherwise this schedules a decode / GPU upload
              * that lands on a later self->frame. */
-            texture_tracker_request_hd_texture(self, tex->upload, palette_hash);
-            overlapped_image = hd_tex_map_find(&tex->upload->textures, palette_hash);
+            texture_tracker_request_hd_texture(self, tex->upload, eff);
+            overlapped_image = hd_tex_map_find(&tex->upload->textures, eff);
          }
          if (overlapped_image != NULL) {
             if (hd_handle_is_none(&result)) {
                /* note that if tex->vram_rect contains rect, then it will be the only entry in overlap, so an early out would be pointless */
                result_rect = fromSRect(tex->vram_rect);
                (*fastpath_capable_out) = self->fastpath_enabled && fromSRect_contains(tex->vram_rect, rect) && (overlapped_image->alpha_flags & ALPHA_FLAG_TRANSPARENT) == 0;
-               result = hd_handle_make(index, palette_hash);
+               result = hd_handle_make(index, eff);
             } else {
                /* Multiple overlap, must fuse */
                unsigned int width
@@ -20455,6 +21182,63 @@ static Rect fromSRect(SRect rect) {
          }
       } }
 
+      /* Cross-mode fallback (Direction A): upload-rect found no HD match. Try the
+       * page-aligned (-pages) pack for this VRAM page before native. Gate on "no
+       * upload-rect FILE exists for this draw" so a texture whose replacement is just
+       * mid-load doesn't trigger a wasted page probe. Page handles are per-frame, so
+       * they MUST bypass handle_cache - return directly. */
+      if (self->replacement_fallback && !self->replacement_mode_pages && hd_handle_is_none(&result)
+            && mode->mode != TextureMode_None) {
+         bool upload_rect_has_file = false;
+         int oi;
+         for (oi = 0; oi < overlap.count; oi++) {
+            TextureRect *tex = rect_tracker_get_index(&self->tracker, overlap.items[oi]);
+            HdTextureId fid;
+            fid.hash = tex->upload->hash; fid.palette_hash = palette_hash; fid.pages = false;
+            if (hd_key_set_contains(&self->known_files, hd_pack_key(fid))) {
+               upload_rect_has_file = true;
+               break;
+            }
+            /* A reduced-range file counts too (don't trigger a wasted page probe). */
+            if (have_pal_data) {
+               uint32_t rh = texture_tracker_effective_palette_hash_upload(self, tex->upload, (int)mode->mode, pal_local, palette_hash);
+               if (rh != palette_hash) {
+                  HdTextureId rid;
+                  rid.hash = tex->upload->hash; rid.palette_hash = rh; rid.pages = false;
+                  if (hd_key_set_contains(&self->known_files, hd_pack_key(rid))) {
+                     upload_rect_has_file = true;
+                     break;
+                  }
+               }
+            }
+         }
+         if (!upload_rect_has_file) {
+            unsigned width = mode->mode == TextureMode_Palette4bpp ? 64
+                  : mode->mode == TextureMode_Palette8bpp ? 128 : 256;
+            Rect page_rect = { 0, 0, 0, 0 };
+            uint32_t page_hash;
+            uint32_t page_phash;
+            HdTextureHandle page;
+            page_rect.x = page_x; page_rect.y = page_y; page_rect.width = width; page_rect.height = 256;
+            page_hash = texture_tracker_hash_page_cached(self, page_rect);
+            page_phash = palette_hash;
+            if (have_pal_data) {
+               uint32_t rh = texture_tracker_effective_palette_hash_page(self, page_rect, page_hash, pal_local, palette_hash);
+               if (rh != palette_hash) {
+                  HdTextureId rid;
+                  rid.hash = page_hash; rid.palette_hash = rh; rid.pages = true;
+                  if (hd_key_set_contains(&self->known_files_pages, hd_pack_key(rid)))
+                     page_phash = rh;
+               }
+            }
+            page = texture_tracker_match_page(self, page_rect, page_hash, page_phash);
+            if (!hd_handle_is_none(&page)) {
+               (*fastpath_capable_out) = false;
+               return page;
+            }
+         }
+      }
+
       if (!hd_handle_is_none(&result))
          handle_lru_cache_insert(&self->handle_cache, result_rect, palette_hash, result);
       return result;
@@ -20465,6 +21249,31 @@ static Rect fromSRect(SRect rect) {
    static HdTexture texture_tracker_get_hd_texture(struct TextureTracker *self,
          HdTextureHandle handle)
    {
+      if (handle.page) {
+         /* Page-aligned replacement: resolve from this frame's page_bindings.
+          * vram_rect is the page in VRAM words; the shader maps it to the full
+          * image via (vram_rect, texel_rect={0,0,img_w,img_h}) - like the fused path. */
+         if (handle.index < 0 || handle.index >= self->page_bindings_count
+               || !ih_is_valid(&self->page_bindings[handle.index].texture)) {
+            HdTexture _r;
+            TT_LOG(RETRO_LOG_WARN, "stale page HdTextureHandle: %d\n", handle.index);
+            _r.vram_rect = (SRect){0, 0, 1, 1};
+            _r.texel_rect = (SRect){0, 0, (int)(image_get_width(ih_get(&self->default_hd_texture), 0)), (int)(image_get_height(ih_get(&self->default_hd_texture), 0))};
+            ih_copy(&_r.texture, &self->default_hd_texture); /* owned +1 (released by the consumer) */
+            return _r;
+         }
+         {
+            ReplacedPage *rp = &self->page_bindings[handle.index];
+            Image *img = ih_get(&rp->texture);
+            HdTexture _r;
+            /* Reconstruct a counted handle from the cached image (add_reference + adopt). */
+            image_add_reference(img);
+            _r.vram_rect = toSRect(rp->page_rect);
+            _r.texel_rect = (SRect){0, 0, (int)image_get_width(img, 0), (int)image_get_height(img, 0)};
+            _r.texture = ih_make(img);
+            return _r;
+         }
+      }
       if (!handle.fused)
       {
          int scaleX;
@@ -20486,7 +21295,7 @@ static Rect fromSRect(SRect rect) {
                HdTexture _r;
                _r.vram_rect = (SRect){0, 0, 1, 1};
                _r.texel_rect = (SRect){0, 0, (int)(image_get_width(ih_get(&self->default_hd_texture), 0)), (int)(image_get_height(ih_get(&self->default_hd_texture), 0))};
-               _r.texture = self->default_hd_texture;
+               ih_copy(&_r.texture, &self->default_hd_texture); /* owned +1 (released by the consumer) */
                return _r;
             }
          }
@@ -20501,7 +21310,7 @@ static Rect fromSRect(SRect rect) {
                HdTexture _r;
                _r.vram_rect = (SRect){0, 0, 1, 1};
                _r.texel_rect = (SRect){0, 0, (int)(image_get_width(ih_get(&self->default_hd_texture), 0)), (int)(image_get_height(ih_get(&self->default_hd_texture), 0))};
-               _r.texture = self->default_hd_texture;
+               ih_copy(&_r.texture, &self->default_hd_texture); /* owned +1 (released by the consumer) */
                return _r;
             }
          }
@@ -20540,9 +21349,416 @@ static bool is_power_of_two(int n) {
       return n != 0 && (n & (n - 1)) == 0;
    }
 
+   /* ===== Page-aligned experiment + Lazy(sync) function definitions (PAGE_ALIGN.md) ===== */
+
+   /* CRC32 of a VRAM page rect read from the CPU mirror. Row-by-row incremental
+    * CRC is bit-identical to CRCing one gathered buffer, so it matches -pages
+    * dumps while avoiding a malloc+copy on the common (no x-wrap) path. */
+   static uint32_t texture_tracker_hash_page(struct TextureTracker *self, Rect page_rect) {
+      uint32_t crc = 0;
+      self->dbg_page_hashes++;
+      if (page_rect.x + page_rect.width <= FB_WIDTH) {
+         unsigned j;
+         for (j = 0; j < page_rect.height; j++) {
+            unsigned vy = (page_rect.y + j) & (FB_HEIGHT - 1);
+            const uint16_t *row = &self->vram_mirror[vy * FB_WIDTH + page_rect.x];
+            crc = crc32(crc, (const unsigned char*)row, page_rect.width * sizeof(uint16_t));
+         }
+         return crc;
+      }
+      {  /* rare x-wrap: gather then CRC */
+         uint16_t *vec = (uint16_t*)malloc((size_t)page_rect.width * page_rect.height * sizeof(uint16_t));
+         unsigned j, i;
+         size_t k = 0;
+         for (j = 0; j < page_rect.height; j++) {
+            unsigned vy = (page_rect.y + j) & (FB_HEIGHT - 1);
+            for (i = 0; i < page_rect.width; i++) {
+               unsigned vx = (page_rect.x + i) & (FB_WIDTH - 1);
+               vec[k++] = self->vram_mirror[vy * FB_WIDTH + vx];
+            }
+         }
+         crc = crc32(0, (unsigned char*)vec, (size_t)page_rect.width * page_rect.height * sizeof(uint16_t));
+         free(vec);
+         return crc;
+      }
+   }
+
+   /* Memoized page hash: re-CRC only if the page was written since last hash AND
+    * not already refreshed this frame (caps busy regions to one re-hash/page/frame). */
+   static uint32_t texture_tracker_hash_page_cached(struct TextureTracker *self, Rect page_rect) {
+      int i;
+      for (i = 0; i < self->cached_page_hashes_count; i++) {
+         CachedPageHash *c = &self->cached_page_hashes[i];
+         if (rect_eq(&c->rect, &page_rect)) {
+            if (c->dirty && c->hashed_frame != self->frame) {
+               c->hash = texture_tracker_hash_page(self, page_rect);
+               c->dirty = false;
+               c->hashed_frame = self->frame;
+            }
+            return c->hash;
+         }
+      }
+      {
+         uint32_t h = texture_tracker_hash_page(self, page_rect);
+         if (self->cached_page_hashes_count == self->cached_page_hashes_cap) {
+            int ncap = self->cached_page_hashes_cap ? self->cached_page_hashes_cap * 2 : 16;
+            self->cached_page_hashes = (CachedPageHash*)realloc(self->cached_page_hashes, (size_t)ncap * sizeof(CachedPageHash));
+            self->cached_page_hashes_cap = ncap;
+         }
+         {
+            CachedPageHash *c = &self->cached_page_hashes[self->cached_page_hashes_count++];
+            c->rect = page_rect; c->hash = h; c->dirty = false; c->hashed_frame = self->frame;
+         }
+         return h;
+      }
+   }
+
+   /* Drop (mark dirty) memoized page hashes whose page overlaps a written VRAM rect. */
+   static void texture_tracker_invalidate_page_hashes(struct TextureTracker *self, Rect written) {
+      int i;
+      bool all;
+      if (self->cached_page_hashes_count == 0)
+         return;
+      all = (written.x + written.width > FB_WIDTH || written.y + written.height > FB_HEIGHT);
+      for (i = 0; i < self->cached_page_hashes_count; i++) {
+         if (all || rect_intersects(&self->cached_page_hashes[i].rect, &written))
+            self->cached_page_hashes[i].dirty = true;
+      }
+   }
+
+   /* --- VRAM mirror helpers. All x/y wrap to match the live VRAM access pattern. --- */
+   static void texture_tracker_mirror_store(struct TextureTracker *self, Rect rect, const uint16_t *vram) {
+      unsigned j, i;
+      texture_tracker_invalidate_page_hashes(self, rect);
+      for (j = rect.y; j < rect.y + rect.height; j++) {
+         unsigned my = j & (FB_HEIGHT - 1);
+         for (i = rect.x; i < rect.x + rect.width; i++) {
+            unsigned mx = i & (FB_WIDTH - 1);
+            self->vram_mirror[my * FB_WIDTH + mx] = vram[my * FB_WIDTH + mx];
+         }
+      }
+   }
+   static void texture_tracker_mirror_blit(struct TextureTracker *self, Rect dst, Rect src) {
+      uint16_t *tmp;
+      unsigned j, i;
+      texture_tracker_invalidate_page_hashes(self, dst);
+      /* copy src to a temp first so overlapping src/dst can't read overwritten cells */
+      tmp = (uint16_t*)malloc((size_t)src.width * src.height * sizeof(uint16_t));
+      for (j = 0; j < src.height; j++) {
+         unsigned sy = (src.y + j) & (FB_HEIGHT - 1);
+         for (i = 0; i < src.width; i++) {
+            unsigned sx = (src.x + i) & (FB_WIDTH - 1);
+            tmp[j * src.width + i] = self->vram_mirror[sy * FB_WIDTH + sx];
+         }
+      }
+      for (j = 0; j < dst.height; j++) {
+         unsigned dy = (dst.y + j) & (FB_HEIGHT - 1);
+         for (i = 0; i < dst.width; i++) {
+            unsigned dx = (dst.x + i) & (FB_WIDTH - 1);
+            self->vram_mirror[dy * FB_WIDTH + dx] = tmp[j * dst.width + i];
+         }
+      }
+      free(tmp);
+   }
+   static void texture_tracker_mirror_fill(struct TextureTracker *self, Rect rect, uint16_t value) {
+      unsigned j, i;
+      texture_tracker_invalidate_page_hashes(self, rect);
+      for (j = rect.y; j < rect.y + rect.height; j++) {
+         unsigned my = j & (FB_HEIGHT - 1);
+         for (i = rect.x; i < rect.x + rect.width; i++)
+            self->vram_mirror[my * FB_WIDTH + (i & (FB_WIDTH - 1))] = value;
+      }
+   }
+
+   /* Decode a FULL VRAM texture page from the mirror via the active palette and
+    * queue a PNG to <cd>-texture-dump-pages/. Snapshots raw words; the IO worker
+    * decodes off-thread (decode_dump_rgba). */
+   static void texture_tracker_dump_page(struct TextureTracker *self, Rect page_rect, uint32_t page_hash, UsedMode *mode, uint32_t palette_hash) {
+      int shift;
+      int ppp;
+      uint16_t *palette = NULL;
+      char dir[PATH_MAX_TT];
+      char path[PATH_MAX_TT];
+      uint16_t *src;
+      size_t src_len;
+      unsigned j, i;
+      size_t k;
+      switch (mode->mode) {
+         case TextureMode_ABGR1555:    shift = 0; break;
+         case TextureMode_Palette8bpp: shift = 1; break;
+         case TextureMode_Palette4bpp: shift = 2; break;
+         case TextureMode_None:
+         default: return;
+      }
+      if (mode->mode == TextureMode_Palette4bpp || mode->mode == TextureMode_Palette8bpp) {
+         Rect palette_rect = make_rect(mode->palette_offset_x, mode->palette_offset_y, mode->mode == TextureMode_Palette8bpp ? 256 : 16, 1);
+         Palette p = texture_tracker_get_palette(self, palette_rect);
+         if (p.data != NULL)
+            palette = p.data;
+      }
+      ppp = 1 << shift;
+      src_len = (size_t)page_rect.width * page_rect.height;
+      src = (uint16_t*)malloc((src_len ? src_len : 1) * sizeof(uint16_t));
+      k = 0;
+      for (j = 0; j < page_rect.height; j++) {
+         unsigned vy = (page_rect.y + j) & (FB_HEIGHT - 1);
+         for (i = 0; i < page_rect.width; i++) {
+            unsigned vx = (page_rect.x + i) & (FB_WIDTH - 1);
+            src[k++] = self->vram_mirror[vy * FB_WIDTH + vx];
+         }
+      }
+      dump_pages_path(dir, sizeof(dir));
+      {
+         static bool pages_dir_made = false;
+         if (!pages_dir_made) { ensure_directory(dir); pages_dir_made = true; }
+      }
+      if (mode->mode != TextureMode_ABGR1555 && palette == NULL)
+         snprintf(path, sizeof(path), "%s%x-missing.png", dir, (unsigned)page_hash);
+      else
+         snprintf(path, sizeof(path), "%s%x-%x.png", dir, (unsigned)page_hash, (unsigned)palette_hash);
+      {
+         IORequest *dump = (IORequest *)malloc(sizeof(IORequest));
+         dump->next = NULL;
+         dump->kind = IORequestKind_Dump;
+         snprintf(dump->path, sizeof(dump->path), "%s", path);
+         dump->width  = (int)(page_rect.width * ppp);
+         dump->height = (int)page_rect.height;
+         dump->pages  = true;
+         dump->dump_mode = (int)mode->mode;
+         dump->ppp    = ppp;
+         dump->src = src; dump->src_len = src_len;
+         if (palette != NULL) {
+            dump->palette_len = (size_t)(mode->mode == TextureMode_Palette8bpp ? 256 : 16);
+            dump->palette = (uint16_t*)malloc(dump->palette_len * sizeof(uint16_t));
+            memcpy(dump->palette, palette, dump->palette_len * sizeof(uint16_t));
+         } else {
+            dump->palette = NULL; dump->palette_len = 0;
+         }
+         slock_lock(self->iothread.channel->lock);
+         io_channel_push_request(self->iothread.channel, dump);
+         slock_unlock(self->iothread.channel->lock);
+         scond_signal(self->iothread.channel->cond);
+      }
+   }
+
+   /* Auto-create the dump/replacement folder(s) for the active features + modes at
+    * the HD-Texture-Folder location. Only mkdirs when the target path changes. */
+   static void texture_tracker_ensure_directories(struct TextureTracker *self, bool dump, bool replace) {
+      char buf[PATH_MAX_TT];
+      if (retro_cd_base_name[0] == '\0')
+         return; /* no game loaded yet - paths would be malformed */
+      if (dump && self->dump_mode_rect) dump_path(buf, sizeof(buf)); else buf[0] = '\0';
+      if (strcmp(buf, self->ensured_dump_dir) != 0) {
+         if (buf[0]) ensure_directory(buf);
+         snprintf(self->ensured_dump_dir, sizeof(self->ensured_dump_dir), "%s", buf);
+      }
+      if (dump && self->dump_mode_pages) dump_pages_path(buf, sizeof(buf)); else buf[0] = '\0';
+      if (strcmp(buf, self->ensured_dump_pages_dir) != 0) {
+         if (buf[0]) ensure_directory(buf);
+         snprintf(self->ensured_dump_pages_dir, sizeof(self->ensured_dump_pages_dir), "%s", buf);
+      }
+      if (replace) {
+         if (self->replacement_mode_pages) replacements_pages_path(buf, sizeof(buf));
+         else                              replacements_path(buf, sizeof(buf));
+      } else buf[0] = '\0';
+      if (strcmp(buf, self->ensured_replace_dir) != 0) {
+         if (buf[0]) ensure_directory(buf);
+         snprintf(self->ensured_replace_dir, sizeof(self->ensured_replace_dir), "%s", buf);
+      }
+   }
+
+   /* Lazy (synchronous) upload-rect load: disk+decode+GPU upload+bind inline. */
+   static void texture_tracker_sync_load_combo(struct TextureTracker *self, TextureUpload *upload, uint32_t palette_hash) {
+      HdTextureId id;
+      CachedHdImage *cpu;
+      ImageHandle texture;
+      id.hash = upload->hash; id.palette_hash = palette_hash; id.pages = false;
+      cpu = HdImageCache_get(&self->hd_cache, hd_pack_key(id));
+      if (cpu == NULL) {
+         char path[PATH_MAX_TT];
+         RGBAImage image;
+         int alpha_flags = 0;
+         LoadedLevels levels;
+         int width, height;
+         if (hd_key_set_contains(&self->requested, hd_pack_key(id)))
+            return;
+         if (!hd_key_set_contains(&self->known_files, hd_pack_key(id))) {
+            hd_key_set_insert(&self->requested, hd_pack_key(id));
+            return;
+         }
+         replacement_filename_from_hash(path, sizeof(path), id.hash, id.palette_hash);
+         image.data = NULL;
+         load_image(path, &image);
+         if (image.data == NULL) {
+            TT_LOG(RETRO_LOG_ERROR, "sync load failed: %s\n", path);
+            hd_key_set_insert(&self->requested, hd_pack_key(id));
+            return;
+         }
+         levels = prepare_texture(&image, &alpha_flags);
+         width  = levels.levels[0].width;
+         height = levels.levels[0].height;
+         if (!(width % upload->width == 0 && is_power_of_two(width / upload->width) &&
+               height % upload->height == 0 && is_power_of_two(height / upload->height))) {
+            TT_LOG(RETRO_LOG_WARN, "Dimension mismatch (sync) for %x-%x, original=%dx%d, replacement=%dx%d\n",
+                   id.hash, id.palette_hash, upload->width, upload->height, width, height);
+            loaded_levels_reset(&levels);
+            rgba_image_free(&image);
+            hd_key_set_insert(&self->requested, hd_pack_key(id));
+            return;
+         }
+         hd_image_cache_put(&self->hd_cache, id, &levels, alpha_flags);
+         rgba_image_free(&image);
+         self->dbg_responses_received++;
+         cpu = HdImageCache_get(&self->hd_cache, hd_pack_key(id));
+      }
+      texture = renderer_upload_texture(self->uploader, &cpu->levels);
+      hd_gpu_cache_put(&self->hd_gpu_cache, id, texture, cpu->alpha_flags, cpu->bytes);
+      self->dbg_gpu_uploads++;
+      hd_tex_map_set(&upload->textures, palette_hash, ih_get(&texture), cpu->alpha_flags);
+      ih_reset(&texture);
+      self->dbg_attaches++;
+      {
+         int ti;
+         for (ti = 0; ti < self->tracker.textures.count; ti++) {
+            EnduringTextureRect *e = &self->tracker.textures.a[ti];
+            if (e->alive && e->texture_rect.upload == upload)
+               fused_pages_mark_dirty(&self->fused_pages, fromSRect(e->texture_rect.vram_rect));
+         }
+      }
+   }
+
+   /* Lazy-sync page load: disk+decode+GPU upload inline; lands in the shared cache
+    * keyed by {page_hash, palette, pages=true}; no per-upload bind. */
+   static void texture_tracker_sync_load_page(struct TextureTracker *self, HdTextureId id) {
+      CachedHdImage *cpu;
+      ImageHandle texture;
+      if (HdGpuCache_contains(&self->hd_gpu_cache, hd_pack_key(id)))
+         return;
+      cpu = HdImageCache_get(&self->hd_cache, hd_pack_key(id));
+      if (cpu == NULL) {
+         char path[PATH_MAX_TT];
+         RGBAImage image;
+         int alpha_flags = 0;
+         LoadedLevels levels;
+         if (hd_key_set_contains(&self->requested, hd_pack_key(id)))
+            return;
+         if (!hd_key_set_contains(&self->known_files_pages, hd_pack_key(id))) {
+            hd_key_set_insert(&self->requested, hd_pack_key(id));
+            return;
+         }
+         replacement_pages_filename_from_hash(path, sizeof(path), id.hash, id.palette_hash);
+         image.data = NULL;
+         load_image(path, &image);
+         if (image.data == NULL) {
+            TT_LOG(RETRO_LOG_ERROR, "sync page load failed: %s\n", path);
+            hd_key_set_insert(&self->requested, hd_pack_key(id));
+            return;
+         }
+         levels = prepare_texture(&image, &alpha_flags);
+         hd_image_cache_put(&self->hd_cache, id, &levels, alpha_flags);
+         rgba_image_free(&image);
+         self->dbg_responses_received++;
+         cpu = HdImageCache_get(&self->hd_cache, hd_pack_key(id));
+      }
+      texture = renderer_upload_texture(self->uploader, &cpu->levels);
+      hd_gpu_cache_put(&self->hd_gpu_cache, id, texture, cpu->alpha_flags, cpu->bytes);
+      ih_reset(&texture);
+      self->dbg_gpu_uploads++;
+   }
+
+   /* Draw-time page resolve: GPU-cache hit -> bind this frame; else load per the
+    * caching method (lazy_sync inline, else async high-priority) and native this frame. */
+   static HdTextureHandle texture_tracker_match_page(struct TextureTracker *self, Rect page_rect, uint32_t page_hash, uint32_t palette_hash) {
+      HdTextureId id;
+      CachedGpuImage *gpu;
+      id.hash = page_hash; id.palette_hash = palette_hash; id.pages = true;
+      gpu = HdGpuCache_get(&self->hd_gpu_cache, hd_pack_key(id));
+      if (gpu == NULL) {
+         if (self->lazy_sync) {
+            texture_tracker_sync_load_page(self, id);
+            gpu = HdGpuCache_get(&self->hd_gpu_cache, hd_pack_key(id));
+         } else if (HdImageCache_contains(&self->hd_cache, hd_pack_key(id))) {
+            /* decoded; GPU upload at on_queues_reset. Store the BASE (unsalted) key
+             * so the page attach pass can unpack hash/palette. */
+            hd_key_set_insert(&self->pending_attach_pages, ((uint64_t)id.hash << 32) | (uint64_t)id.palette_hash);
+         } else {
+            texture_tracker_want_combo(self, id, true, true); /* on-demand page disk load (high priority) */
+         }
+      }
+      if (gpu == NULL) {
+         self->dbg_page_miss++;
+         return hd_handle_make_none(); /* native this frame */
+      }
+      if (self->page_bindings_count == self->page_bindings_cap) {
+         int ncap = self->page_bindings_cap ? self->page_bindings_cap * 2 : 16;
+         self->page_bindings = (ReplacedPage*)realloc(self->page_bindings, (size_t)ncap * sizeof(ReplacedPage));
+         self->page_bindings_cap = ncap;
+      }
+      {
+         ReplacedPage *rp = &self->page_bindings[self->page_bindings_count];
+         rp->page_rect = page_rect;
+         rp->texture = hd_gpu_image_handle(gpu); /* +1 counted handle owned by page_bindings */
+         rp->alpha_flags = gpu->alpha_flags;
+      }
+      self->dbg_page_binds++;
+      {
+         int idx = self->page_bindings_count;
+         self->page_bindings_count++;
+         return hd_handle_make_page((RectIndex)idx, palette_hash);
+      }
+   }
+
+   /* Release every per-upload HD binding (upload->textures). Each entry holds an
+    * image_add_reference on a GPU-cache image, so persistent bindings would pin VRAM
+    * outside the budget. Clearing them per frame (below) makes the budgeted GPU cache
+    * the sole persistent VRAM owner: the draw path re-binds on-screen combos each
+    * frame via request_hd_texture -> HdGpuCache_get (which touches the LRU), so drawn
+    * textures stay hot and off-screen ones age out and free their VRAM. */
+   static void texture_tracker_clear_all_upload_bindings(struct TextureTracker *self) {
+      int _ti;
+      int _rri;
+      for (_ti = 0; _ti < self->tracker.textures.count; _ti++)
+         hd_tex_map_clear(&self->tracker.textures.a[_ti].texture_rect.upload->textures);
+      for (_rri = 0; _rri < rrvec_size(&self->restorable_rects); _rri++) {
+         RestorableRect *restorable = &self->restorable_rects.items[_rri];
+         int _tri;
+         for (_tri = 0; _tri < ownedrects_size(&restorable->to_restore); _tri++)
+            hd_tex_map_clear(&restorable->to_restore.v.items[_tri].upload->textures);
+      }
+   }
+
+   /* Drop ALL resident HD state and free its VRAM (GPU + RAM caches, in-flight/pending
+    * loads, page bindings, per-upload bindings, fused pages). Used when HD replacement
+    * is turned off so VRAM is reclaimed immediately (does NOT re-scan folders). */
+   static void texture_tracker_flush_hd_state(struct TextureTracker *self) {
+      int i;
+      Rect _mdr;
+      texture_tracker_clear_all_upload_bindings(self);
+      HdGpuCache_clear(&self->hd_gpu_cache);
+      HdImageCache_clear(&self->hd_cache);
+      hd_key_set_clear(&self->requested);
+      hd_key_set_clear(&self->pending_attach);
+      hd_key_set_clear(&self->pending_attach_pages);
+      for (i = 0; i < self->page_bindings_count; i++)
+         ih_reset(&self->page_bindings[i].texture);
+      self->page_bindings_count = 0;
+      _mdr.x = 0; _mdr.y = 0; _mdr.width = FB_WIDTH; _mdr.height = FB_HEIGHT;
+      fused_pages_mark_dead(&self->fused_pages, _mdr);
+      fused_pages_remove_dead(&self->fused_pages); /* actually free the fused-page VRAM now */
+   }
+
    /* TEMPORARY: */
    static void texture_tracker_on_queues_reset(struct TextureTracker *self) {
+      uint64_t up0 = self->dbg_gpu_uploads; /* GPU uploads done by THIS reset (per-frame burst detector) */
       handle_lru_cache_clear(&self->handle_cache);
+      /* page handles don't survive a queue reset (same contract as handle_cache) */
+      { int i; for (i = 0; i < self->page_bindings_count; i++) ih_reset(&self->page_bindings[i].texture); }
+      self->page_bindings_count = 0;
+      /* NOTE: upload->textures bindings are intentionally NOT cleared here. They hold
+       * a shared (ref-counted) copy of the cache's image - not separate VRAM - so
+       * clearing them per frame frees no VRAM, adds heavy re-attach churn, and breaks
+       * handle resolution across a mid-frame queue flush (stale-handle floods). They
+       * are released only on eviction/reload/flush. */
       rect_tracker_releaseDeadHandles(&self->tracker); /* This is called from reset_queue, so as of now no HdTextureHandle's exist */
 
       /* Poll HD uploads */
@@ -20563,9 +21779,14 @@ static bool is_power_of_two(int n) {
             self->dbg_responses_received++;
             id.hash = response->hash;
             id.palette_hash = response->palette_hash;
+            id.pages = response->pages;
             hd_key_set_erase(&self->requested, hd_pack_key(id)); /* no longer in flight; now cached */
             hd_image_cache_put(&self->hd_cache, id, &response->levels, response->alpha_flags);
-            hd_key_set_insert(&self->pending_attach, hd_pack_key(id));
+            if (response->pages)
+               /* page combo: store the BASE (unsalted) key so the page attach pass can unpack it */
+               hd_key_set_insert(&self->pending_attach_pages, ((uint64_t)id.hash << 32) | (uint64_t)id.palette_hash);
+            else
+               hd_key_set_insert(&self->pending_attach, hd_pack_key(id));
             io_response_free(response); /* levels already moved out (now empty) */
             response = rnext;
          }
@@ -20584,6 +21805,7 @@ static bool is_power_of_two(int n) {
             HdTextureId id;
             id.hash = (uint32_t)(self->pending_attach.keys[pi] >> 32);
             id.palette_hash = (uint32_t)self->pending_attach.keys[pi];
+            id.pages = false;
             { TextureUpload *upload = texture_tracker_find_upload(self, id.hash); /* borrowed */
             if (upload == NULL)
                continue; /* not resident yet; kept in cache */
@@ -20640,8 +21862,43 @@ static bool is_power_of_two(int n) {
       }
       hd_key_set_clear(&self->pending_attach);
 
+      /* Page attach pass: page combos have no TextureUpload to bind to - they're
+       * resolved at draw time from the GPU cache. So this only promotes decoded CPU
+       * levels into the GPU cache; match_page binds from there on a later frame. (No
+       * dimension check: the page binding maps vram_rect to the image proportionally.)
+       * pending_attach_pages stores BASE keys; rebuild the salted id to hit the cache. */
+      {
+         int pi;
+         for (pi = 0; pi < self->pending_attach_pages.count; pi++) {
+            HdTextureId id;
+            CachedHdImage *cached;
+            id.hash = (uint32_t)(self->pending_attach_pages.keys[pi] >> 32);
+            id.palette_hash = (uint32_t)self->pending_attach_pages.keys[pi];
+            id.pages = true;
+            if (HdGpuCache_contains(&self->hd_gpu_cache, hd_pack_key(id)))
+               continue; /* already resident */
+            cached = HdImageCache_get(&self->hd_cache, hd_pack_key(id));
+            if (cached == NULL)
+               continue; /* evicted before upload; re-requested on next draw */
+            {
+               ImageHandle texture = renderer_upload_texture(self->uploader, &cached->levels);
+               hd_gpu_cache_put(&self->hd_gpu_cache, id, texture, cached->alpha_flags, cached->bytes);
+               ih_reset(&texture); /* gpu cache holds the surviving ref */
+               self->dbg_gpu_uploads++;
+            }
+         }
+      }
+      hd_key_set_clear(&self->pending_attach_pages);
+
       fused_pages_rebuild_dirty(&self->fused_pages, &self->tracker, self->uploader);
-      fused_pages_remove_dead(&self->fused_pages);
+      fused_pages_evict(&self->fused_pages);      /* LRU-evict to budget (marks dead) */
+      fused_pages_remove_dead(&self->fused_pages); /* free the marked-dead pages' VRAM */
+
+      {
+         uint64_t this_reset_uploads = self->dbg_gpu_uploads - up0;
+         if (this_reset_uploads > self->dbg_gpu_uploads_peak)
+            self->dbg_gpu_uploads_peak = this_reset_uploads;
+      }
       }
    }
    static TextureUpload *texture_tracker_find_upload(struct TextureTracker *self, uint32_t hash) {
@@ -20667,6 +21924,10 @@ static bool is_power_of_two(int n) {
       return NULL;
    }
 
+   /* Defined in libretro.c; declared here so endFrame() can post an OSD toast on the
+    * ']' HD-replacement toggle (the cbs header is #included far below this point). */
+   extern retro_environment_t environ_cb;
+
    static void texture_tracker_endFrame(struct TextureTracker *self) {
       self->frame += 1;
 
@@ -20675,17 +21936,39 @@ static bool is_power_of_two(int n) {
          TT_LOG_VERBOSE(RETRO_LOG_INFO, "hit ratio: %f (%ld, %ld)\n", (double)(self->handle_cache.dbg_hits) / (self->handle_cache.dbg_hits + self->handle_cache.dbg_misses), self->handle_cache.dbg_hits, self->handle_cache.dbg_misses);
          self->handle_cache.dbg_hits = 0;
          self->handle_cache.dbg_misses = 0;
-         TT_LOG(RETRO_LOG_INFO, "[hdcache] last 300f: %llu decodes, %llu gpu-uploads, %llu attaches\n",
+         TT_LOG(RETRO_LOG_INFO, "[hdcache] last 300f: %llu decodes, %llu gpu-uploads (peak %llu/frame), %llu attaches\n",
                (unsigned long long)(self->dbg_responses_received - self->dbg_responses_received_last),
                (unsigned long long)(self->dbg_gpu_uploads - self->dbg_gpu_uploads_last),
+               (unsigned long long)self->dbg_gpu_uploads_peak,
                (unsigned long long)(self->dbg_attaches - self->dbg_attaches_last));
-         TT_LOG(RETRO_LOG_INFO, "[hdcache] mode=%s ; ram %zu/%zu MB (%zu entries) ; vram %zu/%zu MB (%zu entries)\n",
-               self->eager_textures ? "eager" : "lazy",
+         TT_LOG(RETRO_LOG_INFO, "[hdcache] mode=%s ; replace=%s ; ram %zu/%zu MB (%zu entries) ; vram %zu/%zu MB (%zu entries)\n",
+               self->eager_textures ? "eager" : (self->lazy_sync ? "lazy-sync" : "lazy"),
+               self->replacement_mode_pages ? "page" : "upload-rect",
                HdImageCache_size_bytes(&self->hd_cache) / (1024 * 1024), HdImageCache_budget(&self->hd_cache) / (1024 * 1024), HdImageCache_count(&self->hd_cache),
                HdGpuCache_size_bytes(&self->hd_gpu_cache) / (1024 * 1024), HdGpuCache_budget(&self->hd_gpu_cache) / (1024 * 1024), HdGpuCache_count(&self->hd_gpu_cache));
+         {  /* Fused-page composites are a separate VRAM tier NOT counted in the vram figure above. */
+            int64_t _fused_bytes = 0;
+            int _fi;
+            for (_fi = 0; _fi < fused_page_vec_size(&self->fused_pages.pages); _fi++)
+               _fused_bytes += page_bytes(&fused_page_vec_at(&self->fused_pages.pages, _fi)->fusion);
+            TT_LOG(RETRO_LOG_INFO, "[hdcache] fused: %d pages, %.1f MiB\n",
+                  fused_page_vec_size(&self->fused_pages.pages), _fused_bytes / 1048576.0);
+         }
+         if (self->replacement_mode_pages || self->replacement_fallback) {
+            TT_LOG(RETRO_LOG_INFO, "[hdcache] pages(%s): %llu binds, %llu native-misses, %llu page-CRCs (last 300f); memo %d entries\n",
+                  self->replacement_mode_pages ? "mode" : "fallback",
+                  (unsigned long long)(self->dbg_page_binds - self->dbg_page_binds_last),
+                  (unsigned long long)(self->dbg_page_miss - self->dbg_page_miss_last),
+                  (unsigned long long)(self->dbg_page_hashes - self->dbg_page_hashes_last),
+                  self->cached_page_hashes_count);
+         }
          self->dbg_responses_received_last = self->dbg_responses_received;
          self->dbg_gpu_uploads_last = self->dbg_gpu_uploads;
+         self->dbg_gpu_uploads_peak = 0;
          self->dbg_attaches_last = self->dbg_attaches;
+         self->dbg_page_binds_last = self->dbg_page_binds;
+         self->dbg_page_miss_last = self->dbg_page_miss;
+         self->dbg_page_hashes_last = self->dbg_page_hashes;
       }
 
       if (self->frame_dump != NULL) {
@@ -20731,8 +22014,30 @@ static bool is_power_of_two(int n) {
          }
 
          if (dbg_hotkey_query(&self->hd_toggle_key)) {
+            /* Snapshot HD VRAM-cache stats BEFORE any flush, so toggling OFF reports
+             * what was actually resident. Shown ON-SCREEN (bypasses RetroArch's core
+             * log-level filtering) and doubles as a build-freshness check: if you see
+             * this new "cache .../... MB" format, the VRAM-fix build is definitely live. */
+            size_t vram_used   = HdGpuCache_size_bytes(&self->hd_gpu_cache) / (1024 * 1024);
+            size_t vram_budget = HdGpuCache_budget(&self->hd_gpu_cache) / (1024 * 1024);
+            size_t vram_count  = HdGpuCache_count(&self->hd_gpu_cache);
+            int    fused_count = fused_page_vec_size(&self->fused_pages.pages);
             self->hd_textures_enabled = !self->hd_textures_enabled;
+            if (!self->hd_textures_enabled)
+               texture_tracker_flush_hd_state(self); /* free HD VRAM immediately when turned off */
             TT_LOG_VERBOSE(RETRO_LOG_INFO, "Toggling hd textures: %s\n", self->hd_textures_enabled ? "on" : "off");
+            if (environ_cb) {
+               static char hd_msgbuf[256];
+               struct retro_message msg;
+               snprintf(hd_msgbuf, sizeof(hd_msgbuf),
+                     "HD %s | cache %lu/%lu MB, %lu tex, %d fused",
+                     self->hd_textures_enabled ? "ON" : "OFF",
+                     (unsigned long)vram_used, (unsigned long)vram_budget,
+                     (unsigned long)vram_count, fused_count);
+               msg.msg    = hd_msgbuf;
+               msg.frames = 300; /* ~5s at 60fps */
+               environ_cb(RETRO_ENVIRONMENT_SET_MESSAGE, &msg);
+            }
          }
 
          if (dbg_hotkey_query(&self->reload_key)) {
@@ -20767,15 +22072,27 @@ static bool is_power_of_two(int n) {
 
    static void texture_tracker_reload_textures_from_disk(struct TextureTracker *self) {
       char rpath[PATH_MAX_TT];
+      char cfg[PATH_MAX_TT];
       /* Reload the directory listing */
-      read_texture_directory(&self->known_files, replacements_path(rpath, sizeof(rpath)));
+      read_texture_directory(&self->known_files, replacements_path(rpath, sizeof(rpath)), false);
       TT_LOG_VERBOSE(RETRO_LOG_INFO, "Found %d hd textures\n", (int)self->known_files.count);
+
+      /* Page-aligned experiment: reload the -pages listing too. */
+      read_texture_directory(&self->known_files_pages, replacements_pages_path(rpath, sizeof(rpath)), true);
+
+      /* Re-read the dump-ignore list from the (possibly relocated) dump folder. */
+      dump_path(cfg, sizeof(cfg));
+      snprintf(cfg + strlen(cfg), sizeof(cfg) - strlen(cfg), "/dump.cfg");
+      self->dump_ignore_count = parse_config_file(cfg, self->dump_ignore, DUMP_IGNORE_MAX);
 
       /* Drop all cached / loaded HD state so edited files on disk take effect. */
       HdGpuCache_clear(&self->hd_gpu_cache);
       HdImageCache_clear(&self->hd_cache);
       hd_key_set_clear(&self->requested);
       hd_key_set_clear(&self->pending_attach);
+      hd_key_set_clear(&self->pending_attach_pages);
+      self->cached_page_hashes_count = 0;
+      self->cached_page_bounds_count = 0;
       { int _ti; for (_ti = 0; _ti < self->tracker.textures.count; _ti++) {
          EnduringTextureRect *texture = &self->tracker.textures.a[_ti];
          hd_tex_map_clear(&texture->texture_rect.upload->textures);
@@ -21368,7 +22685,7 @@ static int64_t page_bytes(FusionRects *fusion)
          TT_LOG(RETRO_LOG_WARN, "BAD fused index!\n");
          _r.vram_rect = (SRect){0, 0, 1, 1};
          _r.texel_rect = (SRect){0, 0, (int)(image_get_width(ih_get(default_hd_texture), 0)), (int)(image_get_height(ih_get(default_hd_texture), 0))};
-         _r.texture = *default_hd_texture;
+         ih_copy(&_r.texture, default_hd_texture); /* owned +1 (released by the consumer) */
          return _r;
       }
       page = fused_page_vec_at(&self->pages, handle.index);
@@ -21377,14 +22694,14 @@ static int64_t page_bytes(FusionRects *fusion)
          TT_LOG(RETRO_LOG_WARN, "Missing fused texture!\n");
          _r.vram_rect = (SRect){0, 0, 1, 1};
          _r.texel_rect = (SRect){0, 0, (int)(image_get_width(ih_get(default_hd_texture), 0)), (int)(image_get_height(ih_get(default_hd_texture), 0))};
-         _r.texture = *default_hd_texture;
+         ih_copy(&_r.texture, default_hd_texture); /* owned +1 (released by the consumer) */
          return _r;
       }
       {
          HdTexture _r;
          _r.vram_rect = toSRect(page->fusion.vram_rect);
          _r.texel_rect = (SRect){ 0, 0, (int)(image_get_width(ih_get(&page->texture), 0)), (int)(image_get_height(ih_get(&page->texture), 0)) };
-         _r.texture = page->texture;
+         ih_copy(&_r.texture, &page->texture); /* owned +1 (released by the consumer) */
          return _r;
       }
    }
@@ -21400,31 +22717,36 @@ static int64_t page_bytes(FusionRects *fusion)
       {
          FusedPage *p = fused_page_vec_at(&self->pages, x);
          /* return page */
-         if (!p->dead && p->palette == palette && rect_eq(&p->full_page_rect, &page_rect))
+         if (!p->dead && p->palette == palette && rect_eq(&p->full_page_rect, &page_rect)) {
+            p->last_used = ++self->tick; /* touch LRU */
             return hd_handle_make_fused(x);
+         }
       }
 
       /* Make a new fused page */
       TT_LOG_VERBOSE(RETRO_LOG_INFO, "Creating new fused page for palette %x\n", palette);
 
-      /* Initialise the handle and fusion to a valid empty state before
-       * rebuild_page reads them: it tests ih_is_valid(&page->texture) then
-       * dereferences via image_get_width, and fusionrects_eq/_move touch
-       * page->fusion.rects.  The C++->C conversion dropped FusedPage's
-       * default member initialisers, so these were left indeterminate; at
-       * -O2/-O3 the garbage texture handle (observed 0xffffffff) passes
-       * ih_is_valid and crashes in image_get_width. */
-      page.texture = ih_make(NULL);   /* null handle -> ih_is_valid() false -> rebuild_page creates a fresh texture */
-      fusionrects_init(&page.fusion); /* empty rects + zeroed vram_rect/scaleX/scaleY (never spuriously eq to a real fusion) */
+      /* `page` is a raw stack FusedPage: its handle/heap-owning members MUST be
+       * initialised before rebuild_page reads them. rebuild_page checks
+       * ih_is_valid(&page->texture) (so texture must be a NULL handle, not garbage)
+       * and compares page->fusion via fusionrects_eq (so fusion.rects must be a
+       * valid empty vec). Leaving them uninitialised reads as zero at -O0 (safe) but
+       * garbage at -O3 (texture.data=0xffffffff -> ih_is_valid true -> deref crash). */
+      page.texture = ih_make(NULL);
+      fp_init_raw(&page); /* fusion.rects -> empty */
+      page.fusion.vram_rect = make_rect(0, 0, 0, 0);
+      page.fusion.scaleX = 0;
+      page.fusion.scaleY = 0;
       page.dead = false;
       page.dirty = false;
       page.full_page_rect = page_rect;
       page.palette = palette;
       rebuild_page(&page, tracker, uploader);
+      page.last_used = ++self->tick;
+      page.bytes = ih_is_valid(&page.texture)
+         ? (size_t)image_get_width(ih_get(&page.texture), 0) * (size_t)image_get_height(ih_get(&page.texture), 0) * 4u
+         : 0;
       fused_page_vec_push(&self->pages, &page);
-      /* push deep-copies via fp_copy (increfs the texture, deep-copies the
-       * rects), so release the local's now-redundant owned references. */
-      fp_destroy(&page);
       return hd_handle_make_fused(fused_page_vec_size(&self->pages) - 1);
    }
    static void fused_pages_mark_dirty(struct FusedPages *self, Rect rect) {
@@ -21475,6 +22797,38 @@ static int64_t page_bytes(FusionRects *fusion)
          }
       }
       fused_page_vec_truncate(&self->pages, retained);
+   }
+   /* LRU-evict live fused pages (mark them dead) until the total footprint is within
+    * budget. Run at the on_queues_reset safe point, immediately before remove_dead
+    * compacts and frees the marked pages. budget 0 = unlimited (disabled). */
+   static void fused_pages_evict(struct FusedPages *self) {
+      size_t total = 0;
+      int i;
+      if (self->budget_bytes == 0)
+         return;
+      for (i = 0; i < fused_page_vec_size(&self->pages); i++) {
+         FusedPage *p = fused_page_vec_at(&self->pages, i);
+         if (!p->dead)
+            total += p->bytes;
+      }
+      while (total > self->budget_bytes) {
+         int victim = -1;
+         uint64_t oldest = 0;
+         for (i = 0; i < fused_page_vec_size(&self->pages); i++) {
+            FusedPage *p = fused_page_vec_at(&self->pages, i);
+            if (p->dead)
+               continue;
+            if (victim < 0 || p->last_used < oldest) {
+               oldest = p->last_used;
+               victim = i;
+            }
+         }
+         if (victim < 0)
+            break; /* nothing left to evict */
+         { FusedPage *v = fused_page_vec_at(&self->pages, victim);
+           v->dead = true;
+           total -= v->bytes; }
+      }
    }
 
 
@@ -21583,7 +22937,7 @@ static int64_t page_bytes(FusionRects *fusion)
          _crr.y = 0;
          _crr.width = FB_WIDTH;
          _crr.height = FB_HEIGHT;
-         texture_tracker_clearRegion(self, _crr);
+         texture_tracker_clearRegion(self, _crr, 0);
       }
       enduring_arr_clear(&self->tracker.textures); /* load_state should only be called right after creating this TextureTracker, so this ought to be empty already anyway */
       {
@@ -21769,6 +23123,13 @@ static bool track_textures = false;
 static size_t hd_cache_vram_bytes = (size_t)3 * 1024 * 1024 * 1024; /* 3 GB default (matches HD_CACHE_VRAM_BUDGET) */
 static size_t hd_cache_ram_bytes  = (size_t)2 * 1024 * 1024 * 1024; /* 2 GB default (matches HD_CACHE_RAM_BUDGET) */
 static bool   eager_hd_textures   = true; /* default eager (master-consistent); false = lazy */
+static bool   lazy_sync_hd_textures = false; /* Lazy (synchronous): block the render thread on first use */
+/* Page-aligned experiment (see PAGE_ALIGN.md): false = upload-rect (default), true = page-aligned. */
+static bool   hd_dump_mode_rect   = true;
+static bool   hd_dump_mode_pages  = false;
+static bool   hd_replacement_mode_pages = false;
+static bool   hd_replacement_fallback   = false; /* opt-in: on a miss in the active mode, try the other pack */
+static bool   hd_reduce_palette_range    = false; /* opt-in: hash only the CLUT entries a texture uses */
 /*
  * File-local copy of the crop_overscan core option, distinct
  * from the cross-TU `crop_overscan` global declared in
@@ -22353,7 +23714,40 @@ void rhi_vulkan_refresh_variables(void)
 
    var.key = BEETLE_OPT(hd_caching_method);
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-      eager_hd_textures = (strcmp(var.value, "lazy") != 0); /* "eager" (default) or "lazy" */
+   {
+      /* "eager" (default), "lazy" (async), or "lazy_sync" (synchronous) */
+      eager_hd_textures     = (!strcmp(var.value, "eager"));
+      lazy_sync_hd_textures = (!strcmp(var.value, "lazy_sync"));
+   }
+
+   /* Page-aligned experiment: "upload_rect" (default), "page_aligned", or "both". */
+   var.key = BEETLE_OPT(hd_dump_mode);
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      hd_dump_mode_rect  = (!strcmp(var.value, "upload_rect")  || !strcmp(var.value, "both"));
+      hd_dump_mode_pages = (!strcmp(var.value, "page_aligned") || !strcmp(var.value, "both"));
+   }
+
+   var.key = BEETLE_OPT(hd_replacement_mode);
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      hd_replacement_mode_pages = (!strcmp(var.value, "page_aligned"));
+
+   var.key = BEETLE_OPT(hd_replacement_fallback);
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      hd_replacement_fallback = (!strcmp(var.value, "enabled"));
+
+   var.key = BEETLE_OPT(reduce_palette_range);
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      hd_reduce_palette_range = (!strcmp(var.value, "enabled"));
+
+   /* HD Texture Folder: base location for dump/replacement folders. */
+   var.key = BEETLE_OPT(texture_directory);
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "system"))    texture_dir_mode = 1;
+      else if (!strcmp(var.value, "save")) texture_dir_mode = 2;
+      else                                 texture_dir_mode = 0;
+   }
 
    option_display.visible = track_textures;
 
@@ -22534,9 +23928,38 @@ void rhi_vulkan_finalize_frame(const void *fb, unsigned width,
 
    renderer->texture_tracking_enabled = track_textures;
    renderer->tracker.dump_enabled = dump_textures;
-   renderer->tracker.hd_textures_enabled = replace_textures;
+   /* HD Texture Folder changed (or first non-default read): re-scan replacements
+    * from the new base (the tracker init loaded from the content dir, mode 0). */
+   {
+      static int texture_dir_mode_applied = 0;
+      if (texture_dir_mode != texture_dir_mode_applied) {
+         texture_tracker_reload_textures_from_disk(&renderer->tracker);
+         texture_dir_mode_applied = texture_dir_mode;
+      }
+   }
+   /* Apply Replace Textures only when it actually changes, so the in-game ']' toggle
+    * (see texture_tracker_endFrame) isn't re-stamped back to the menu value every
+    * frame. A menu change still re-applies and re-syncs. */
+   {
+      static int replace_textures_applied = -1; /* -1 = force the first apply */
+      if ((int)replace_textures != replace_textures_applied) {
+         renderer->tracker.hd_textures_enabled = replace_textures;
+         if (!replace_textures)
+            texture_tracker_flush_hd_state(&renderer->tracker); /* free HD VRAM immediately when turned off */
+         replace_textures_applied = replace_textures;
+      }
+   }
    renderer_set_hd_cache_budgets(renderer, hd_cache_ram_bytes, hd_cache_vram_bytes);
    renderer->tracker.eager_textures = eager_hd_textures;
+   renderer->tracker.lazy_sync = lazy_sync_hd_textures;
+   renderer->tracker.dump_mode_rect  = hd_dump_mode_rect;
+   renderer->tracker.dump_mode_pages = hd_dump_mode_pages;
+   renderer->tracker.replacement_mode_pages = hd_replacement_mode_pages;
+   renderer->tracker.replacement_fallback   = hd_replacement_fallback;
+   renderer->tracker.reduce_palette_range   = hd_reduce_palette_range;
+   /* Auto-create the dump/replacement folders once enabled + a game is loaded (after
+    * the mode flags above so it picks the right rect/pages folder). */
+   texture_tracker_ensure_directories(&renderer->tracker, dump_textures, replace_textures);
    renderer->render_state.adaptive_smoothing = adaptive_smoothing;
    renderer->render_state.dither_native_resolution = dither_mode == DITHER_NATIVE;
    renderer->render_state.crop_overscan = vulkan_crop_overscan;


### PR DESCRIPTION
This is the remainder of an **HD texture replacement overhaul** for the Vulkan
renderer. The first part — the decode-once three-tier cache, the multi-threaded PNG
decode pool, same-frame (no pop-in) binding, and the Eager/Lazy caching method with
VRAM/RAM budgets — is already in master. This PR adds the rest of the overhaul as a
set of independent features. Taken together the texture-replacement system is
substantially reworked for the next release (none of it was in the last stable build).

Everything here is **opt-in and defaults to the existing upload-rect behaviour**, so
existing packs and the on-disk format are unaffected — with defaults unchanged this is
a no-op for current users.

### Already in master (the foundation this completes)

Merged in b2f80b83 and converted to C in ed292809:

- Decode-once three-tier cache (GPU image → RAM pixels → disk; LRU + byte budgets).
- Multi-threaded PNG decode (4-worker IO pool).
- Same-frame binding of cached textures (eliminates per-frame pop-in).
- Eager / Lazy caching method + VRAM/RAM budget core options.

### Added in this PR

Independent features, equal standing — all default off / upload-rect:

- **Threaded dump decode + prioritised IO queue.** The palette→RGBA→tri-alpha
  expansion moves off the render thread onto the IO worker pool (the render thread only
  snapshots the raw VRAM words), and the IO queue is split into on-demand vs background
  priorities so draw-time loads jump ahead of prefetch and dumps.
- **Page-aligned dump & replacement.** Dump/match whole VRAM texture pages (clean
  256×256 tiles) as an alternative to the fragmented per-upload-rectangle sections —
  friendlier for authoring static backgrounds, UI and 3D art (addresses the fragmented
  dumps in #918). Keyed into the same cache by `(page_hash, palette)` via a CPU VRAM
  mirror (for draw-time hashing) and a per-frame page-hash memo.
- **Dual ("Both") dumping.** HD Dump Mode = `Upload-rect` / `Page-aligned` / `Both`;
  "Both" collects both pack types in a single playthrough.
- **Cross-mode replacement fallback.** On a miss in the active replacement mode,
  optionally try the other pack before falling back to native (works both directions),
  so an upload-rect pack and a page pack can cover each other without conversion.
- **Reduce palette range.** Hash only the CLUT entries a texture actually indexes
  (not the whole CLUT), so unused/garbage/rewritten palette slots don't fork a
  texture's hash — fewer dumps and better match coverage (most useful for 8bpp).
  Backward-compatible: dump filenames are unchanged and it falls back to the
  full-palette hash, so existing packs still match. Applies to both the upload-rect
  and page-aligned paths.
- **Lazy (synchronous) caching method.** Load on first use but block until ready (no
  pop-in, at the cost of a brief stall when many new textures appear at once).
- **HD Texture Folder option.** Keep the dump/replacement folders under the Content
  (default), System or Save directory instead of next to the content; folders are
  auto-created.
- **Live hotkeys** (require RetroArch **Game Focus**): `]` toggles HD replacements
  on/off with an on-screen message; `'` reloads replacements from disk.

### Implementation / compatibility

- All C, on the C/C89 `rhi_lib_vulkan.c`; compiles under
  `-Werror=declaration-after-statement` (the MSVC-C89 target). No new dependencies.
- Reuses the existing cache / IO pool / budgets; page vs upload-rect cache entries are
  namespaced in the packed cache key so both pack types share one cache + budget
  without aliasing.
- Defaults are upload-rect everywhere → no change for existing users. Page packs and
  upload-rect packs are **not** interchangeable (the hash covers a different region of
  VRAM); page mode suits static/reused art and 3D, upload-rect suits 2D animated
  multi-palette sprites. Design + authoring workflow: **`PAGE_ALIGN.md`** (added);
  `HD_TEXTURE_CACHE.md` gains a short *Palette-range hashing* section (plus a `.c`
  reference fix for the C-converted renderer).

### Testing

- Built and tested on Windows (`mednafen_psx_hw_libretro.dll`, MSYS2 / MinGW-w64, GCC)
  against RetroArch 1.22.2; source is cross-platform (same `make HAVE_HW=1`).
- Exercised in *Castlevania: Symphony of the Night* and others: page dump/match, Both
  dumping, cross-mode fallback, the Lazy variants, the HD Texture Folder relocation,
  and the live toggle/reload hotkeys.

### Notes for review

- Structured as one code commit + one docs commit; happy to squash to one or split
  per-feature if you prefer.
- Built directly on your C/C89 conversion of the Vulkan renderer, on current master
  (`b84c0c11`). The `#971` uninitialised-field fixes are already upstream and are not
  part of this PR.