### PR TITLE
Add option for core provided aspect ratio to be force 16:9

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -4356,6 +4356,12 @@ static void check_variables(bool startup)
             has_new_geometry = true;
          aspect_ratio_setting = 3;
       }
+	  else if (!strcmp(var.value, "16:9"))
+      {
+         if (!startup && aspect_ratio_setting != 4)
+            has_new_geometry = true;
+         aspect_ratio_setting = 4;
+      }
    }
 
    if (startup)

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -1482,6 +1482,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "uncorrected", "Uncorrected" },
          { "4:3",  "Force 4:3" },
          { "ntsc", "Force NTSC" },
+         { "16:9", "Force 16:9" },
       },
       "corrected"
    },

--- a/rhi/rhi_intf.c
+++ b/rhi/rhi_intf.c
@@ -1262,6 +1262,10 @@ float rhi_common_get_aspect_ratio(bool pal_content, int crop_overscan,
 
       return ar;
    }
+	else if (aspect_ratio_setting == 4) /* Force 16:9 */
+   {
+      return (16.0 / 9.0);
+   }
 
    return ar; /* 4:3 */
 }


### PR DESCRIPTION
This is useful when using widescreen cheat codes, or for games that have a native 16:9 mode. In these cases you don't want to use the widescreen hack option.

The same can be achieve by changing ⚙️->Video->Scaling->Aspect Ratio: 16:9, however, I feel it's more convenient when this setting can be left on 'core provided'. Having the 16:9 option in the core means it's only necessary to save a 'core game override' and not a 'retroarch config game overridge'.