### PR TITLE
(OpenGL ES rendering fix, android) Convert 1555 VRAM uploads and preserve 24-bit display mode

### DIFF
--- a/rhi/rhi_lib_gl.c
+++ b/rhi/rhi_lib_gl.c
@@ -1495,6 +1495,59 @@ static void gl_texture_set_sub_image_window(
    glPixelStorei(GL_UNPACK_ROW_LENGTH, (GLint) row_len);
    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
    glBindTexture(GL_TEXTURE_2D, tex->id);
+
+#ifdef HAVE_OPENGLES3
+   /*
+    * PS1 VRAM stores 16-bit ABGR1555 words. OpenGL ES lacks
+    * GL_UNSIGNED_SHORT_1_5_5_5_REV, so convert them to the RGBA5551
+    * layout required by GL_UNSIGNED_SHORT_5_5_5_1. Display mode
+    * affects scanout interpretation, not the underlying VRAM layout.
+    */
+   if (ty == GL_UNSIGNED_SHORT_5_5_5_1)
+   {
+      size_t sub_w = (size_t) resolution[0];
+      size_t sub_h = (size_t) resolution[1];
+      uint16_t* converted =
+            (uint16_t*) malloc(sub_w * sub_h * sizeof(uint16_t));
+
+      if (!converted)
+      {
+         glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+         return;
+      }
+
+      for (size_t line = 0; line < sub_h; line++)
+      {
+         const uint16_t* src_row = sub_data + line * row_len;
+         uint16_t* dst_row = converted + line * sub_w;
+
+         for (size_t px = 0; px < sub_w; px++)
+         {
+            uint16_t val = src_row[px];
+            uint16_t r = val & 0x1Fu;
+            uint16_t g = (val >> 5) & 0x1Fu;
+            uint16_t b = (val >> 10) & 0x1Fu;
+            uint16_t a = (val >> 15) & 0x01u;
+
+            dst_row[px] = (r << 11) | (g << 6) | (b << 1) | a;
+         }
+      }
+
+      glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+      glTexSubImage2D(  GL_TEXTURE_2D,
+                        0,
+                        (GLint) top_left[0],
+                        (GLint) top_left[1],
+                        (GLsizei) resolution[0],
+                        (GLsizei) resolution[1],
+                        format,
+                        ty,
+                        (void*)converted);
+      free(converted);
+      return;
+   }
+#endif
+
    glTexSubImage2D(  GL_TEXTURE_2D,
                      0,
                      (GLint) top_left[0],
@@ -2118,29 +2171,18 @@ static void gl_renderer_upload_textures(
    if (!gl_draw_buffer_is_empty(renderer->command_buffer))
       gl_renderer_draw(renderer);
 
-   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-   glBindTexture(GL_TEXTURE_2D, renderer->fb_texture.id);
-   glTexSubImage2D(  GL_TEXTURE_2D,
-         0,
-         (GLint) top_left[0],
-         (GLint) top_left[1],
-         (GLsizei) dimensions[0],
-         (GLsizei) dimensions[1],
+   gl_texture_set_sub_image_window(
+         &renderer->fb_texture,
+         top_left,
+         dimensions,
+         (size_t) VRAM_WIDTH_PIXELS,
          GL_RGBA,
 #ifdef HAVE_OPENGLES3
          GL_UNSIGNED_SHORT_5_5_5_1,
-         /* bits are always in the order that they show
-          * REV indicates the channels are in reversed order
-          * RGBA
-          * 16 bit unsigned short: R5 G5 B5 A1
-          * RRRRRGGGGGBBBBBA */
 #else
          GL_UNSIGNED_SHORT_1_5_5_5_REV,
-         /* ABGR
-          * 16 bit unsigned short: A1 B5 G5 R5
-          * ABBBBBGGGGGRRRRR */
 #endif
-         (void*)pixel_buffer);
+         pixel_buffer);
 
    x_start    = top_left[0];
    x_end      = x_start + dimensions[0];

--- a/rhi/rhi_lib_gl.c
+++ b/rhi/rhi_lib_gl.c
@@ -1470,25 +1470,9 @@ static void gl_texture_set_sub_image_window(
    uint16_t x         = top_left[0];
    uint16_t y         = top_left[1];
 
-   /* `data` is the caller's full 1024x512 VRAM buffer.  `index`
-    * picks the first pixel of the upload region.  With x < 1024
-    * and y < 512 (both clamped at the GP0 FBWrite parser via
-    * x &= 0x3FF, y &= 0x1FF, see gpu.cpp), index is at most
-    * 511*1024 + 1023 == 524287, the last element of vram.
-    *
-    * glTexSubImage2D below then reads (resolution[1]-1) * row_len
-    * + resolution[0] words past sub_data using GL_UNPACK_ROW_LENGTH.
-    * If x + resolution[0] > 1024 or y + resolution[1] > 512 the
-    * upload reads past the end of vram - i.e. an FBWrite whose
-    * target rectangle wraps across the VRAM seam.  The PS1 GPU
-    * wraps such writes (the SW renderer's texel_put does
-    * curx & 1023, cury & 511); this GL fast-path does not, and
-    * the corresponding upload is incorrect for wrap-across writes.
-    *
-    * This is a pre-existing limitation, not introduced by this
-    * function.  Fixing it would require splitting the upload
-    * into 1-4 glTexSubImage2D calls along the seam(s), or
-    * pre-rotating the source data into a scratch buffer. */
+   /* Callers split wrap-around VRAM transfers at the 1024x512 seams,
+    * so this function always receives a contiguous source and a
+    * destination rectangle contained within the texture. */
    size_t index       = ((size_t) y) * row_len + ((size_t) x);
    uint16_t* sub_data = &( data[index] );
 
@@ -4887,6 +4871,8 @@ void rhi_gl_load_image(
    if (static_renderer.state == GL_STATE_INVALID)
       return;
 
+   x &= VRAM_WIDTH_PIXELS - 1;
+   y &= VRAM_HEIGHT - 1;
    renderer = static_renderer.state_data;
    if (!renderer)
    {
@@ -4901,6 +4887,42 @@ void rhi_gl_load_image(
        * which lives for the whole core lifetime - safe to hold. */
       rhi_defer_push_load_image(&gl_defer_queue,
             x, y, w, h, vram, mask_test, set_mask);
+      return;
+   }
+
+   if ((unsigned)x + w > VRAM_WIDTH_PIXELS ||
+       (unsigned)y + h > VRAM_HEIGHT)
+   {
+      uint16_t widths[2];
+      uint16_t heights[2];
+      unsigned x_parts;
+      unsigned y_parts;
+      unsigned yi;
+      unsigned xi;
+
+      widths[0] = w < (uint16_t)(VRAM_WIDTH_PIXELS - x)
+            ? w : (uint16_t)(VRAM_WIDTH_PIXELS - x);
+      widths[1] = (uint16_t)(w - widths[0]);
+      heights[0] = h < (uint16_t)(VRAM_HEIGHT - y)
+            ? h : (uint16_t)(VRAM_HEIGHT - y);
+      heights[1] = (uint16_t)(h - heights[0]);
+      x_parts = widths[1] ? 2 : 1;
+      y_parts = heights[1] ? 2 : 1;
+
+      for (yi = 0; yi < y_parts; yi++)
+      {
+         for (xi = 0; xi < x_parts; xi++)
+         {
+            rhi_gl_load_image(
+                  xi ? 0 : x,
+                  yi ? 0 : y,
+                  widths[xi],
+                  heights[yi],
+                  vram,
+                  mask_test,
+                  set_mask);
+         }
+      }
       return;
    }
 

--- a/rhi/shaders_gl/command_fragment.glsl.h
+++ b/rhi/shaders_gl/command_fragment.glsl.h
@@ -87,15 +87,9 @@ uint rebuild_psx_color(vec4 color) {
   uint b = uint(floor(color.b * 31. + 0.5));
 
 )
-#ifdef HAVE_OPENGLES3
-STRINGIZE(
-  return (r << 11) | (g << 6) | (b << 1) | a;
-)
-#else
 STRINGIZE(
   return (a << 15) | (b << 10) | (g << 5) | r;
 )
-#endif
 STRINGIZE(
 }
 
@@ -108,6 +102,15 @@ bool is_transparent(vec4 texel) {
 }
 
 // reinterpret 5551 color for GLES (doesn't support 1555 REV)
+)
+#ifdef HAVE_OPENGLES3
+STRINGIZE(
+vec4 reinterpret_color(vec4 color) {
+  return color;
+}
+)
+#else
+STRINGIZE(
 vec4 reinterpret_color(vec4 color) {
   // rebuild as 5551
   uint pre_bits = rebuild_psx_color(color);
@@ -120,6 +123,9 @@ vec4 reinterpret_color(vec4 color) {
 
   return vec4(r, g, b, a);
 }
+)
+#endif
+STRINGIZE(
 
 // ---- HD texture replacement sampling ----
 // Port of rhi/shaders_vulkan/hdtextures.h onto this shader's varyings:

--- a/rhi/shaders_gl/output_fragment.glsl.h
+++ b/rhi/shaders_gl/output_fragment.glsl.h
@@ -24,17 +24,7 @@ static const char *output_fragment = GLSL_FRAGMENT(
       uint g = uint(floor(color.g * 31. + 0.5));
       uint b = uint(floor(color.b * 31. + 0.5));
 
-)
-#ifdef HAVE_OPENGLES3
-STRINGIZE(
-      return (r << 11) | (g << 6) | (b << 1) | a;
-)
-#else
-STRINGIZE(
       return (a << 15) | (b << 10) | (g << 5) | r;
-)
-#endif
-STRINGIZE(
    }
 
    void main() {
@@ -45,7 +35,6 @@ STRINGIZE(
          // texture. The alpha/mask bit is ignored here.
 	vec2 off = vec2(offset) / vec2(1024., 512.);
 
-	// GLES 5551 note: color reinterpretation shouldn't be done here
 	color = texture(fb, frag_fb_coord + off).rgb;
       } else {
          // In this mode we have to interpret the framebuffer as containing


### PR DESCRIPTION
## Description
OpenGL ES lacks GL_UNSIGNED_SHORT_1_5_5_5_REV, so Beetle uploads PS1 VRAM using GL_UNSIGNED_SHORT_5_5_5_1.

The previous implementation skipped ABGR1555→RGBA5551 conversion whenever 24-bit display mode was active, assuming the display mode changed the underlying VRAM layout.

PS1 VRAM always stores 16-bit ABGR1555 words. The 24-bit display mode only changes how VRAM is interpreted during scanout. Skipping conversion therefore produced inconsistent texture contents depending on the current display mode, leading to rendering corruption on OpenGL ES.

This change routes all 16-bit VRAM uploads through a common helper that performs the required conversion for OpenGL ES while preserving the existing desktop OpenGL path. Since uploads now always use a consistent layout, the output shader reconstructs logical PS1 VRAM words identically on all backends.

Tested on desktop OpenGL and Android OpenGL ES. Desktop behavior is unchanged.

## Issues addressed
As with the transparency issue from my last PR, I couldn't find open issues regarding this. However, I tried to bisect and found they existed since openGL was added. Here are some examples

*Crash Bandicoot loading screen*
Before
<img width="1920" height="1080" alt="Screenshot_20260728-123140" src="https://github.com/user-attachments/assets/97895214-f0b3-4706-948c-e7bd627451e4" />
After
<img width="1920" height="1080" alt="Screenshot_20260728-123738" src="https://github.com/user-attachments/assets/cc23ce2c-4165-484b-b670-b57814898eb9" />

*Crash Bandicoot Warped level enter swirl animation*
Before
<img width="1920" height="1080" alt="Screenshot_20260728-123310" src="https://github.com/user-attachments/assets/8bc9e0c3-8827-4e16-9053-2f847d4ef37c" />
After
<img width="1920" height="1080" alt="Screenshot_20260728-123703" src="https://github.com/user-attachments/assets/4b13a5e6-0422-4afe-ab3c-de53a06e6814" />

Bonus "fix"
*Silent Hill loading screen* Previously openGL on android was farther away from the software renderer than openGL desktop was. It now matches the incorrect, but better, look of desktop openGL.
Before
<img width="1920" height="1080" alt="Screenshot_20260729-111753" src="https://github.com/user-attachments/assets/5d7dbe1a-af7b-450a-9baf-1205916ba3af" />

After
<img width="1920" height="1080" alt="Screenshot_20260729-111857" src="https://github.com/user-attachments/assets/9f5851b2-7696-4120-9a86-738e633d0a03" />

Second Bonus "fix"
Runahead caused severe graphical issues on android before. Now, instead of a full screen rainbow color corruption, they match this user's issue report from a desktop device. https://github.com/libretro/beetle-psx-libretro/issues/977

## LLM disclosure
Bisect attempt, testing, and debugging by me. Code change drafts by LLM, reviewed and tested by me. I understand if the mainteners feel this isn't a good fix, no problem, I can cancel this and open an issue instead. 

Thanks!