### PR TITLE
Fix several disc-control errors

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -4206,9 +4206,15 @@ static bool disk_set_image_index(unsigned index)
 {
    unsigned num_images = disk_get_num_images();
 
-   /* The frontend's contract on this callback is that index is in
-    * [0, num_images). Be defensive: refuse impossible values rather
-    * than letting them flow through to CD_SelectedDisc--. */
+   /* An index of num_images is a request to eject the disc in the libretro API. */
+   if (index == num_images)
+   {
+      eject_state = true;
+      CD_SelectedDisc = -1;
+      DoSimpleCommand(MDFN_MSC_EJECT_DISK);
+      return true;
+   }
+
    if (num_images == 0)
       return false;
    if (index >= num_images)

--- a/libretro.c
+++ b/libretro.c
@@ -2306,6 +2306,12 @@ static unsigned CalcDiscSCEx(void)
       unsigned i;
       for (i = 0; i < cdifs.count; i++)
       {
+         if (!cdifs.items[i])
+         {
+            cdifs.scex_ids[i] = NULL;
+            continue;
+         }
+
          uint8_t buf[2048];
          uint8_t fbuf[2048 + 1];
          char serial[BEETLE_DISC_SERIAL_SIZE];

--- a/libretro.c
+++ b/libretro.c
@@ -3923,6 +3923,8 @@ int StateAction(StateMem *sm, int load, int data_only)
    if(load)
    {
       ForceEventUpdates(0); // FIXME to work with debugger step mode.
+      if (ret)
+         eject_state = CD_TrayOpen;
    }
 
    return(ret);


### PR DESCRIPTION
## Description

Fix several disc-control edge cases exposed by multi-disc games and savestate restores:

* Honor the libretro no-disc image index by ejecting without changing the playlist.
* Skip empty disc slots when recalculating disc region information.
* Resynchronize the frontend eject state after loading a savestate.

## Motivation and context

The disc-control state could become inconsistent in several cases:

* Selecting "No disc" passed `num_images` to the setter, which was rejected or clamped to the last disc instead of ejecting.
* Newly added but unpopulated disc slots have a `NULL` `CDIF`; region detection attempted to read them and could crash while replacing another image.
* Savestates restore the internal tray state but did not update `eject_state`, so subsequent frontend insert/eject requests could perform the wrong operation.

Together these fixes make disc replacement, removal, no-disc selection, and savestate restores behave consistently.

## How has this been tested?

Tested with Metal Gear Solid using a debug core, including:

* Adding empty disc slots and replacing/removing images.
* Selecting and restoring the no-disc state.
* Removing the final image.
* Disc and no-disc savestate restores with both open and closed tray states.
* Verification of the serialized internal tray state.

The previous empty-slot replacement crash is no longer reproducible, and all tested disc-state combinations pass.

## What is the effect on users?

Multi-disc games handle disc replacement, ejection, and savestate restoration more reliably, without selecting the wrong disc or crashing when empty disc slots are present.