### PR TITLE
RHI: stabilize interlaced dynamic cropping

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -6761,8 +6761,11 @@ void retro_run(void)
          /* Smart height geometry trigger */
          if (crop_overscan == 2)
          {
-            /* Get rid of startup logo shift */
-            if (currently_interlaced || PrevInterlaced)
+            /* Get rid of startup logo shift. Keyed on the 239-line window
+             * the BIOS programs, not on the cropped height, so user
+             * scanline crops on a 240-line title cannot trigger it. */
+            if ((currently_interlaced || PrevInterlaced) &&
+                GPU_get_vertical_range_lines() == 239)
             {
                if (height == 478 || height == 239)
                   height = (height == 239) ? 236 : 472;

--- a/mednafen/psx/gpu.c
+++ b/mednafen/psx/gpu.c
@@ -2918,6 +2918,11 @@ uint8_t GPU_get_upscale_shift(void)
    return GPU.upscale_shift;
 }
 
+uint32_t GPU_get_vertical_range_lines(void)
+{
+   return GPU.VertEnd - GPU.VertStart;
+}
+
 bool GPU_DMACanWrite(void)
 {
    return CalcFIFOReadyBit();

--- a/mednafen/psx/gpu.h
+++ b/mednafen/psx/gpu.h
@@ -290,6 +290,10 @@ void GPU_set_dither_upscale_shift(uint8_t factor);
 
 uint8_t GPU_get_upscale_shift(void);
 
+/* Lines spanned by the programmed vertical display range (GP1(07)),
+ * before any scanline cropping and before interlace doubling. */
+uint32_t GPU_get_vertical_range_lines(void);
+
 bool GPU_get_display_possibly_dirty(void);
 
 void GPU_set_display_possibly_dirty(bool dirty);

--- a/rhi/rhi_lib_gl.c
+++ b/rhi/rhi_lib_gl.c
@@ -4565,7 +4565,12 @@ static gl_display_rect compute_gl_display_rect(gl_renderer *renderer)
             y = (256 - renderer->config.display_area_vrange[1]) + (renderer->last_scanline - 239);
         }
    }
-   if (renderer->crop_overscan == 2 && renderer->config.is_480i && height == 239)
+   /* Startup-logo shift, keyed on the programmed window rather than the
+    * cropped height (see the Vulkan renderer). The viewport origin is
+    * lower-left, so the bottom edge moves down by the same six lines the
+    * height loses and the top line stays where software and Vulkan put it. */
+   if (renderer->crop_overscan == 2 && renderer->config.is_480i &&
+       renderer->config.display_area_vrange[1] - renderer->config.display_area_vrange[0] == 239)
    {
       height = 236;
       y -= 3;

--- a/rhi/rhi_lib_gl.c
+++ b/rhi/rhi_lib_gl.c
@@ -4565,6 +4565,11 @@ static gl_display_rect compute_gl_display_rect(gl_renderer *renderer)
             y = (256 - renderer->config.display_area_vrange[1]) + (renderer->last_scanline - 239);
         }
    }
+   if (renderer->crop_overscan == 2 && renderer->config.is_480i && height == 239)
+   {
+      height = 236;
+      y -= 3;
+   }
    height *= (renderer->config.is_480i ? 2 : 1);
    y *= (renderer->config.is_480i ? 2 : 1);
 

--- a/rhi/rhi_lib_vulkan.c
+++ b/rhi/rhi_lib_vulkan.c
@@ -7519,6 +7519,8 @@ static DisplayRect renderer_compute_display_rect(Renderer *self)
          upper_offset = self->render_state.vert_start - 16 - self->render_state.slstart;
       }
    }
+   if (self->render_state.crop_overscan == 2 && self->render_state.is_480i && display_height == 239)
+      display_height = 236;
    if (self->render_state.is_480i)
    {
       display_height *= 2;

--- a/rhi/rhi_lib_vulkan.c
+++ b/rhi/rhi_lib_vulkan.c
@@ -7519,7 +7519,14 @@ static DisplayRect renderer_compute_display_rect(Renderer *self)
          upper_offset = self->render_state.vert_start - 16 - self->render_state.slstart;
       }
    }
-   if (self->render_state.crop_overscan == 2 && self->render_state.is_480i && display_height == 239)
+   /* Startup-logo shift: the BIOS programs a 239-line window while
+    * interlaced, which would re-geometry the frontend between 478 and the
+    * 472/480 lines of the screens around it. Key the clamp on the window
+    * the game programmed, not on the cropped height, so user scanline
+    * crops on a 240-line title cannot land on 239 and lose six extra
+    * lines they did not ask for. Mirrors the software path. */
+   if (self->render_state.crop_overscan == 2 && self->render_state.is_480i &&
+       self->render_state.vert_end - self->render_state.vert_start == 239)
       display_height = 236;
    if (self->render_state.is_480i)
    {


### PR DESCRIPTION
## Description 

This presents as the PS bios logo jumping up a few pixels during boot when using either HW renderer. 

Software: Dynamic cropping already normalizes the temporary 478-line interlaced frame to 472 lines, keeping the BIOS image stable.

Vulkan: The change applies the same 478-to-472 normalization when creating the Vulkan scanout, matching software rendering.

OpenGL: OpenGL also uses a separate 478-line, lower-left-origin viewport. It therefore needs a six-line alignment adjustment so the same edge is cropped as in software and Vulkan.

## Issues

Closes https://github.com/libretro/beetle-psx-libretro/issues/956

## LLM Usage

Testing, and debugging by me. Code change drafts by LLM, reviewed, tested, and adjusted by me.