### PR TITLE
lightrec: pass PGXP opcodes directly to JIT callbacks

### DIFF
--- a/deps/lightrec/emitter.c
+++ b/deps/lightrec/emitter.c
@@ -3435,15 +3435,13 @@ static void rec_META(struct lightrec_cstate *state,
 /* Emit the PGXP CPU-tracking call for a non-memory op.  This runs *before*
  * the native op: the tracker reads the source registers from the GPR file
  * and computes the result itself (lightrec_pgxp_cpu_track), so the sources
- * must be synced back but the destination is left alone.  The wrapper
- * argument is the LUT entry + offset, identical to C_WRAPPER_RW_GENERIC. */
+ * must be synced back but the destination is left alone. */
 static void rec_pgxp_cpu_track(struct lightrec_cstate *state,
 			       const struct block *block, u16 offset)
 {
 	struct regcache *reg_cache = state->reg_cache;
 	jit_state_t *_jit = block->_jit;
 	union code c = block->opcode_list[offset].c;
-	u32 lut_entry;
 
 	jit_note(__FILE__, __LINE__);
 
@@ -3458,9 +3456,7 @@ static void rec_pgxp_cpu_track(struct lightrec_cstate *state,
 		lightrec_clean_reg_if_loaded(reg_cache, _jit, REG_LO, false);
 	}
 
-	lut_entry = lightrec_get_lut_entry(block);
-	call_to_c_wrapper(state, block, (lut_entry << 16) | offset,
-			  C_WRAPPER_PGXP_CPU);
+	call_to_c_wrapper(state, block, c.opcode, C_WRAPPER_PGXP_CPU);
 }
 
 void lightrec_rec_opcode(struct lightrec_cstate *state,

--- a/deps/lightrec/lightrec.c
+++ b/deps/lightrec/lightrec.c
@@ -1014,22 +1014,12 @@ void lightrec_pgxp_cpu_track(struct lightrec_state *state, union code c)
 	}
 }
 
-/* JIT wrapper: arg encodes the block LUT entry and opcode offset exactly
- * like C_WRAPPER_RW_GENERIC. */
 static void lightrec_pgxp_cpu_cb(struct lightrec_state *state, u32 arg)
 {
-	struct block *block;
-	u16 offset = (u16)arg;
-
 	if (!state->ops.pgxp_cpu)
 		return;
 
-	block = lightrec_find_block_from_lut(state->block_cache,
-					     arg >> 16, state->curr_pc);
-	if (unlikely(!block))
-		return;
-
-	lightrec_pgxp_cpu_track(state, block->opcode_list[offset].c);
+	lightrec_pgxp_cpu_track(state, (union code) { .opcode = arg });
 }
 
 static void lightrec_pgxp_addu_identity_cb(struct lightrec_state *state,


### PR DESCRIPTION
Pass the optimized opcode in the generated callback argument instead of reconstructing it through a runtime block lookup. This removes a fallible lookup boundary and reduces the work performed by PGXP CPU tracking callbacks.