### PR TITLE
OpenGL: preserve raw texture colors

### DIFF
--- a/rhi/shaders_gl/command_fragment.glsl.h
+++ b/rhi/shaders_gl/command_fragment.glsl.h
@@ -1171,9 +1171,9 @@ STRINGIZE(
    uint x_dither = (uint(gl_FragCoord.x) / dither_scaling) & 3U;
    uint y_dither = (uint(gl_FragCoord.y) / dither_scaling) & 3U;
 
-   // The multiplication by `frag_dither` will result in
-   // `dither_offset` being 0 if dithering is disabled
+   // Raw textures bypass modulation and its dither.
    int dither_offset =
+      frag_texture_blend_mode == BLEND_MODE_RAW_TEXTURE ? 0 :
       dither_pattern[y_dither * 4U + x_dither] * int(frag_dither);
 
    if (modulation_quantized)
@@ -1187,7 +1187,12 @@ STRINGIZE(
        * truncates instead; make that conversion explicit. This also keeps
        * filtered framebuffer feedback moving toward zero without reducing
        * the sampling precision used to produce output_rgb. */
-      if (native_rgb5 != 0u)
+      /* A raw texel is already an exact PS1 RGB5 value. Re-quantizing it
+       * here makes the copy depend on the driver's normalized-float
+       * conversion and can turn a channel into n - 1. Let the RGB5
+       * attachment round it back to the same hardware value instead. */
+      if (native_rgb5 != 0u &&
+          frag_texture_blend_mode != BLEND_MODE_RAW_TEXTURE)
          output_rgb = floor(clamp(output_rgb, vec3(0.), vec3(1.)) * 31.) /
                       31.;
 


### PR DESCRIPTION
## Description 
Notably fixes incorrect lava appearance in Jumping Flash! level 2 under OpenGL for windows and android, seen in this screenshot. Similar fix coming for Vulkan soon. Partially closes [libretro/beetle-psx-libretro#387](https://github.com/libretro/beetle-psx-libretro/issues/387)

## Before
<img width="1080" height="2340" alt="Screenshot_20260909_231319_RetroArch (AArch64)" src="https://github.com/user-attachments/assets/6e120996-6af4-4a4d-84ea-6e5010b66264" />

## After
<img width="1080" height="2340" alt="Screenshot_20260909_232721_RetroArch (AArch64)" src="https://github.com/user-attachments/assets/745ec3f2-2933-4e5c-9e01-aa3540b8d18f" />

Disclosure: this change was developed and tested with assistance from codex.