### PR TITLE
gl: fix fixed-point modulation for framebuffer feedback

### DIFF
--- a/rhi/rhi_intf.c
+++ b/rhi/rhi_intf.c
@@ -886,7 +886,8 @@ void rhi_intf_push_quad(
                texpage_x, texpage_y, clut_x, clut_y,
                texture_blend_mode,
                depth_shift,
-               dither,
+               /* Sprite modulation uses a zero dither offset. */
+               dither && !is_sprite,
                blend_mode, mask_test, set_mask);
 #endif
          break;

--- a/rhi/rhi_lib_gl.c
+++ b/rhi/rhi_lib_gl.c
@@ -705,6 +705,9 @@ struct gl_command_vertex {
    uint16_t texture_limits[4];
    /* gl_texture window mask/OR values */
    uint8_t texture_window[4];
+   /* The primitive samples VRAM content produced by GPU rendering rather
+    * than only game-uploaded texture data. */
+   uint8_t framebuffer_feedback;
    /* Depth-cue sidecar: far colour (1.0 == 0xFF) in [0..2], blend factor in
     * [3]. t == 0 makes the shader mix the identity, so vertices without a
     * recovered cue cost nothing. KEEP LAST -- positional initializers above
@@ -923,6 +926,9 @@ struct gl_vram_sync_writer
 struct gl_vram_sync_tile
 {
    struct gl_vram_sync_writer writers[GL_VRAM_SYNC_WRITERS_PER_TILE];
+   /* Pixels whose current contents originated from GPU rendering. Unlike
+    * pending writers, this provenance survives synchronization and frames. */
+   uint64_t gpu_written_mask;
 };
 
 
@@ -2206,7 +2212,15 @@ static TTRect gl_tt_texture_vram_rect(gl_renderer *r,
 
 static void gl_vram_sync_clear(gl_renderer *renderer)
 {
-   memset(renderer->vram_sync.tiles, 0, sizeof(renderer->vram_sync.tiles));
+   unsigned ty;
+   unsigned tx;
+
+   /* Synchronization makes pending writers current, but does not change
+    * where the pixels originated. Preserve GPU-written provenance. */
+   for (ty = 0; ty < GL_VRAM_SYNC_TILES_Y; ty++)
+      for (tx = 0; tx < GL_VRAM_SYNC_TILES_X; tx++)
+         memset(renderer->vram_sync.tiles[ty][tx].writers, 0,
+               sizeof(renderer->vram_sync.tiles[ty][tx].writers));
 }
 
 /* Return the bits covered by a native VRAM rectangle inside one 8x8 tile.
@@ -2275,6 +2289,80 @@ static bool gl_vram_sync_rect_is_dirty(gl_renderer *renderer,
    return false;
 }
 
+static bool gl_vram_sync_rect_is_gpu_written(gl_renderer *renderer,
+      unsigned x, unsigned y, unsigned w, unsigned h)
+{
+   unsigned tx0;
+   unsigned tx1;
+   unsigned ty0;
+   unsigned ty1;
+   unsigned raw_tx;
+   unsigned raw_ty;
+
+   if (!w || !h)
+      return false;
+
+   x %= VRAM_WIDTH_PIXELS;
+   y %= VRAM_HEIGHT;
+   tx0 = x / GL_VRAM_SYNC_TILE_SIZE;
+   tx1 = (x + w - 1) / GL_VRAM_SYNC_TILE_SIZE;
+   ty0 = y / GL_VRAM_SYNC_TILE_SIZE;
+   ty1 = (y + h - 1) / GL_VRAM_SYNC_TILE_SIZE;
+
+   for (raw_ty = ty0; raw_ty <= ty1; raw_ty++)
+   {
+      unsigned ty = raw_ty % GL_VRAM_SYNC_TILES_Y;
+      for (raw_tx = tx0; raw_tx <= tx1; raw_tx++)
+      {
+         unsigned tx = raw_tx % GL_VRAM_SYNC_TILES_X;
+         uint64_t read_mask = gl_vram_sync_tile_mask(
+               x, y, w, h, raw_tx, raw_ty);
+
+         if (read_mask & renderer->vram_sync.tiles[ty][tx].gpu_written_mask)
+            return true;
+      }
+   }
+
+   return false;
+}
+
+static void gl_vram_sync_update_gpu_written_rect(gl_renderer *renderer,
+      unsigned x, unsigned y, unsigned w, unsigned h, bool gpu_written)
+{
+   unsigned tx0;
+   unsigned tx1;
+   unsigned ty0;
+   unsigned ty1;
+   unsigned raw_tx;
+   unsigned raw_ty;
+
+   if (!w || !h)
+      return;
+
+   x %= VRAM_WIDTH_PIXELS;
+   y %= VRAM_HEIGHT;
+   tx0 = x / GL_VRAM_SYNC_TILE_SIZE;
+   tx1 = (x + w - 1) / GL_VRAM_SYNC_TILE_SIZE;
+   ty0 = y / GL_VRAM_SYNC_TILE_SIZE;
+   ty1 = (y + h - 1) / GL_VRAM_SYNC_TILE_SIZE;
+
+   for (raw_ty = ty0; raw_ty <= ty1; raw_ty++)
+   {
+      unsigned ty = raw_ty % GL_VRAM_SYNC_TILES_Y;
+      for (raw_tx = tx0; raw_tx <= tx1; raw_tx++)
+      {
+         unsigned tx = raw_tx % GL_VRAM_SYNC_TILES_X;
+         uint64_t mask = gl_vram_sync_tile_mask(
+               x, y, w, h, raw_tx, raw_ty);
+
+         if (gpu_written)
+            renderer->vram_sync.tiles[ty][tx].gpu_written_mask |= mask;
+         else
+            renderer->vram_sync.tiles[ty][tx].gpu_written_mask &= ~mask;
+      }
+   }
+}
+
 static void gl_vram_sync_clean_rect(gl_renderer *renderer,
       unsigned x, unsigned y, unsigned w, unsigned h)
 {
@@ -2327,6 +2415,7 @@ static void gl_vram_sync_mark_rect(gl_renderer *renderer,
       return;
 
    sequence = ++renderer->vram_sync.sequence;
+   gl_vram_sync_update_gpu_written_rect(renderer, x, y, w, h, true);
    x %= VRAM_WIDTH_PIXELS;
    y %= VRAM_HEIGHT;
    tx0 = x / GL_VRAM_SYNC_TILE_SIZE;
@@ -2531,7 +2620,7 @@ static void gl_vram_sync_mirror_rect(gl_renderer *renderer,
 #endif
 
 static void gl_vram_sync_primitive(gl_renderer *renderer,
-      const gl_command_vertex *v, unsigned vertices)
+      gl_command_vertex *v, unsigned vertices)
 {
    float min_x;
    float min_y;
@@ -2542,6 +2631,7 @@ static void gl_vram_sync_primitive(gl_renderer *renderer,
    int x1;
    int y1;
    unsigned i;
+   bool framebuffer_feedback = false;
 
 #ifdef GL_READ_FRAMEBUFFER
    if (v[0].texture_blend_mode != 0 &&
@@ -2556,15 +2646,26 @@ static void gl_vram_sync_primitive(gl_renderer *renderer,
       unsigned clut_width = depth == 1 ? 256u : 16u;
       bool texture_dirty;
       bool clut_dirty = false;
+      bool texture_gpu_written;
+      bool clut_gpu_written = false;
 
       if (texture_rect.height && !texture_rect.width)
          texture_rect.width = 1;
       texture_dirty = gl_vram_sync_get_producer_rect(renderer,
             texture_rect.x, texture_rect.y,
             texture_rect.width, texture_rect.height, &producer_rect);
+      texture_gpu_written = gl_vram_sync_rect_is_gpu_written(renderer,
+            texture_rect.x, texture_rect.y,
+            texture_rect.width, texture_rect.height);
       if (depth == 1 || depth == 2)
+      {
          clut_dirty = gl_vram_sync_rect_is_dirty(renderer,
                v[0].clut[0], v[0].clut[1], clut_width, 1);
+         clut_gpu_written = gl_vram_sync_rect_is_gpu_written(renderer,
+               v[0].clut[0], v[0].clut[1], clut_width, 1);
+      }
+
+      framebuffer_feedback = texture_gpu_written || clut_gpu_written;
 
       if (texture_dirty || clut_dirty)
       {
@@ -2586,6 +2687,9 @@ static void gl_vram_sync_primitive(gl_renderer *renderer,
       }
    }
 #endif
+
+   for (i = 0; i < vertices; i++)
+      v[i].framebuffer_feedback = framebuffer_feedback;
 
    min_x = max_x = v[0].position[0] + renderer->config.draw_offset[0];
    min_y = max_y = v[0].position[1] + renderer->config.draw_offset[1];
@@ -2980,6 +3084,9 @@ static void gl_renderer_upload_textures(
    y_start    = top_left[1];
    y_end      = y_start + dimensions[1];
 
+   gl_vram_sync_update_gpu_written_rect(renderer,
+         x_start, y_start, dimensions[0], dimensions[1], false);
+
    {
       gl_image_load_vertex init[4] =
       {
@@ -3301,9 +3408,15 @@ static bool gl_renderer_new(gl_renderer *renderer, gl_draw_config config)
    if (command_buffer->program)
    {
       uint32_t dither_scaling = dither_mode == DITHER_UPSCALED ? 1 : upscaling;
+      uint32_t native_rgb5 = depth == 16 && !renderer->fb_out_fp16;
+      uint32_t fixed_point_modulation = !psx_pgxp_color;
 
       glUseProgram(command_buffer->program->id);
       glUniform1ui(gl_uniform_map_get(&command_buffer->program->uniforms, "dither_scaling"), dither_scaling);
+      glUniform1ui(gl_uniform_map_get(&command_buffer->program->uniforms,
+               "fixed_point_modulation"), fixed_point_modulation);
+      glUniform1ui(gl_uniform_map_get(&command_buffer->program->uniforms,
+               "native_rgb5"), native_rgb5);
    }
 
    switch (depth)
@@ -4726,9 +4839,15 @@ static bool retro_refresh_variables(gl_renderer *renderer)
    if (renderer->command_buffer->program)
    {
       uint32_t dither_scaling = dither_mode == DITHER_UPSCALED ? 1 : upscaling;
+      uint32_t native_rgb5 = depth == 16 && !renderer->fb_out_fp16;
+      uint32_t fixed_point_modulation = !psx_pgxp_color;
 
       glUseProgram(renderer->command_buffer->program->id);
       glUniform1ui(gl_uniform_map_get(&renderer->command_buffer->program->uniforms, "dither_scaling"), dither_scaling);
+      glUniform1ui(gl_uniform_map_get(&renderer->command_buffer->program->uniforms,
+               "fixed_point_modulation"), fixed_point_modulation);
+      glUniform1ui(gl_uniform_map_get(&renderer->command_buffer->program->uniforms,
+               "native_rgb5"), native_rgb5);
    }
 
    glLineWidth((GLfloat) upscaling);
@@ -5057,6 +5176,8 @@ static const struct gl_attribute gl_command_vertex_attribs[] = {
    { "dither",             offsetof(gl_command_vertex, dither),             GL_UNSIGNED_BYTE,  1 },
    { "semi_transparent",   offsetof(gl_command_vertex, semi_transparent),   GL_UNSIGNED_BYTE,  1 },
    { "texture_window",     offsetof(gl_command_vertex, texture_window),     GL_UNSIGNED_BYTE,  4 },
+   { "framebuffer_feedback",
+      offsetof(gl_command_vertex, framebuffer_feedback), GL_UNSIGNED_BYTE, 1 },
    { "texture_limits",     offsetof(gl_command_vertex, texture_limits),     GL_UNSIGNED_SHORT, 4 }
 };
 
@@ -6914,6 +7035,7 @@ void rhi_gl_load_image(
 
    /* The CPU upload is applied to both fb_texture and fb_out. */
    gl_vram_sync_clean_rect(renderer, x, y, w, h);
+   gl_vram_sync_update_gpu_written_rect(renderer, x, y, w, h, false);
 
 #ifdef DEBUG
    get_error("rhi_gl_load_image");
@@ -7675,6 +7797,7 @@ void rhi_gl_fill_rect(
          gl_vram_sync_clean_rect(renderer, x, y, w, h);
    }
 #endif
+   gl_vram_sync_update_gpu_written_rect(renderer, x, y, w, h, true);
 }
 
 void rhi_gl_copy_rect(
@@ -7816,6 +7939,7 @@ void rhi_gl_copy_rect(
          gl_vram_sync_clean_rect(renderer, dst_x, dst_y, w, h);
    }
 #endif
+   gl_vram_sync_update_gpu_written_rect(renderer, dst_x, dst_y, w, h, true);
 
 #ifdef DEBUG
    get_error("rhi_gl_copy_rect");

--- a/rhi/shaders_gl/command_fragment.glsl.h
+++ b/rhi/shaders_gl/command_fragment.glsl.h
@@ -21,6 +21,12 @@ uniform sampler2D fb_texture;
 
 // Scaling to apply to the dither pattern
 uniform uint dither_scaling;
+// The current render target stores native RGB5 channels. Quantize explicitly
+// so OpenGL's normalized conversion cannot round a feedback value to itself.
+uniform uint native_rgb5;
+// Reproduce the GPU's fixed-point texture modulation before attachment
+// conversion can round away a low-intensity framebuffer decrement.
+uniform uint fixed_point_modulation;
 // HDR fp16 target only. 0: saturate the modulated texture source to 1.0
 // before blending (hardware behaviour; the UNORM targets do this at the
 // write stage for free). 1: leave it hot for over-white single-layer
@@ -95,6 +101,8 @@ flat in uint frag_semi_transparent;
 flat in uvec4 frag_texture_window;
 // Texture limits: [Umin, Vmin, Umax, Vmax]
 flat in uvec4 frag_texture_limits;
+// The sampled texture or palette contains GPU-rendered VRAM data.
+flat in uint frag_framebuffer_feedback;
 
 out vec4 frag_color;
 
@@ -1021,6 +1029,7 @@ void main() {
    }
 
    vec4 color;
+   bool modulation_quantized = false;
    float opacity=1.;
    
       if (frag_texture_blend_mode == BLEND_MODE_NO_TEXTURE)
@@ -1117,10 +1126,35 @@ STRINGIZE(
          if (frag_texture_blend_mode == BLEND_MODE_RAW_TEXTURE) {
             color = vec4(texel.rgb, mask_bit);
          } else /* BLEND_MODE_TEXTURE_BLEND */ {
-            // Blend the texel with the shading color. `frag_shading_color`
-            // is multiplied by two so that it can be used to darken or
-            // lighten the texture as needed.
-            color = vec4(pgxp_shading() * 2. * texel.rgb, mask_bit);
+            if (fixed_point_modulation != 0u &&
+                frag_framebuffer_feedback != 0u)
+            {
+               uint mod_x =
+                  (uint(gl_FragCoord.x) / dither_scaling) & 3u;
+               uint mod_y =
+                  (uint(gl_FragCoord.y) / dither_scaling) & 3u;
+               float mod_dither = float(
+                  dither_pattern[mod_y * 4u + mod_x] * int(frag_dither));
+               vec3 texel5 = floor(texel.rgb * 31. + vec3(0.5));
+               vec3 shade8 = floor(clamp(pgxp_shading(), vec3(0.),
+                                         vec3(1.)) * 255. + vec3(0.001));
+               vec3 modulated = floor(texel5 * shade8 / 16.);
+
+               /* ModTexel first truncates the 5-bit texel times the 8-bit
+                * shading colour to an intermediate fixed-point value.  Its
+                * DitherLUT then adds the 4x4 offset, divides by eight with
+                * truncation, and clamps the result to a 5-bit channel. */
+               color = vec4(clamp(floor((modulated + mod_dither) / 8.),
+                                  vec3(0.), vec3(31.)) / 31., mask_bit);
+               modulation_quantized = true;
+            }
+            else
+            {
+               // Blend the texel with the shading color. The shading color
+               // is multiplied by two so that it can darken or lighten the
+               // texture as needed.
+               color = vec4(pgxp_shading() * 2. * texel.rgb, mask_bit);
+            }
          }
 
          // Saturate the modulated source to 1.0. The old comment here
@@ -1141,9 +1175,23 @@ STRINGIZE(
    int dither_offset =
       dither_pattern[y_dither * 4U + x_dither] * int(frag_dither);
 
-   float dither = float(dither_offset) / 255.;
+   if (modulation_quantized)
+      frag_color = color;
+   else
+   {
+      float dither = float(dither_offset) / 255.;
+      vec3 output_rgb = color.rgb + vec3(dither);
 
-   frag_color = color + vec4(dither, dither, dither, 0.);
+      /* RGB5 attachments convert normalized values by rounding. The GPU
+       * truncates instead; make that conversion explicit. This also keeps
+       * filtered framebuffer feedback moving toward zero without reducing
+       * the sampling precision used to produce output_rgb. */
+      if (native_rgb5 != 0u)
+         output_rgb = floor(clamp(output_rgb, vec3(0.), vec3(1.)) * 31.) /
+                      31.;
+
+      frag_color = vec4(output_rgb, color.a);
+   }
 }
 );
 

--- a/rhi/shaders_gl/command_vertex.glsl.h
+++ b/rhi/shaders_gl/command_vertex.glsl.h
@@ -21,6 +21,7 @@ in uint dither;
 in uint semi_transparent;
 in uvec4 texture_window;
 in uvec4 texture_limits;
+in uint framebuffer_feedback;
 
 // Drawing offset
 uniform ivec2 offset;
@@ -36,6 +37,7 @@ flat out uint frag_dither;
 flat out uint frag_semi_transparent;
 flat out uvec4 frag_texture_window;
 flat out uvec4 frag_texture_limits;
+flat out uint frag_framebuffer_feedback;
 )
 
 #if defined(FILTER_SABR) || defined(FILTER_XBR)
@@ -84,6 +86,7 @@ void main() {
    frag_semi_transparent = semi_transparent;
    frag_texture_window = texture_window;
    frag_texture_limits = texture_limits;
+   frag_framebuffer_feedback = framebuffer_feedback;
 )
 #if defined(FILTER_SABR) || defined(FILTER_XBR)
 STRINGIZE(


### PR DESCRIPTION
## Description
OpenGL currently performs texture modulation in floating point and relies on normalized framebuffer conversion to quantize the result. For framebuffer feedback, round-to-nearest conversion can map a low-intensity result back to the same RGB5 value. Repeated feedback then stops decaying instead of fading toward zero.

Track GPU-written VRAM provenance alongside the existing synchronization tiles and preserve it after synchronization and across frame boundaries. CPU image uploads clear the provenance of the pixels they replace. Pass this state with each primitive so textures and palettes sourced from GPU-written VRAM use the PlayStation GPU fixed-point modulation, dithering, truncation, and clamping order.

Explicitly truncate native RGB5 output instead of relying on OpenGL normalized conversion. Also preserve the existing sprite classification when forwarding draws to OpenGL so sprite modulation uses its zero dither offset.

Ordinary uploaded textures retain the higher-precision modulation path in 32-bit mode. The implementation is shared by desktop OpenGL and OpenGL ES.

## Related issues
Fixes https://github.com/libretro/beetle-psx-libretro/issues/380

https://github.com/libretro/beetle-psx-libretro/pull/982 brought OpenGL and OpenGL ES in line with each other (but both were still inaccurate). This completely matches software renderer now for OpenGL and OpenGL ES. Works in 16bit and 32bit modes, with and without dithering (previously changing the bit mode or dithering creating slightly different failures). Tested 25 games looking for regressions, none found.

## LLM disclosure
Testing, and debugging by me. Code change drafts by LLM, reviewed, tested, and adjusted by me.