### PR TITLE
[Regression fix] gl: complete dependency-driven framebuffer mirrors

### DIFF
--- a/rhi/rhi_lib_gl.c
+++ b/rhi/rhi_lib_gl.c
@@ -7667,6 +7667,11 @@ static void gl_mirror_fb_out_to_fb_texture(gl_renderer *renderer,
          GL_COLOR_BUFFER_BIT,
          GL_NEAREST);
 
+   /* Some drivers do not make dependency-driven framebuffer mirrors visible
+    * to the following texture fetch without explicit completion. */
+   if (allow_with_software_fb)
+      glFinish();
+
    if (scissor_was_enabled)
       glEnable(GL_SCISSOR_TEST);
 


### PR DESCRIPTION
## Description

Some drivers do not make dependency-driven framebuffer mirrors visible to the following texture fetch without explicit completion.

Complete these mirrors before their consumers are queued to prevent stale framebuffer contents from being sampled.

## Related issues

https://github.com/libretro/beetle-psx-libretro/pull/984 caused a difficult to reproduce regression. The Konami splash screen in Silent Hill would display as a white screen on some android devices. This fixes that issue.

## LLM disclosure
Testing, and debugging by me. Code change drafts by LLM, reviewed, tested, and adjusted by me.