### PR TITLE
Fix incorrect alpha channel scaling in GLES 5551 color reinterpretation

### DIFF
--- a/rhi/shaders_gl/command_fragment.glsl.h
+++ b/rhi/shaders_gl/command_fragment.glsl.h
@@ -110,7 +110,7 @@ vec4 reinterpret_color(vec4 color) {
   uint pre_bits = rebuild_psx_color(color);
 
   // interpret as 1555
-  float a = float((pre_bits & 0x8000U) >> 15) / 31.;
+  float a = float((pre_bits & 0x8000U) >> 15);
   float b = float((pre_bits & 0x7C00U) >> 10) / 31.;
   float g = float((pre_bits & 0x3E0U) >> 5) / 31.;
   float r = float(pre_bits & 0x1FU) / 31.;


### PR DESCRIPTION
## Description
Transparency effects render as black on the OpenGL HW renderer on android. I couldn't find any open issues for this. I suspect it's because not many people use this core on android. I tried to bisect, but it seems to have been an issue since OpenGL was added in https://github.com/libretro/beetle-psx-libretro/commit/3f525d7d67b7c8f83ca0c951c279abc04decb17f.

reinterpret_color() in the GLES fallback path (used because GLES does not support 1555 REV) incorrectly divides the alpha bit by 31 along with the RGB channels. The alpha bit is a single-bit semi-transparency flag, not a 5-bit color intensity, so it should remain a plain 0 or 1 value rather than being scaled into a 0 to 1 float range alongside the RGB fields. Dividing it by 31 collapses the flag into a value close to zero in both its set and unset states, causing semi-transparent effects such as shadows, dust, and hazy overlays to render as solid black on GLES, which affects Android specifically since GLES is the fallback path used there.

The fix removes the erroneous division for the alpha component while leaving the RGB channels unchanged, since those are the only fields that represent 5-bit intensity values requiring normalization. This has been tested across roughly ten games on Android and resolves the rendering issue in all of them without introducing new visual artifacts. Since the change only corrects how a boolean flag is interpreted and does not alter any RGB color data or the blending logic that consumes the flag, it is not expected to affect any other rendering path.

## LLM disclosure
Gemini and Claude assisted with the investigation, potential fixes and wrote the description.

## Testing
Tested Spyro the Dragon, Spyro: Year of the Dragon, Gran Turismo 1, Gran Turismo 2, Crash 1, and a few others. The issue was resolved in all games, no new issues observed. 

Before:
<img width="1080" height="824" alt="Screenshot_20260727-164328" src="https://github.com/user-attachments/assets/879b6a14-7b90-42b9-984a-c4bc627555a9" />

After:
<img width="1080" height="817" alt="Screenshot_20260727-193726" src="https://github.com/user-attachments/assets/b38e2a65-5522-4ea2-94db-df46471ae69a" />