### PR TITLE
HD textures: Reduce Palette Range fused-path fix + replacement loading reliability

### DIFF
--- a/HD_TEXTURE_CACHE.md
+++ b/HD_TEXTURE_CACHE.md
@@ -157,6 +157,18 @@ INFO log line shows the active mode and `used/budget` for each tier.
   full-palette hash, so existing full-palette packs still match with it enabled.
   Off by default — re-dump a game to benefit.
 
+  **Fused-page path** (fixed): a draw whose sample region spans several uploads
+  composites them through a fused page. The fusion used to look each upload's
+  image up under the draw's **full**-palette hash only, while the draw path had
+  bound those images under each upload's **reduced** hash — so composited draws
+  (e.g. a text line built from dozens of per-glyph uploads, as in SotN's end
+  credits) replaced nothing with the option enabled. Each `FusedPage` now
+  snapshots the draw's gathered CLUT contents at creation, and
+  `fusion_rects()` / `rebuild_page()` resolve the same per-upload effective hash
+  as the single-upload path (`fused_effective_palette_hash()`: reduced when that
+  file exists, else full), so fused pages find and blit exactly the images the
+  draw path bound. Behaviour with the option off is unchanged.
+
 ### Build
 
 Build the HW core as usual — `make HAVE_HW=1` — then optionally `strip` the

--- a/TT_RELIABILITY_AUDIT.md
+++ b/TT_RELIABILITY_AUDIT.md
@@ -137,6 +137,18 @@ dedup — kills the O(n^2) reload stall), handle-cache doubled hd_tex_map_find
 fixed, savestate re-warm routed through want_combo (dedup + cache-skip).
 All in rhi/rhi_tt.c (154 insertions / 44 deletions).
 
+### Finding H (2026-08-21b, from Jed's flicker localization) — per-mutation inline
+fused rebuilds. Flicker appeared ONLY in streaming-text scenes (typewriter
+dialogue at boss intros, end credits) and never in upload-once static text, and
+predated every loader patch. Cause: the upload/blit hooks called
+`fused_pages_rebuild_dirty` INLINE on every VRAM mutation — once per typed
+character — clearing + re-blitting an in-place-reused composite image mid-frame
+while earlier draws of the frame still referenced it (vk_tt_page_begin reuses
+the same handle and records into the current command buffer). FIXED (commit
+7eb7ddea): hooks only mark dirty; rebuilds coalesced to the on_queues_reset safe
+point + a page's FIRST serve of each frame (`rebuilt_frame` stamp on FusedPage).
+Trade-off: mid-frame mutations reach the composite one serve later.
+
 Not yet done (candidates for a later pass): Eager re-prefetch after reload,
 `requested`/pending clear on caching-mode switch, reload IO generation stamp,
 the GL on_queues_reset gap, the `replace_textures_applied` static latch, the

--- a/TT_RELIABILITY_AUDIT.md
+++ b/TT_RELIABILITY_AUDIT.md
@@ -1,0 +1,143 @@
+# rhi_tt HD replacement pipeline — reliability audit (2026-08-21)
+
+*Trigger: with the fused-path Reduce fix deployed, text replacements still fail
+intermittently — reload (') recovers a varying subset, Eager loads more than Lazy,
+all modes miss some, and single-upload sprites occasionally slip one native frame
+even in Lazy (synchronous). Audit of the request → IO → cache → attach → bind → fuse
+lifecycle in `rhi/rhi_tt.c` (branch `reduce-fused-fix`). Every finding below marked
+CONFIRMED was verified by direct code reading; line numbers refer to this branch.*
+
+Symptoms: **S1** text intermittently never loads / reload shuffles the subset;
+**S2** Eager > Lazy for text; **S3** even Eager misses some; **S4** 1-frame native
+slips of ordinary sprites in Lazy (synchronous); (budgets are not a factor).
+
+## Confirmed defects (ranked)
+
+### A. Draw-loop early-return starves requests for fused draws — CONFIRMED (S1, S2 primary)
+`texture_tracker_get_hd_texture_index`'s overlap loop is the ONLY producer of
+upload-rect load requests in Lazy modes (`request_hd_texture`, rhi_tt.c:4331), but
+it `return fused_pages_get_or_make(...)` MID-LOOP at the second image-bearing
+upload (4340-4351). Uploads later in overlap order are never iterated — never
+requested, this frame or any later frame (positions 0,1 stay bound, so the gate
+re-forms identically). The fused machinery itself only looks up
+(`hd_tex_map_find`, fusion_rects:5717), never requests. In Lazy (synchronous) it
+is brutally deterministic: exactly TWO glyphs of a 20-glyph line ever load.
+**Fix:** complete the overlap iteration (requesting every unbound upload) before
+deciding single-vs-fused; return the fused handle after the loop.
+
+### B. `want_combo` cache-hit early-out never attaches — CONFIRMED (S3, S1)
+rhi_tt.c:3825-3826: combo already in GPU/CPU cache → plain `return` — no bind, no
+`pending_attach`. Bindings live on `TextureUpload` objects, and text uploads churn
+(rects overwritten → upload destroyed → re-created with an EMPTY textures map). So
+Eager's upload-time prefetch is a NO-OP exactly for recreated uploads whose images
+are already cached — those depend entirely on the starved draw loop (A).
+**Fix:** on cache hit insert `pending_attach` (the attach pass already handles
+both tiers) instead of returning silently.
+
+### C. `pending_attach` is one-shot; unattached combos are dropped — CONFIRMED (S1, S3)
+Attach pass: `find_upload(id.hash) == NULL → continue /* kept in cache */`
+(4997-4999) — but `hd_key_set_clear(&self->pending_attach)` right after the pass
+(5051) discards the marker for skipped combos too. A response draining while the
+glyph's upload is momentarily dead (text rows recycle constantly) is consumed with
+no attach and no re-arm; with B, nothing ever re-binds it. The IO-vs-recycle race
+decides which glyphs survive → the reload-to-reload variance.
+**Fix:** retain unattached keys (clear only attached / dimension-rejected /
+cache-evicted entries).
+
+### D. In-frame GPU-cache bind never dirties fused pages — CONFIRMED (S1, S2)
+`request_hd_texture`'s GPU-hit branch binds and returns (3877-3882) WITHOUT
+`fused_pages_mark_dirty` — unlike sync_load_combo (4802-4809) and the attach pass
+(5008-5013). A glyph that does get bound via the draw loop stays invisible to an
+existing fused page until something else dirties it. Lazy binds mostly through
+this silent path; Eager mostly through the marking attach pass — another Eager/Lazy
+asymmetry.
+**Fix:** mark this upload's live rects dirty after the bind (same loop as
+sync_load_combo).
+
+### E. `fused_pages_get_or_make` serves an existing DIRTY page stale — CONFIRMED (S4, S1)
+The found-branch (5900-5915) never checks `p->dirty` and never rebuilds; dirty
+pages rebuild only at the next upload/blit or safe point. Binds made THIS frame
+(sync loads included) render native for ≥1 frame on any fused draw — the likely
+mechanism of the 1-frame sprite slips when a draw routes through fusion, and a
++1-frame lag on all text convergence.
+**Fix:** `if (p->dirty) rebuild_page(p, tracker, tt);` before returning (the
+new-page path already calls rebuild_page from this context; `fusionrects_eq`
+keeps the no-change cost trivial).
+
+### F. IO worker silent on failure → permanent `requested` poison — CONFIRMED (S1, S3 residue)
+The worker pushes a response only on success (3106-3125); failure just logs. The
+combo stays in `requested` forever (the design comment at 3818-3820 states it:
+"never retried (until a reload clears it)"). Intended for missing files, but it
+fires identically for TRANSIENT failures — AV/indexer sharing violations on a
+25k-file folder, handle pressure during 4-worker bursts. `sync_load_combo` inserts
+the same permanent negative on failure (4774-4777).
+**Fix:** always push a response with a success flag; on failure erase `requested`
+(bounded retries), keep the permanent negative only for genuine not-found.
+Grep the RetroArch log for "failed to load:" to gauge how often this fires.
+
+### G. `rect_tracker_place` doesn't dirty the lookup grid — CONFIRMED (S4)
+`rect_tracker_clear`/`upload`/`blit` set `lookup_grid_dirty`; `rect_tracker_place`
+(5481-5485, used by the readback-restore path at 3756-3761) does not — restored
+rects are invisible to `rect_tracker_overlapping` (4188) until something else
+dirties the grid, so a fully-cached sprite can miss for the rest of the frame.
+One-line fix: set the flag in `rect_tracker_place`.
+
+## Plausible, not yet verified in depth
+
+- **Eager prefetch fires only on first-ever upload of a hash** (`!preexisting`,
+  3776) and is never re-run by reload → post-reload Eager behaves like Lazy.
+- **Mode switch doesn't clear `requested`** (set_config): switching into
+  Lazy (synchronous) with async requests in flight blocks the sync loader (4765).
+- **Reload doesn't quiesce in-flight IO** (no generation stamp) and doesn't clear
+  `handle_cache`.
+- **GL renderer never calls `texture_tracker_on_queues_reset`** → async attach
+  never runs on GL at all (Vulkan unaffected).
+- **`replace_textures_applied` is a process-lifetime function-static** (6250):
+  after a tracker recreation (context rebuild) replacement stays silently disabled
+  until the option is re-toggled.
+- **Non-canonical pack filenames** (zero-padded hex) enumerate into known_files
+  via `sscanf %x-%x` but the loader probes only the canonical `%x` spelling.
+
+## Efficiency notes (secondary)
+
+- `known_files` is built by per-insert memmove into a sorted array → O(n²): with
+  25k files that is ~2.5 GB of moves on init AND on every reload keypress (the
+  reload stall). Collect unsorted + one qsort.
+- `texture_tracker_find_upload` is a linear scan over all live rects, run per
+  upload and per attach; the attach pass also scans ALL rects per attached combo
+  to mark fused pages dirty. O(uploads × rects) per frame in text-heavy scenes.
+- `hd_tex_map_find` computed twice in one expression on the handle-cache hit path
+  (4177).
+- The shader fastpath is force-disabled in rhi_lib_vulkan.c:8780
+  (`fastpath_capable_out = false;` immediately after the call — debug leftover),
+  yet the tracker still computes fastpath capability per draw.
+- Savestate re-warm (`load_hd_texture`, 3792) bypasses `want_combo`'s cache/
+  in-flight dedup → up to triple decodes per combo after a savestate load.
+
+## How the symptoms decompose
+
+- **S1** = A (starvation) + C (dropped attaches) + D (invisible binds) + F (poison),
+  all reshuffled by reload because reload clears bindings/caches/`requested` and
+  re-runs every race with fresh timing.
+- **S2** = Eager's upload-time prefetch + marking attach pass bypass A and D;
+  Lazy depends wholly on the starved, non-marking draw loop.
+- **S3** = B (prefetch no-op for cached combos on recreated uploads) + C + F.
+- **S4** = E (stale fused page served) + G (restored rect invisible).
+
+## Patch set — IMPLEMENTED (branch `reduce-fused-fix`, 2026-08-21)
+
+P1 (A) full overlap iteration before the fuse decision; P2 (B) want_combo
+cache-hit schedules pending_attach; P3 (C) attach pass retains unresident keys
+(dropped only when evicted from both caches); P4 (D) GPU-hit bind marks fused
+pages dirty; P5 (E) fused_pages_get_or_make rebuilds a dirty page before serving
+it; P6 (F) IO worker pushes empty-levels failure responses, drain erases
+`requested` so the next draw retries; P7 (G) rect_tracker_place sets
+lookup_grid_dirty. Efficiency: known_files bulk build (append + one qsort +
+dedup — kills the O(n^2) reload stall), handle-cache doubled hd_tex_map_find
+fixed, savestate re-warm routed through want_combo (dedup + cache-skip).
+All in rhi/rhi_tt.c (154 insertions / 44 deletions).
+
+Not yet done (candidates for a later pass): Eager re-prefetch after reload,
+`requested`/pending clear on caching-mode switch, reload IO generation stamp,
+the GL on_queues_reset gap, the `replace_textures_applied` static latch, the
+fastpath force-disable in rhi_lib_vulkan.c:8780, find_upload hash map.

--- a/rhi/rhi_tt.c
+++ b/rhi/rhi_tt.c
@@ -1099,6 +1099,14 @@ static void rect_tracker_clear(struct RectTracker *self, SRect rect)
       size_t   bytes;      /* approx VRAM footprint of texture (w*h*4); for the LRU budget */
       uint64_t last_used;  /* LRU tick (higher = more recently used) */
 
+      /* Reduce Palette Range: snapshot of the draw's gathered CLUT contents at
+       * page creation (`palette` identifies it, so equal hash = equal contents).
+       * Rebuilds use it to resolve each upload's REDUCED-range hash - the hash
+       * the draw path bound its image under - instead of only the full-palette
+       * `palette`. pal_count 0 = no snapshot (option off / palette ungathered). */
+      uint16_t pal_data[256];
+      unsigned pal_count;
+
       FusionRects fusion;
    };
 
@@ -1118,6 +1126,8 @@ static void fp_copy(FusedPage *dst, const FusedPage *src) {
       dst->dead            = src->dead;
       dst->bytes           = src->bytes;
       dst->last_used       = src->last_used;
+      memcpy(dst->pal_data, src->pal_data, sizeof(dst->pal_data));
+      dst->pal_count       = src->pal_count;
       dst->fusion.vram_rect = src->fusion.vram_rect;
       dst->fusion.scaleX    = src->fusion.scaleX;
       dst->fusion.scaleY    = src->fusion.scaleY;
@@ -1135,6 +1145,7 @@ static void fp_init_raw(FusedPage *p) {
       ownedrects_init(&p->fusion.rects);
       p->bytes = 0;
       p->last_used = 0;
+      p->pal_count = 0;
    }
 static void fp_destroy(FusedPage *p) {
       ih_reset(&p->texture);
@@ -1226,14 +1237,18 @@ static void fused_pages_deinit(struct FusedPages *self) { fused_page_vec_deinit(
    static HdTextureHandle fused_pages_get_or_make(struct FusedPages *self,
          TTRect page_rect,
          uint32_t palette,
-         struct RectTracker *tracker);
+         struct RectTracker *tracker,
+         TextureTracker *tt,               /* for Reduce Palette Range resolution */
+         const uint16_t *pal_data,         /* draw's gathered CLUT (NULL if none) */
+         unsigned pal_count);
    static HdTexture fused_pages_get_from_handle(struct FusedPages *self,
          HdTextureHandle handle,
          ImageHandle *default_hd_texture);
    static void fused_pages_mark_dirty(struct FusedPages *self, TTRect rect); /* For blit dst, upload, and hd texture load */
    static void fused_pages_mark_dead(struct FusedPages *self, TTRect rect); /* For clear */
    static void fused_pages_rebuild_dirty(struct FusedPages *self,
-         struct RectTracker *tracker);
+         struct RectTracker *tracker,
+         TextureTracker *tt);
    static void fused_pages_remove_dead(struct FusedPages *self);
    static void fused_pages_evict(struct FusedPages *self); /* LRU-evict live pages to the budget */
    static int64_t page_bytes(FusionRects *fusion); /* approx VRAM footprint of a fused page */
@@ -3534,7 +3549,7 @@ static TTRect fromSRect(SRect rect) {
       rect_tracker_blit(&self->tracker, make_srect(dst.x, dst.y, dst.width, dst.height), make_srect(src.x, src.y, src.width, src.height));
       texture_tracker_mirror_blit(self, dst, src); /* keep the page mirror current */
       fused_pages_mark_dirty(&self->fused_pages, dst);
-      fused_pages_rebuild_dirty(&self->fused_pages, &self->tracker);
+      fused_pages_rebuild_dirty(&self->fused_pages, &self->tracker, self);
       texture_tracker_clear_palette_cache(self, dst);
    }
 
@@ -3748,7 +3763,7 @@ static TTRect fromSRect(SRect rect) {
          rect_tracker_upload(&self->tracker, toSRect(rect), upload);
       }
       fused_pages_mark_dirty(&self->fused_pages, rect);
-      fused_pages_rebuild_dirty(&self->fused_pages, &self->tracker);
+      fused_pages_rebuild_dirty(&self->fused_pages, &self->tracker, self);
 
       /* HD texture caching method: - Lazy (self->eager_textures=false): nothing
        * is queued here; each (hash,palette) is loaded on demand when first
@@ -4330,7 +4345,10 @@ static TTRect fromSRect(SRect rect) {
                   : 256;
                TTRect page_rect = { page_x, page_y, width, 256 };
                (*fastpath_capable_out) = false;
-               return fused_pages_get_or_make(&self->fused_pages, page_rect, palette_hash, &self->tracker);
+               return fused_pages_get_or_make(&self->fused_pages, page_rect, palette_hash, &self->tracker,
+                     self,
+                     have_pal_data ? pal_local : NULL,
+                     have_pal_data ? (unsigned)palette_rect.width : 0);
             }
          }
       } }
@@ -5060,7 +5078,7 @@ static bool is_power_of_two(int n) {
       }
       hd_key_set_clear(&self->pending_attach_pages);
 
-      fused_pages_rebuild_dirty(&self->fused_pages, &self->tracker);
+      fused_pages_rebuild_dirty(&self->fused_pages, &self->tracker, self);
       fused_pages_evict(&self->fused_pages);      /* LRU-evict to budget (marks dead) */
       fused_pages_remove_dead(&self->fused_pages); /* free the marked-dead pages' VRAM */
 
@@ -5631,10 +5649,57 @@ static int64_t page_bytes(FusionRects *fusion)
       return 0;
    }
 
+   /* Per-upload effective palette hash for the FUSED-page path: the same
+    * reduced-range resolution the single-upload draw path applies (reduced hash
+    * preferred only when that replacement file exists, else the full hash), so
+    * a fused page finds/blits the images the draw path actually bound. Mode is
+    * implied by the fused page's width (64 = 4bpp, 128 = 8bpp). Without this,
+    * composited multi-upload draws (e.g. SotN's end-credits letter lines, built
+    * from dozens of 12x16 glyph uploads drawn by one 240x16 line prim) bind
+    * nothing when Reduce Palette Range is enabled: the images sit in
+    * upload->textures under reduced hashes while the fusion looked up only the
+    * full hash. */
+   static uint32_t fused_effective_palette_hash(TextureTracker *tt,
+         TextureUpload *upload,
+         unsigned page_width,
+         const uint16_t *pal_data,
+         unsigned pal_count,
+         uint32_t full_hash){
+      int mode;
+      uint32_t rh;
+      HdTextureId rid;
+      if (tt == NULL || !tt->reduce_palette_range || pal_data == NULL || pal_count == 0)
+         return full_hash;
+      if (page_width == 64)
+         mode = (int)TextureMode_Palette4bpp;
+      else if (page_width == 128)
+         mode = (int)TextureMode_Palette8bpp;
+      else
+         return full_hash;                     /* direct colour: no palette */
+      if (mode == (int)TextureMode_Palette8bpp && pal_count < 256)
+         return full_hash;
+      if (mode == (int)TextureMode_Palette4bpp && pal_count < 16)
+         return full_hash;
+      rh = texture_tracker_effective_palette_hash_upload(tt, upload, mode, pal_data, full_hash);
+      if (rh == full_hash)
+         return full_hash;
+      /* Same gating as the draw path: prefer the reduced hash only when a
+       * reduced-range file exists, so full-palette packs keep matching. */
+      rid.hash = upload->hash;
+      rid.palette_hash = rh;
+      rid.pages = false;
+      if (hd_key_set_contains(&tt->known_files, hd_pack_key(rid)))
+         return rh;
+      return full_hash;
+   }
+
    static void fusion_rects(struct FusionRects *out,
          TTRect full_page_rect,
          uint32_t palette_hash,
-         struct RectTracker *tracker){
+         struct RectTracker *tracker,
+         TextureTracker *tt,
+         const uint16_t *pal_data,
+         unsigned pal_count){
       int _ei;
       struct FusionRects *f = out;
       fusionrects_init(f);
@@ -5647,7 +5712,9 @@ static int64_t page_bytes(FusionRects *fusion)
          intersection = intersect(toSRect(full_page_rect), e->texture_rect.vram_rect);
          if (intersection.valid) {
             TextureUpload *upload = e->texture_rect.upload;
-            HdTexEntry *hd_texture = hd_tex_map_find(&upload->textures, palette_hash);
+            uint32_t eff = fused_effective_palette_hash(tt, upload,
+                  (unsigned)full_page_rect.width, pal_data, pal_count, palette_hash);
+            HdTexEntry *hd_texture = hd_tex_map_find(&upload->textures, eff);
             if (hd_texture != NULL) {
                TTRect r;
                /* Clip to the destination texture (important, otherwise it might blit out of bounds which may have wrought havoc upon my sanity) */
@@ -5672,7 +5739,8 @@ static int64_t page_bytes(FusionRects *fusion)
    }
 
    static void rebuild_page(FusedPage *page,
-         struct RectTracker *tracker){
+         struct RectTracker *tracker,
+         TextureTracker *tt){
       int texture_width;
       TT_LOG_VERBOSE(RETRO_LOG_INFO, "Rebuilding page for %x, %d,%d %dx%d\n",
             page->palette,
@@ -5686,7 +5754,8 @@ static int64_t page_bytes(FusionRects *fusion)
 
       {
          FusionRects fusion;
-         fusion_rects(&fusion, page->full_page_rect, page->palette, tracker);
+         fusion_rects(&fusion, page->full_page_rect, page->palette, tracker, tt,
+               page->pal_count ? page->pal_data : NULL, page->pal_count);
          if (fusionrects_eq(&page->fusion, &fusion)) {
             TT_LOG_VERBOSE(RETRO_LOG_INFO, "Rebuilt page: no change\n");
             fusionrects_destroy(&fusion);
@@ -5731,7 +5800,11 @@ static int64_t page_bytes(FusionRects *fusion)
          TextureRect *tex = &page->fusion.rects.v.items[_fri];
          TextureUpload *upload = tex->upload;
 
-         HdTexEntry *hd_texture = hd_tex_map_find(&upload->textures, page->palette);
+         HdTexEntry *hd_texture = hd_tex_map_find(&upload->textures,
+               fused_effective_palette_hash(tt, upload,
+                     (unsigned)page->full_page_rect.width,
+                     page->pal_count ? page->pal_data : NULL,
+                     page->pal_count, page->palette));
          /* That's odd */
          if (hd_texture == NULL)
             continue;
@@ -5816,14 +5889,27 @@ static int64_t page_bytes(FusionRects *fusion)
    static HdTextureHandle fused_pages_get_or_make(struct FusedPages *self,
          TTRect page_rect,
          uint32_t palette,
-         struct RectTracker *tracker){
+         struct RectTracker *tracker,
+         TextureTracker *tt,
+         const uint16_t *pal_data,
+         unsigned pal_count){
       int x;
       FusedPage page;
+      if (pal_count > 256)
+         pal_count = 256;
       for (x = 0; x < fused_page_vec_size(&self->pages); x++)
       {
          FusedPage *p = fused_page_vec_at(&self->pages, x);
          /* return page */
          if (!p->dead && p->palette == palette && rect_eq(&p->full_page_rect, &page_rect)) {
+            if (p->pal_count == 0 && pal_data != NULL && pal_count > 0) {
+               /* Page predates the palette snapshot (e.g. Reduce Palette Range
+                * toggled mid-session): adopt it and re-fuse so per-upload
+                * reduced hashes resolve. */
+               memcpy(p->pal_data, pal_data, (size_t)pal_count * sizeof(uint16_t));
+               p->pal_count = pal_count;
+               rebuild_page(p, tracker, tt);
+            }
             p->last_used = ++self->tick; /* touch LRU */
             return hd_handle_make_fused(x);
          }
@@ -5847,7 +5933,12 @@ static int64_t page_bytes(FusionRects *fusion)
       page.dirty = false;
       page.full_page_rect = page_rect;
       page.palette = palette;
-      rebuild_page(&page, tracker);
+      page.pal_count = 0;
+      if (pal_data != NULL && pal_count > 0) {
+         memcpy(page.pal_data, pal_data, (size_t)pal_count * sizeof(uint16_t));
+         page.pal_count = pal_count;
+      }
+      rebuild_page(&page, tracker, tt);
       page.last_used = ++self->tick;
       page.bytes = ih_is_valid(&page.texture)
          ? (size_t)tt_img_width(ih_get(&page.texture)) * (size_t)tt_img_height(ih_get(&page.texture)) * 4u
@@ -5874,13 +5965,14 @@ static int64_t page_bytes(FusionRects *fusion)
       }
    }
    static void fused_pages_rebuild_dirty(struct FusedPages *self,
-         struct RectTracker *tracker){
+         struct RectTracker *tracker,
+         TextureTracker *tt){
       bool changed = false;
       int _i;
       for (_i = 0; _i < fused_page_vec_size(&self->pages); _i++) {
          FusedPage *page = fused_page_vec_at(&self->pages, _i);
          if (!page->dead && page->dirty) {
-            rebuild_page(page, tracker);
+            rebuild_page(page, tracker, tt);
             changed = true;
          }
       }

--- a/rhi/rhi_tt.c
+++ b/rhi/rhi_tt.c
@@ -1107,6 +1107,15 @@ static void rect_tracker_clear(struct RectTracker *self, SRect rect)
       uint16_t pal_data[256];
       unsigned pal_count;
 
+      /* Frame stamp of the last rebuild (tracker frame counter). Guards the
+       * serve-time rebuild to at most once per page per frame: streaming
+       * content (typewriter dialogue, credits lines building letter by letter)
+       * dirties a page many times per frame, and rebuilding an in-place-reused
+       * image while earlier draws of the same frame reference it produced
+       * transient partial composites (visible flicker in exactly those
+       * scenes). (uint64_t)-1 = never rebuilt. */
+      uint64_t rebuilt_frame;
+
       FusionRects fusion;
    };
 
@@ -1128,6 +1137,7 @@ static void fp_copy(FusedPage *dst, const FusedPage *src) {
       dst->last_used       = src->last_used;
       memcpy(dst->pal_data, src->pal_data, sizeof(dst->pal_data));
       dst->pal_count       = src->pal_count;
+      dst->rebuilt_frame   = src->rebuilt_frame;
       dst->fusion.vram_rect = src->fusion.vram_rect;
       dst->fusion.scaleX    = src->fusion.scaleX;
       dst->fusion.scaleY    = src->fusion.scaleY;
@@ -1146,6 +1156,7 @@ static void fp_init_raw(FusedPage *p) {
       p->bytes = 0;
       p->last_used = 0;
       p->pal_count = 0;
+      p->rebuilt_frame = (uint64_t)-1;
    }
 static void fp_destroy(FusedPage *p) {
       ih_reset(&p->texture);
@@ -3596,8 +3607,11 @@ static TTRect fromSRect(SRect rect) {
          TTRect src){
       rect_tracker_blit(&self->tracker, make_srect(dst.x, dst.y, dst.width, dst.height), make_srect(src.x, src.y, src.width, src.height));
       texture_tracker_mirror_blit(self, dst, src); /* keep the page mirror current */
+      /* Mark only - rebuilds are COALESCED to the safe point / first serve of
+       * the frame. The inline rebuild here ran once per VRAM blit (once per
+       * typed character during dialogue), clearing+re-blitting a possibly
+       * in-use composite mid-frame: the streaming-text flicker. */
       fused_pages_mark_dirty(&self->fused_pages, dst);
-      fused_pages_rebuild_dirty(&self->fused_pages, &self->tracker, self);
       texture_tracker_clear_palette_cache(self, dst);
    }
 
@@ -3810,8 +3824,10 @@ static TTRect fromSRect(SRect rect) {
       } else {
          rect_tracker_upload(&self->tracker, toSRect(rect), upload);
       }
+      /* Mark only - rebuilds are COALESCED (see texture_tracker_blit). Uploads
+       * during streaming text (credits letters, dialogue glyphs) dirtied and
+       * inline-rebuilt composites once per letter. */
       fused_pages_mark_dirty(&self->fused_pages, rect);
-      fused_pages_rebuild_dirty(&self->fused_pages, &self->tracker, self);
 
       /* HD texture caching method: - Lazy (self->eager_textures=false): nothing
        * is queued here; each (hash,palette) is loaded on demand when first
@@ -5853,6 +5869,7 @@ static int64_t page_bytes(FusionRects *fusion)
                );
 
       page->dirty = false;
+      page->rebuilt_frame = tt ? tt->frame : (uint64_t)-1;
 
       {
          FusionRects fusion;
@@ -6012,13 +6029,17 @@ static int64_t page_bytes(FusionRects *fusion)
                p->pal_count = pal_count;
                rebuild_page(p, tracker, tt);
             }
-            /* Serve the page FRESH: bindings made earlier this frame (sync
-             * loads, in-frame GPU-cache hits) only MARK the page dirty, and
-             * dirty pages used to rebuild no earlier than the next VRAM write
-             * or safe point - so every fused draw rendered at least one frame
-             * behind its own bindings (a native flash even in Lazy-sync).
-             * rebuild_page early-outs via fusionrects_eq when nothing changed. */
-            if (p->dirty)
+            /* Serve the page FRESH - but at most ONE rebuild per page per
+             * frame. The first serve of a frame rebuilds a dirty page (so
+             * bindings made since last frame show without a native flash, even
+             * in Lazy-sync); later same-frame serves of a re-dirtied page keep
+             * the image stable instead of clearing+re-blitting it while
+             * earlier draws of this frame still reference it (streaming text
+             * dirties a page per typed character - rebuilding per mutation
+             * produced transient partial composites = flicker). Re-dirtied
+             * pages catch up at the next safe point or next frame's first
+             * serve. rebuild_page early-outs via fusionrects_eq if unchanged. */
+            if (p->dirty && (tt == NULL || p->rebuilt_frame != tt->frame))
                rebuild_page(p, tracker, tt);
             p->last_used = ++self->tick; /* touch LRU */
             return hd_handle_make_fused(x);

--- a/rhi/rhi_tt.c
+++ b/rhi/rhi_tt.c
@@ -3121,7 +3121,24 @@ static uint8_t *loaded_pixel(LoadedImage *image, int x, int y) {
 
                rgba_image_free(&image);
             } else {
+               /* FAILURE response (empty levels): previously the failure branch
+                * pushed nothing, so the combo stayed in `requested` forever -
+                * one transient open/decode failure (AV/indexer sharing
+                * violation, handle pressure during a burst) meant permanent
+                * native until a manual reload. The drain erases `requested` on
+                * an empty response so the next draw can retry. */
+               IOResponse *response = (IOResponse *)malloc(sizeof(IOResponse));
                TT_LOG(RETRO_LOG_ERROR, "failed to load: %s\n", path);
+               response->next         = NULL;
+               response->hash         = hash;
+               response->palette_hash = palette_hash;
+               response->alpha_flags  = 0;
+               response->pages        = request->pages;
+               loaded_levels_init(&response->levels);
+
+               slock_lock(channel->lock);
+               io_channel_push_response(channel, response);
+               slock_unlock(channel->lock);
             }
          } else if (request->kind == IORequestKind_Dump) {
             /* Decode (palette->RGBA->tri-alpha) here on the worker, then encode+write,
@@ -3286,6 +3303,15 @@ static uint8_t *loaded_pixel(LoadedImage *image, int x, int y) {
       }
    }
 
+   /* qsort comparator for HdKeySet bulk builds (u64 ascending). */
+   static int hd_key_u64_cmp(const void *a, const void *b) {
+      uint64_t ka = *(const uint64_t *)a;
+      uint64_t kb = *(const uint64_t *)b;
+      if (ka < kb) return -1;
+      if (ka > kb) return 1;
+      return 0;
+   }
+
    static void read_texture_directory(HdKeySet *out, const char *path, bool pages) {
       RDIR *dir;
       hd_key_set_clear(out);
@@ -3311,10 +3337,32 @@ static uint8_t *loaded_pixel(LoadedImage *image, int x, int y) {
             /* pages=true sets id.pages so hd_pack_key salts these away from the
              * upload-rect keyspace (they share the cache, separate known_files). */
             id.hash = hash; id.palette_hash = palette_hash; id.pages = pages;
-            hd_key_set_insert(out, hd_pack_key(id));
+            /* Bulk build: append unsorted, then one qsort+dedup below. The
+             * sorted-insert (memmove per key) made this scan O(n^2) - with a
+             * 25k-file pack that is gigabytes of moves, paid at init AND on
+             * every reload-textures keypress (the reload stall). */
+            if (out->count == out->cap) {
+               int ncap = out->cap ? out->cap * 2 : 16;
+               uint64_t *nk = (uint64_t *)realloc(out->keys, (size_t)ncap * sizeof(uint64_t));
+               if (nk == NULL)
+                  break;
+               out->keys = nk;
+               out->cap = ncap;
+            }
+            out->keys[out->count++] = hd_pack_key(id);
             TT_LOG_VERBOSE(RETRO_LOG_INFO, "file found: %s\n", name);
          }
          retro_closedir(dir);
+      }
+      if (out->count > 1) {
+         int r, w;
+         qsort(out->keys, (size_t)out->count, sizeof(uint64_t), hd_key_u64_cmp);
+         /* dedup in place (the same combo present in several extensions) */
+         w = 1;
+         for (r = 1; r < out->count; r++)
+            if (out->keys[r] != out->keys[w - 1])
+               out->keys[w++] = out->keys[r];
+         out->count = w;
       }
    }
 
@@ -3790,25 +3838,22 @@ static TTRect fromSRect(SRect rect) {
    }
 
    static void texture_tracker_load_hd_texture(struct TextureTracker *self, uint32_t hash) {
+      /* Savestate re-warm. Route through want_combo (like the Eager prefetch)
+       * rather than raw IORequest pushes: that restores the cache-hit skip,
+       * in-flight dedup via `requested`, and low-priority classification. The
+       * raw path re-read and re-decoded already-cached combos wholesale after
+       * every savestate load, and could triple-load one combo (raw + draw-path
+       * async + lazy-sync inline). */
       int lo = hd_key_set_lower_bound(&self->known_files, (uint64_t)hash << 32);
       int hi = hd_key_set_lower_bound(&self->known_files, ((uint64_t)hash + 1) << 32);
-      if (lo != hi) {
-         int ki;
-         slock_lock(self->iothread.channel->lock);
-         for (ki = lo; ki < hi; ki++) {
-            uint32_t palette_hash = (uint32_t)self->known_files.keys[ki];
-            IORequest *load = (IORequest *)malloc(sizeof(IORequest));
-            TT_LOG_VERBOSE(RETRO_LOG_INFO, "requesting texture: %x-%x\n", hash, palette_hash);
-            load->next = NULL;
-            load->kind = IORequestKind_Load;
-            load->hash = hash;
-            load->palette_hash = palette_hash;
-            load->pages = false;
-            load->src = NULL; load->palette = NULL; /* Load: no dump payload to free */
-            io_channel_push_request(self->iothread.channel, load); /* savestate warm = background */
-         }
-         slock_unlock(self->iothread.channel->lock);
-         scond_signal(self->iothread.channel->cond);
+      int ki;
+      for (ki = lo; ki < hi; ki++) {
+         HdTextureId combo;
+         combo.hash = hash;
+         combo.palette_hash = (uint32_t)self->known_files.keys[ki];
+         combo.pages = false;
+         TT_LOG_VERBOSE(RETRO_LOG_INFO, "requesting texture: %x-%x\n", hash, combo.palette_hash);
+         texture_tracker_want_combo(self, combo, false, false); /* savestate warm = background */
       }
    }
 
@@ -3822,8 +3867,19 @@ static TTRect fromSRect(SRect rect) {
       /* pages=true sources the file from the -pages folder and checks
        * known_files_pages; both feed the SAME 3-tier cache (id.pages namespaces
        * the shared requested/hd_cache/hd_gpu_cache via hd_pack_key's salt). */
-      if (HdGpuCache_contains(&self->hd_gpu_cache, hd_pack_key(id)) || HdImageCache_contains(&self->hd_cache, hd_pack_key(id)))
-         return; /* already resident in VRAM, or already decoded in RAM */
+      if (HdGpuCache_contains(&self->hd_gpu_cache, hd_pack_key(id)) || HdImageCache_contains(&self->hd_cache, hd_pack_key(id))) {
+         /* Already decoded/resident - but not necessarily BOUND to the current
+          * upload object: bindings live on TextureUpload, and uploads are
+          * destroyed and recreated (with EMPTY textures maps) as their VRAM
+          * recycles. Schedule an attach so the safe-point pass re-binds the
+          * cached image; returning silently here made the Eager prefetch a
+          * no-op exactly for cached combos on recreated uploads. */
+         if (pages)
+            hd_key_set_insert(&self->pending_attach_pages, ((uint64_t)id.hash << 32) | (uint64_t)id.palette_hash);
+         else
+            hd_key_set_insert(&self->pending_attach, hd_pack_key(id));
+         return;
+      }
       if (!hd_key_set_insert(&self->requested, hd_pack_key(id)))
          return; /* already in flight, or negatively cached */
       if (!hd_key_set_contains(pages ? &self->known_files_pages : &self->known_files, hd_pack_key(id)))
@@ -3878,6 +3934,16 @@ static TTRect fromSRect(SRect rect) {
       if (gpu != NULL) {
          hd_tex_map_set(&upload->textures, palette_hash, gpu->image, gpu->alpha_flags);
          self->dbg_attaches++;
+         /* Invalidate covering fused pages, exactly like sync_load_combo and
+          * the safe-point attach pass do - this was the one bind site that
+          * didn't, so a composite that predated the bind kept rendering the
+          * native texels for this upload indefinitely. */
+         { int _ti; for (_ti = 0; _ti < self->tracker.textures.count; _ti++)
+         {
+            EnduringTextureRect *e = &self->tracker.textures.a[_ti];
+            if (e->alive && e->texture_rect.upload == upload)
+               fused_pages_mark_dirty(&self->fused_pages, fromSRect(e->texture_rect.vram_rect));
+         } }
          return;
       }
 
@@ -4174,7 +4240,8 @@ static TTRect fromSRect(SRect rect) {
                /* Index by the handle's own palette hash (may be a reduced-range hash),
                 * not the draw's full palette_hash. */
                uint32_t hh = cache_result.handle.palette_hash;
-               (*fastpath_capable_out) = self->fastpath_enabled && ((hd_tex_map_find(&tex->texture_rect.upload->textures, hh) ? hd_tex_map_find(&tex->texture_rect.upload->textures, hh)->alpha_flags : 0) & ALPHA_FLAG_TRANSPARENT) == 0;
+               HdTexEntry *hce = hd_tex_map_find(&tex->texture_rect.upload->textures, hh);
+               (*fastpath_capable_out) = self->fastpath_enabled && (((hce ? hce->alpha_flags : 0) & ALPHA_FLAG_TRANSPARENT) == 0);
                return cache_result.handle;
             }
          }
@@ -4305,7 +4372,16 @@ static TTRect fromSRect(SRect rect) {
 
       result = hd_handle_make_none();
 
-      { int oi; for (oi = 0; oi < overlap.count; oi++) {
+      { int oi;
+      int bound_count = 0;
+      /* Iterate the ENTIRE overlap set before deciding single-vs-fused. This
+       * loop is the ONLY producer of upload-rect load requests in the Lazy
+       * modes, and it used to return the fused handle mid-loop at the second
+       * image-bearing upload - so in a draw spanning many uploads (e.g. a text
+       * line built from dozens of glyph uploads) every upload past that point
+       * was never requested, this frame or any later one: those replacements
+       * could never load (and Lazy-synchronous loaded exactly two per draw). */
+      for (oi = 0; oi < overlap.count; oi++) {
          RectIndex index = overlap.items[oi];
          TextureRect *tex = rect_tracker_get_index(&self->tracker, index);
          uint32_t eff = palette_hash;
@@ -4332,25 +4408,27 @@ static TTRect fromSRect(SRect rect) {
             overlapped_image = hd_tex_map_find(&tex->upload->textures, eff);
          }
          if (overlapped_image != NULL) {
+            bound_count++;
             if (hd_handle_is_none(&result)) {
                /* note that if tex->vram_rect contains rect, then it will be the only entry in overlap, so an early out would be pointless */
                result_rect = fromSRect(tex->vram_rect);
                (*fastpath_capable_out) = self->fastpath_enabled && fromSRect_contains(tex->vram_rect, rect) && (overlapped_image->alpha_flags & ALPHA_FLAG_TRANSPARENT) == 0;
                result = hd_handle_make(index, eff);
-            } else {
-               /* Multiple overlap, must fuse */
-               unsigned int width
-                  = mode->mode == TextureMode_Palette4bpp ? 64
-                  : mode->mode == TextureMode_Palette8bpp ? 128
-                  : 256;
-               TTRect page_rect = { page_x, page_y, width, 256 };
-               (*fastpath_capable_out) = false;
-               return fused_pages_get_or_make(&self->fused_pages, page_rect, palette_hash, &self->tracker,
-                     self,
-                     have_pal_data ? pal_local : NULL,
-                     have_pal_data ? (unsigned)palette_rect.width : 0);
             }
          }
+      }
+      if (bound_count >= 2) {
+         /* Multiple overlap, must fuse - decided AFTER the full request pass. */
+         unsigned int width
+            = mode->mode == TextureMode_Palette4bpp ? 64
+            : mode->mode == TextureMode_Palette8bpp ? 128
+            : 256;
+         TTRect page_rect = { page_x, page_y, width, 256 };
+         (*fastpath_capable_out) = false;
+         return fused_pages_get_or_make(&self->fused_pages, page_rect, palette_hash, &self->tracker,
+               self,
+               have_pal_data ? pal_local : NULL,
+               have_pal_data ? (unsigned)palette_rect.width : 0);
       } }
 
       /* Cross-mode fallback (Direction A): upload-rect found no HD match. Try the
@@ -4968,13 +5046,20 @@ static bool is_power_of_two(int n) {
             id.hash = response->hash;
             id.palette_hash = response->palette_hash;
             id.pages = response->pages;
-            hd_key_set_erase(&self->requested, hd_pack_key(id)); /* no longer in flight; now cached */
-            hd_image_cache_put(&self->hd_cache, id, &response->levels, response->alpha_flags);
-            if (response->pages)
-               /* page combo: store the BASE (unsalted) key so the page attach pass can unpack it */
-               hd_key_set_insert(&self->pending_attach_pages, ((uint64_t)id.hash << 32) | (uint64_t)id.palette_hash);
-            else
-               hd_key_set_insert(&self->pending_attach, hd_pack_key(id));
+            hd_key_set_erase(&self->requested, hd_pack_key(id)); /* no longer in flight; retryable or cached */
+            if (response->levels.count == 0) {
+               /* Failure response: the load failed although the file is listed
+                * in known_files (transient open/decode error). Erasing
+                * `requested` above lets the next draw retry; nothing to cache. */
+               self->dbg_responses_received--; /* not a delivered image */
+            } else {
+               hd_image_cache_put(&self->hd_cache, id, &response->levels, response->alpha_flags);
+               if (response->pages)
+                  /* page combo: store the BASE (unsalted) key so the page attach pass can unpack it */
+                  hd_key_set_insert(&self->pending_attach_pages, ((uint64_t)id.hash << 32) | (uint64_t)id.palette_hash);
+               else
+                  hd_key_set_insert(&self->pending_attach, hd_pack_key(id));
+            }
             io_response_free(response); /* levels already moved out (now empty) */
             response = rnext;
          }
@@ -4987,6 +5072,7 @@ static bool is_power_of_two(int n) {
        * stay cached (NOT discarded) and attach on a later self->frame. */
       {
          int pi;
+         int kept = 0;
          for (pi = 0; pi < self->pending_attach.count; pi++) {
             int height;
             int width;
@@ -4995,8 +5081,19 @@ static bool is_power_of_two(int n) {
             id.palette_hash = (uint32_t)self->pending_attach.keys[pi];
             id.pages = false;
             { TextureUpload *upload = texture_tracker_find_upload(self, id.hash); /* borrowed */
-            if (upload == NULL)
-               continue; /* not resident yet; kept in cache */
+            if (upload == NULL) {
+               /* Not resident yet: RETAIN the marker (in place, order kept) so
+                * the combo attaches when its hash returns to VRAM. The
+                * wholesale clear below used to discard these - a response
+                * draining while its upload was momentarily dead (constant for
+                * recycling text rows) lost its attach forever. Bounded: drop
+                * the marker once the image has been evicted from both caches
+                * (it will be re-requested on draw). */
+               if (HdGpuCache_contains(&self->hd_gpu_cache, hd_pack_key(id)) ||
+                     HdImageCache_contains(&self->hd_cache, hd_pack_key(id)))
+                  self->pending_attach.keys[kept++] = self->pending_attach.keys[pi];
+               continue;
+            }
             if (hd_tex_map_contains(&upload->textures, id.palette_hash))
                continue; /* already attached */
 
@@ -5047,8 +5144,8 @@ static bool is_power_of_two(int n) {
             }
             }
          }
+         self->pending_attach.count = kept; /* attached/evicted/mismatched dropped; unresident retained */
       }
-      hd_key_set_clear(&self->pending_attach);
 
       /* Page attach pass: page combos have no TextureUpload to bind to - they're
        * resolved at draw time from the GPU cache. So this only promotes decoded CPU
@@ -5482,6 +5579,11 @@ static bool is_power_of_two(int n) {
          TextureRect texture){
       rect_tracker_clear_rect(self, &texture.vram_rect);
       enduring_arr_push(&self->textures, texture, true);
+      /* The other mutators (upload/blit/clear) flag the spatial grid; place
+       * did not, so rects re-placed by the readback-restore path were invisible
+       * to rect_tracker_overlapping for the rest of the frame - a fully-cached
+       * sprite could draw native right after a restore. */
+      self->lookup_grid_dirty = true;
    }
 
    static void rect_tracker_rebuild_lookup_grid(struct RectTracker *self) {
@@ -5910,6 +6012,14 @@ static int64_t page_bytes(FusionRects *fusion)
                p->pal_count = pal_count;
                rebuild_page(p, tracker, tt);
             }
+            /* Serve the page FRESH: bindings made earlier this frame (sync
+             * loads, in-frame GPU-cache hits) only MARK the page dirty, and
+             * dirty pages used to rebuild no earlier than the next VRAM write
+             * or safe point - so every fused draw rendered at least one frame
+             * behind its own bindings (a native flash even in Lazy-sync).
+             * rebuild_page early-outs via fusionrects_eq when nothing changed. */
+            if (p->dirty)
+               rebuild_page(p, tracker, tt);
             p->last_used = ++self->tick; /* touch LRU */
             return hd_handle_make_fused(x);
          }


### PR DESCRIPTION
Four commits fixing HD texture replacement loading defects in the shared tracker (`rhi/rhi_tt.c`), found while chasing replacements that intermittently failed to load. All were diagnosed against a game whose text renders as many small per-glyph uploads drawn by single wide prims (SotN's end credits / dialogue), which exercises the fused-page path heavily — but every fix is game-agnostic. `TT_RELIABILITY_AUDIT.md` (added here) documents each mechanism with line references.

**1. Fused-page path ignores Reduce Palette Range** — with the option on, the draw path binds each upload's image under its *reduced* palette hash, but `fusion_rects()`/`rebuild_page()` looked images up under the draw's *full* hash only, so composited multi-upload draws replaced nothing. `FusedPage` now snapshots the draw's gathered CLUT at creation and both sites resolve the same per-upload effective hash as the single-upload path (reduced when that file exists, else full). Option-off behaviour unchanged.

**2. Seven loading-reliability fixes:**
- the draw path's overlap loop returned the fused handle mid-loop at the second image-bearing upload, so later-ordered uploads were never requested (in Lazy modes this loop is the only request source; Lazy-synchronous loaded exactly two uploads per composited draw, permanently). The full overlap set is now requested before the single-vs-fused decision;
- `want_combo` early-returned on cache-resident combos without scheduling an attach, so Eager prefetch was a no-op for recreated uploads whose images were already cached;
- the attach pass cleared `pending_attach` wholesale, dropping combos whose upload was momentarily non-resident (a response racing VRAM recycling lost its attach forever); unresident combos are now retained until attached or cache-evicted;
- the in-frame GPU-cache-hit bind never marked fused pages dirty, so composites never picked those bindings up;
- `fused_pages_get_or_make` served existing *dirty* pages without rebuilding (one native frame per bind even in Lazy-synchronous);
- the IO worker pushed no response on a failed load, permanently stranding the combo in `requested` after one transient open failure (AV/indexer contention); it now pushes an empty-levels failure response so the drain un-marks it for retry;
- `rect_tracker_place` didn't set `lookup_grid_dirty`, hiding rects re-placed by the readback-restore path from the spatial query.

Plus scan perf: `known_files` is now bulk-built (append + one qsort + dedup) instead of per-key sorted-insert memmoves — O(n log n) instead of O(n²), which removes a multi-second stall on init and on every reload-textures press with large packs (~25k files); the savestate re-warm routes through `want_combo` (cache-skip + in-flight dedup instead of unconditional raw loads); a doubled `hd_tex_map_find` on the handle-cache hit path is now a single lookup.

**3. Coalesce fused-page rebuilds to once per page per frame** — the upload/blit hooks rebuilt dirty pages inline on every VRAM mutation, clearing and re-blitting an in-place-reused composite mid-frame while earlier draws of the frame still referenced it. Streaming text (typewriter dialogue, credits lines building letter by letter) triggered this once per typed character, showing transient partial composites. Hooks now only mark dirty; rebuilds happen at the existing safe point and at a page's first serve of each frame (`rebuilt_frame` stamp).

Built and tested on Windows (MinGW-w64 GCC 13, Vulkan renderer) against a 25k-file replacement pack: composited text that previously never loaded now binds fully in all caching methods with Reduce Palette Range on or off, the reload stall is gone, and streaming-text scenes no longer flicker during composite updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)