### PR TITLE
GPU: synchronize texture window state on reset

### DIFF
--- a/mednafen/psx/gpu.c
+++ b/mednafen/psx/gpu.c
@@ -1309,6 +1309,7 @@ static void GPU_SoftReset(void) /* Control command 0x00 */
    GPU.twy = 0;
 
    RecalcTexWindowStuff(&GPU);
+   rhi_intf_set_tex_window(GPU.tww, GPU.twh, GPU.twx, GPU.twy);
 
    /* */
    GPU.ClipX0 = 0;


### PR DESCRIPTION
## Description
GPU: synchronize texture window state on reset

## Fixes 
Closes https://github.com/libretro/beetle-psx-libretro/issues/622